### PR TITLE
Open app with multiple files

### DIFF
--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -25,9 +25,14 @@
 
 #if os(iOS)
 
+import AppUI
 import UIKit
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        ImporterPipe.shared.send([url])
+        return true
+    }
 }
 
 #else
@@ -52,6 +57,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return quitConfirmationAlert()
         }
         return .terminateNow
+    }
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        ImporterPipe.shared.send(urls)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Business/ImporterPipe.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/ImporterPipe.swift
@@ -1,0 +1,31 @@
+//
+//  ImporterPipe.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 9/30/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Foundation
+
+public enum ImporterPipe {
+    public static let shared = PassthroughSubject<[URL], Never>()
+}

--- a/Passepartout/Library/Sources/AppUI/Views/App/ProfileImporterModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/App/ProfileImporterModifier.swift
@@ -49,8 +49,8 @@ struct ProfileImporterModifier: ViewModifier {
                 allowsMultipleSelection: true,
                 onCompletion: handleResult
             )
-            .onOpenURL { url in
-                handleResult(.success([url]))
+            .onReceive(ImporterPipe.shared) {
+                handleResult(.success($0))
             }
             .alert(
                 Strings.Views.Profiles.Toolbar.importProfile,


### PR DESCRIPTION
onOpenURL cannot handle multiple URLs on macOS, whereas NSApplicationDelegate can.

Fixes #637 