### PR TITLE
Import remote profiles serially

### DIFF
--- a/Passepartout/Library/Sources/AppLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/ProfileManager.swift
@@ -260,8 +260,9 @@ private extension ProfileManager {
         }
 
         // pull remote updates into local profiles (best-effort)
-        for remoteProfile in allRemoteProfiles.values {
-            Task.detached { [weak self] in
+        let profilesToImport = allRemoteProfiles.values
+        Task.detached { [weak self] in
+            for remoteProfile in profilesToImport {
                 do {
                     pp_log(.app, .notice, "Import remote profile \(remoteProfile.id)...")
                     try await self?.save(remoteProfile)


### PR DESCRIPTION
Follow the same approach as #636, because if no profiles are formerly installed the first import will trigger a VPN permission alert. Weird things may happen in that case if profiles are imported in parallel.