### PR TITLE
Add initial support for providers

### DIFF
--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -168,9 +168,9 @@
 				0E7E3D5B2B9345FD002BBDB4 /* App.entitlements */,
 				0E7C3CCC2C9AF44600B72E69 /* AppDelegate.swift */,
 				0EB08B962CA46F4900A02591 /* AppPlist.strings */,
+				0E7E3D5C2B9345FD002BBDB4 /* Assets.xcassets */,
 				0EC066D02C7DC47600D88A94 /* LaunchScreen.storyboard */,
 				0E7E3D5F2B9345FD002BBDB4 /* PassepartoutApp.swift */,
-				0E7E3D5C2B9345FD002BBDB4 /* Assets.xcassets */,
 			);
 			path = App;
 			sourceTree = "<group>";

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -76,6 +76,7 @@ let package = Package(
         .target(
             name: "CommonLibrary",
             dependencies: [
+                .product(name: "PassepartoutAPIBundle", package: "passepartoutkit-source"),
                 .product(name: "PassepartoutKit", package: "passepartoutkit-source"),
                 .product(name: "PassepartoutOpenVPNOpenSSL", package: "passepartoutkit-source-openvpn-openssl"),
                 .product(name: "PassepartoutWireGuardGo", package: "passepartoutkit-source-wireguard-go")

--- a/Passepartout/Library/Sources/AppLibrary/Business/ProviderFactory.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/ProviderFactory.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  ProviderFactory.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 10/8/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,34 +23,17 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
+import Foundation
+import PassepartoutKit
 
-import SwiftUI
+@MainActor
+public final class ProviderFactory: ObservableObject {
+    public let providerManager: ProviderManager
 
-struct ProfileGeneralView: View {
+    public let vpnProviderManager: VPNProviderManager
 
-    @ObservedObject
-    var profileEditor: ProfileEditor
-
-    var body: some View {
-        Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
-        }
-        .themeForm()
+    public init(providerManager: ProviderManager, vpnProviderManager: VPNProviderManager) {
+        self.providerManager = providerManager
+        self.vpnProviderManager = vpnProviderManager
     }
 }
-
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
-}
-
-#endif

--- a/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
@@ -36,6 +36,8 @@ public final class AppContext: ObservableObject {
 
     public let profileManager: ProfileManager
 
+    public let profileProcessor: ProfileProcessor
+
     public let tunnel: Tunnel
 
     public let tunnelEnvironment: TunnelEnvironment
@@ -44,6 +46,8 @@ public final class AppContext: ObservableObject {
 
     public let registry: Registry
 
+    public let providerFactory: ProviderFactory
+
     private let constants: Constants
 
     private var subscriptions: Set<AnyCancellable>
@@ -51,13 +55,16 @@ public final class AppContext: ObservableObject {
     public init(
         iapManager: IAPManager,
         profileManager: ProfileManager,
+        profileProcessor: ProfileProcessor,
         tunnel: Tunnel,
         tunnelEnvironment: TunnelEnvironment,
         registry: Registry,
+        providerFactory: ProviderFactory,
         constants: Constants
     ) {
         self.iapManager = iapManager
         self.profileManager = profileManager
+        self.profileProcessor = profileProcessor
         self.tunnel = tunnel
         self.tunnelEnvironment = tunnelEnvironment
         connectionObserver = ConnectionObserver(
@@ -66,6 +73,7 @@ public final class AppContext: ObservableObject {
             interval: constants.connection.refreshInterval
         )
         self.registry = registry
+        self.providerFactory = providerFactory
         self.constants = constants
         subscriptions = []
 
@@ -100,7 +108,7 @@ private extension AppContext {
 
 private extension AppContext {
     func installSavedProfile(_ profile: Profile) async throws {
-        try await tunnel.install(profile, processor: iapManager)
+        try await tunnel.install(profile, processor: profileProcessor)
     }
 
     func uninstallRemovedProfiles(withIds profileIds: [Profile.ID]) {
@@ -125,7 +133,7 @@ private extension AppContext {
                 return
             }
             if tunnel.status == .active {
-                try await tunnel.connect(with: profile, processor: iapManager)
+                try await tunnel.connect(with: profile, processor: profileProcessor)
             }
         }
     }

--- a/Passepartout/Library/Sources/AppUI/Business/ProfileEditor.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/ProfileEditor.swift
@@ -93,36 +93,18 @@ extension ProfileEditor {
     }
 }
 
-// MARK: - Metadata
+// MARK: - Editing
 
 extension ProfileEditor {
-    var id: Profile.ID {
-        editableProfile.id
-    }
-
-    var name: String {
+    var profile: EditableProfile {
         get {
-            editableProfile.name
+            editableProfile
         }
         set {
-            editableProfile.name = newValue
+            editableProfile = newValue
         }
     }
-
-    func displayName(forModuleWithId moduleId: UUID) -> String? {
-        editableProfile.displayName(forModuleWithId: moduleId)
-    }
-
-    func name(forModuleWithId moduleId: UUID) -> String? {
-        editableProfile.name(forModuleWithId: moduleId)
-    }
-
-    func setName(_ name: String, forModuleWithId moduleId: UUID) {
-        editableProfile.setName(name, forModuleWithId: moduleId)
-    }
 }
-
-// MARK: - Modules
 
 extension ProfileEditor {
     var modules: [any ModuleBuilder] {

--- a/Passepartout/Library/Sources/AppUI/Business/ProfileProcessor.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/ProfileProcessor.swift
@@ -26,6 +26,11 @@
 import Foundation
 import PassepartoutKit
 
-protocol ProfileProcessor {
-    func processedProfile(_ profile: Profile) throws -> Profile
+@MainActor
+public final class ProfileProcessor: ObservableObject {
+    public let process: (Profile) throws -> Profile
+
+    public init(process: @escaping (Profile) throws -> Profile) {
+        self.process = process
+    }
 }

--- a/Passepartout/Library/Sources/AppUI/Business/Tunnel+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/Tunnel+Extensions.swift
@@ -30,12 +30,12 @@ import PassepartoutKit
 @MainActor
 extension Tunnel {
     func install(_ profile: Profile, processor: ProfileProcessor) async throws {
-        let newProfile = try processor.processedProfile(profile)
+        let newProfile = try processor.process(profile)
         try await install(newProfile, connect: false, title: \.name)
     }
 
     func connect(with profile: Profile, processor: ProfileProcessor) async throws {
-        let newProfile = try processor.processedProfile(profile)
+        let newProfile = try processor.process(profile)
         try await install(newProfile, connect: true, title: \.name)
     }
 

--- a/Passepartout/Library/Sources/AppUI/Domain/EditableProfile.swift
+++ b/Passepartout/Library/Sources/AppUI/Domain/EditableProfile.swift
@@ -58,14 +58,10 @@ struct EditableProfile: MutableProfileType {
 
         builder.modulesMetadata = modulesMetadata?.reduce(into: [:]) {
             var metadata = $1.value
-            guard let name = metadata.name else {
-                return
+            if var trimmedName = metadata.name {
+                trimmedName = trimmedName.trimmingCharacters(in: .whitespaces)
+                metadata.name = !trimmedName.isEmpty ? trimmedName : nil
             }
-            let trimmedName = name.trimmingCharacters(in: .whitespaces)
-            guard !trimmedName.isEmpty else {
-                return
-            }
-            metadata.name = trimmedName
             $0[$1.key] = metadata
         }
 

--- a/Passepartout/Library/Sources/AppUI/Domain/Issue.swift
+++ b/Passepartout/Library/Sources/AppUI/Domain/Issue.swift
@@ -81,7 +81,7 @@ struct Issue: Identifiable {
             .replacingOccurrences(of: "$appLine", with: appLine ?? "unknown")
             .replacingOccurrences(of: "$osLine", with: osLine)
             .replacingOccurrences(of: "$deviceLine", with: deviceLine ?? "unknown")
-            // FIXME: #614, replace with provider later
+            // FIXME: #703, report provider in issue
             .replacingOccurrences(of: "$providerName", with: "none")
             .replacingOccurrences(of: "$providerLastUpdate", with: "unknown")
             .replacingOccurrences(of: "$purchasedProducts", with: purchasedProducts.map(\.rawValue).description)

--- a/Passepartout/Library/Sources/AppUI/L10n/EditableModule+Description.swift
+++ b/Passepartout/Library/Sources/AppUI/L10n/EditableModule+Description.swift
@@ -30,7 +30,7 @@ extension ModuleBuilder {
 
     @MainActor
     func description(inEditor editor: ProfileEditor) -> String {
-        editor.displayName(forModuleWithId: id) ?? typeDescription
+        editor.profile.displayName(forModuleWithId: id) ?? typeDescription
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/L10n/PassepartoutKit+L10n.swift
+++ b/Passepartout/Library/Sources/AppUI/L10n/PassepartoutKit+L10n.swift
@@ -144,6 +144,31 @@ extension OnDemandModule.Policy: LocalizableEntity {
     }
 }
 
+extension VPNServer {
+    public var sortableRegion: String {
+        [countryCodes.first?.localizedAsRegionCode, area]
+            .compactMap { $0 }
+            .joined(separator: " - ")
+    }
+
+    public var sortableAddresses: String {
+        if let hostname {
+            return hostname
+        }
+        if let ipAddresses {
+            return ipAddresses
+                .compactMap {
+                    guard let address = Address(data: $0) else {
+                        return nil
+                    }
+                    return address.description
+                }
+                .joined(separator: ", ")
+        }
+        return ""
+    }
+}
+
 extension OpenVPN.Credentials.OTPMethod: StyledLocalizableEntity {
     public enum Style {
         case entity

--- a/Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
@@ -243,6 +243,8 @@ public enum Strings {
     public static let profile = Strings.tr("Localizable", "global.profile", fallback: "Profile")
     /// Protocol
     public static let `protocol` = Strings.tr("Localizable", "global.protocol", fallback: "Protocol")
+    /// Provider
+    public static let provider = Strings.tr("Localizable", "global.provider", fallback: "Provider")
     /// Public key
     public static let publicKey = Strings.tr("Localizable", "global.public_key", fallback: "Public key")
     /// Purchase
@@ -583,6 +585,12 @@ public enum Strings {
         public static let importProfile = Strings.tr("Localizable", "views.profiles.toolbar.import_profile", fallback: "Import profile")
         /// New profile
         public static let newProfile = Strings.tr("Localizable", "views.profiles.toolbar.new_profile", fallback: "New profile")
+      }
+    }
+    public enum Provider {
+      public enum Vpn {
+        /// Refresh infrastructure
+        public static let refreshInfrastructure = Strings.tr("Localizable", "views.provider.vpn.refresh_infrastructure", fallback: "Refresh infrastructure")
       }
     }
     public enum Settings {

--- a/Passepartout/Library/Sources/AppUI/Mock/Mock.swift
+++ b/Passepartout/Library/Sources/AppUI/Mock/Mock.swift
@@ -29,8 +29,6 @@ import Foundation
 import PassepartoutKit
 import UtilsLibrary
 
-// MARK: AppContext
-
 extension AppContext {
     public static let mock: AppContext = .mock(withRegistry: Registry())
 
@@ -56,9 +54,16 @@ extension AppContext {
                     }
                 return ProfileManager(profiles: profiles)
             }(),
+            profileProcessor: ProfileProcessor {
+                try $0.withProviderModules()
+            },
             tunnel: Tunnel(strategy: FakeTunnelStrategy(environment: env)),
             tunnelEnvironment: env,
             registry: registry,
+            providerFactory: ProviderFactory(
+                providerManager: ProviderManager(repository: InMemoryProviderRepository()),
+                vpnProviderManager: VPNProviderManager(repository: InMemoryVPNProviderRepository())
+            ),
             constants: .shared
         )
     }
@@ -73,6 +78,18 @@ extension IAPManager {
 extension ProfileManager {
     public static var mock: ProfileManager {
         AppContext.mock.profileManager
+    }
+}
+
+extension ProviderFactory {
+    public static var mock: ProviderFactory {
+        AppContext.mock.providerFactory
+    }
+}
+
+extension ProfileProcessor {
+    public static var mock: ProfileProcessor {
+        AppContext.mock.profileProcessor
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
@@ -47,6 +47,7 @@
 "global.private_key" = "Private key";
 "global.profile" = "Profile";
 "global.protocol" = "Protocol";
+"global.provider" = "Provider";
 "global.public_key" = "Public key";
 "global.purchase" = "Purchase";
 "global.remove" = "Delete";
@@ -126,6 +127,8 @@
 
 "views.profile.rows.add_module" = "Add module";
 "views.profile.module_list.section.footer" = "Drag modules to rearrange them, as their order determines priority.";
+
+"views.provider.vpn.refresh_infrastructure" = "Refresh infrastructure";
 
 "views.settings.sections.icloud.footer" = "To erase the iCloud store securely, do so on all your synced devices. This will not affect local profiles.";
 "views.settings.rows.confirm_quit" = "Ask before quit";

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/DNSView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/DNSView.swift
@@ -30,7 +30,7 @@ import UtilsLibrary
 
 extension DNSModule.Builder: ModuleViewProviding {
     func moduleView(with editor: ProfileEditor) -> some View {
-        DNSView(editor: editor, original: self)
+        DNSView(editor: editor, module: self)
     }
 }
 
@@ -45,9 +45,9 @@ private struct DNSView: View {
     @Binding
     private var draft: DNSModule.Builder
 
-    init(editor: ProfileEditor, original: DNSModule.Builder) {
+    init(editor: ProfileEditor, module: DNSModule.Builder) {
         self.editor = editor
-        _draft = editor.binding(forModule: original)
+        _draft = editor.binding(forModule: module)
     }
 
     var body: some View {
@@ -62,7 +62,7 @@ private struct DNSView: View {
             .labelsHidden()
         }
         .themeManualInput()
-        .asModuleView(with: editor, draft: draft)
+        .moduleView(editor: editor, draft: draft)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/HTTPProxyView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/HTTPProxyView.swift
@@ -29,7 +29,7 @@ import UtilsLibrary
 
 extension HTTPProxyModule.Builder: ModuleViewProviding {
     func moduleView(with editor: ProfileEditor) -> some View {
-        HTTPProxyView(editor: editor, original: self)
+        HTTPProxyView(editor: editor, module: self)
     }
 }
 
@@ -44,9 +44,9 @@ private struct HTTPProxyView: View {
     @Binding
     private var draft: HTTPProxyModule.Builder
 
-    init(editor: ProfileEditor, original: HTTPProxyModule.Builder) {
+    init(editor: ProfileEditor, module: HTTPProxyModule.Builder) {
         self.editor = editor
-        _draft = editor.binding(forModule: original)
+        _draft = editor.binding(forModule: module)
     }
 
     var body: some View {
@@ -58,7 +58,7 @@ private struct HTTPProxyView: View {
         }
         .labelsHidden()
         .themeManualInput()
-        .asModuleView(with: editor, draft: draft)
+        .moduleView(editor: editor, draft: draft)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/IPView+Route.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/IPView+Route.swift
@@ -111,7 +111,7 @@ private extension IPView.RouteView {
                 Button("Add route") {
                     isPresented = true
                 }
-                .sheet(isPresented: $isPresented) {
+                .themeModal(isPresented: $isPresented) {
                     NavigationStack {
                         IPView.RouteView(family: .v4) {
                             route = $0

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/IPView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/IPView.swift
@@ -29,7 +29,7 @@ import UtilsLibrary
 
 extension IPModule.Builder: ModuleViewProviding {
     func moduleView(with editor: ProfileEditor) -> some View {
-        IPView(editor: editor, original: self)
+        IPView(editor: editor, module: self)
     }
 }
 
@@ -44,9 +44,9 @@ struct IPView: View {
     @State
     private var routePresentation: RoutePresentation?
 
-    init(editor: ProfileEditor, original: IPModule.Builder) {
+    init(editor: ProfileEditor, module: IPModule.Builder) {
         self.editor = editor
-        _draft = editor.binding(forModule: original)
+        _draft = editor.binding(forModule: module)
     }
 
     var body: some View {
@@ -55,7 +55,7 @@ struct IPView: View {
             ipSections(for: .v6)
             interfaceSection
         }
-        .asModuleView(with: editor, draft: draft)
+        .moduleView(editor: editor, draft: draft)
         .themeModal(item: $routePresentation, content: routeModal)
     }
 }

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/OnDemandView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/OnDemandView.swift
@@ -29,7 +29,7 @@ import UtilsLibrary
 
 extension OnDemandModule.Builder: ModuleViewProviding {
     func moduleView(with editor: ProfileEditor) -> some View {
-        OnDemandView(editor: editor, original: self)
+        OnDemandView(editor: editor, module: self)
     }
 }
 
@@ -54,12 +54,12 @@ private struct OnDemandView: View {
 
     init(
         editor: ProfileEditor,
-        original: OnDemandModule.Builder,
+        module: OnDemandModule.Builder,
         observer: WifiObserver? = nil
     ) {
         self.editor = editor
         wifi = Wifi(observer: observer ?? CoreLocationWifiObserver())
-        _draft = editor.binding(forModule: original)
+        _draft = editor.binding(forModule: module)
     }
 
     var body: some View {
@@ -67,7 +67,7 @@ private struct OnDemandView: View {
             enabledSection
             restrictedArea
         }
-        .asModuleView(with: editor, draft: draft)
+        .moduleView(editor: editor, draft: draft)
         .modifier(PaywallModifier(reason: $paywallReason))
     }
 }
@@ -257,7 +257,7 @@ private extension OnDemandView {
     return module.preview {
         OnDemandView(
             editor: $0,
-            original: $1,
+            module: $1,
             observer: MockWifi()
         )
     }

--- a/Passepartout/Library/Sources/AppUI/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -49,7 +49,7 @@ struct ProfileEditView: View, Routable {
         debugChanges()
         return List {
             NameSection(
-                name: $profileEditor.name,
+                name: $profileEditor.profile.name,
                 placeholder: Strings.Placeholders.Profile.name
             )
             Group {

--- a/Passepartout/Library/Sources/AppUI/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -64,7 +64,7 @@ struct ModuleListView: View, Routable {
         }
         .onDeleteCommand(perform: removeSelectedModule)
         .toolbar(content: toolbarContent)
-        .navigationTitle(profileEditor.name)
+        .navigationTitle(profileEditor.profile.name)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/DefaultModuleViewFactory.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/DefaultModuleViewFactory.swift
@@ -52,22 +52,3 @@ private extension ProfileEditor {
         return (provider, module.typeDescription)
     }
 }
-
-extension View {
-
-    @MainActor
-    func asModuleView<T>(with editor: ProfileEditor, draft: T, withName: Bool = true) -> some View where T: ModuleBuilder, T: Equatable {
-        Form {
-            if withName {
-                NameSection(
-                    name: editor.binding(forNameOf: draft.id),
-                    placeholder: draft.typeDescription
-                )
-            }
-            self
-        }
-        .themeForm()
-        .themeManualInput()
-        .themeAnimation(on: draft, category: .modules)
-    }
-}

--- a/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/ModuleSection.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/ModuleSection.swift
@@ -70,12 +70,6 @@ struct HashableRoute: Hashable {
     }
 }
 
-extension Collection {
-    var nilIfEmpty: [Element]? {
-        !isEmpty ? Array(self) : nil
-    }
-}
-
 extension View {
     func moduleSection(for rows: [ModuleRow]?, header: String) -> some View {
         rows.map { rows in

--- a/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/ModuleViewModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/ModuleViewModifier.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  ModuleViewModifier.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 10/9/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,34 +23,36 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
-
+import PassepartoutKit
 import SwiftUI
 
-struct ProfileGeneralView: View {
+struct ModuleViewModifier<T>: ViewModifier where T: ModuleBuilder & Equatable {
 
     @ObservedObject
-    var profileEditor: ProfileEditor
+    var editor: ProfileEditor
 
-    var body: some View {
+    let draft: T
+
+    let withName: Bool
+
+    func body(content: Content) -> some View {
         Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
+            if withName {
+                NameSection(
+                    name: editor.binding(forNameOf: draft.id),
+                    placeholder: draft.typeDescription
+                )
+            }
+            content
         }
         .themeForm()
+        .themeManualInput()
+        .themeAnimation(on: draft, category: .modules)
     }
 }
 
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
+extension View {
+    func moduleView<T>(editor: ProfileEditor, draft: T, withName: Bool = true) -> some View where T: ModuleBuilder & Equatable {
+        modifier(ModuleViewModifier(editor: editor, draft: draft, withName: withName))
+    }
 }
-
-#endif

--- a/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/ProfileEditor+UI.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/ProfileEditor/ProfileEditor+UI.swift
@@ -29,9 +29,25 @@ import SwiftUI
 extension ProfileEditor {
     func binding(forNameOf moduleId: UUID) -> Binding<String> {
         Binding { [weak self] in
-            self?.name(forModuleWithId: moduleId) ?? ""
+            self?.profile.name(forModuleWithId: moduleId) ?? ""
         } set: { [weak self] in
-            self?.setName($0, forModuleWithId: moduleId)
+            self?.profile.setName($0, forModuleWithId: moduleId)
+        }
+    }
+
+    func binding(forProviderOf moduleId: UUID) -> Binding<ProviderID?> {
+        Binding { [weak self] in
+            self?.profile.providerId(forModuleWithId: moduleId)
+        } set: { [weak self] in
+            self?.profile.setProviderId($0, forModuleWithId: moduleId)
+        }
+    }
+
+    func binding<E>(forProviderEntityOf moduleId: UUID) -> Binding<E?> where E: ProviderEntity & Codable {
+        Binding { [weak self] in
+            try? self?.profile.providerEntity(E.self, forModuleWithId: moduleId)
+        } set: { [weak self] in
+            try? self?.profile.setProviderEntity($0, forModuleWithId: moduleId)
         }
     }
 

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
@@ -1,0 +1,135 @@
+//
+//  ProviderPanelModifier.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 10/7/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AppLibrary
+import PassepartoutKit
+import SwiftUI
+
+struct ProviderPanelModifier<Entity, ProviderContent>: ViewModifier where Entity: ProviderEntity, Entity.Configuration: ProviderConfigurationIdentifiable & Codable, ProviderContent: View {
+
+    @EnvironmentObject
+    private var providerManager: ProviderManager
+
+    var apis: [APIMapper] = API.shared
+
+    @Binding
+    var providerId: ProviderID?
+
+    @Binding
+    var selectedEntity: Entity?
+
+    @ViewBuilder
+    let providerContent: (ProviderID, Entity?) -> ProviderContent
+
+    func body(content: Content) -> some View {
+        providerPicker
+            .task {
+                await refreshIndex()
+            }
+
+        if let providerId {
+            providerContent(providerId, selectedEntity)
+        } else {
+            content
+        }
+    }
+}
+
+private extension ProviderPanelModifier {
+    var supportedProviders: [ProviderMetadata] {
+        providerManager.providers.filter {
+            $0.supports(Entity.Configuration.self)
+        }
+    }
+
+    var providersPlusEmpty: [ProviderMetadata] {
+        [ProviderMetadata("", description: Strings.Global.none)] + supportedProviders
+    }
+
+    var providerPicker: some View {
+        let hasProviders = !supportedProviders.isEmpty
+        return Picker(Strings.Global.provider, selection: $providerId) {
+            if hasProviders {
+                ForEach(providersPlusEmpty, id: \.id) {
+                    Text($0.description)
+                        .tag($0.id.nilIfEmpty)
+                }
+            } else {
+                Text(" ") // enforce constant picker height on iOS
+                    .tag(providerId) // tag always exists
+            }
+        }
+        .onChange(of: providerId) { _ in
+            selectedEntity = nil
+        }
+        .disabled(!hasProviders)
+    }
+}
+
+private extension ProviderPanelModifier {
+
+    // FIXME: #707, fetch bundled providers on launch
+    // FIXME: #704, rate-limit fetch
+    func refreshIndex() async {
+        do {
+            try await providerManager.fetchIndex(from: apis)
+        } catch {
+            pp_log(.app, .error, "Unable to fetch index: \(error)")
+        }
+    }
+}
+
+private extension ProviderID {
+    var nilIfEmpty: ProviderID? {
+        !rawValue.isEmpty ? self : nil
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    @State
+    var providerId: ProviderID? = .hideme
+
+    @State
+    var vpnEntity: VPNEntity<OpenVPN.Configuration>?
+
+    return List {
+        EmptyView()
+            .modifier(ProviderPanelModifier(
+                apis: [API.bundled],
+                providerId: $providerId,
+                selectedEntity: $vpnEntity,
+                providerContent: { id, entity in
+                    HStack {
+                        Text("Server")
+                        Spacer()
+                        Text(entity?.server.serverId ?? "None")
+                    }
+                }
+            ))
+    }
+    .withMockEnvironment()
+}

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/VPNFiltersView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/VPNFiltersView.swift
@@ -1,0 +1,180 @@
+//
+//  VPNFiltersView.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 10/9/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AppLibrary
+import PassepartoutKit
+import SwiftUI
+
+// FIXME: #703, providers UI
+
+struct VPNFiltersView<Configuration>: View where Configuration: Decodable {
+
+    @ObservedObject
+    var manager: VPNProviderManager
+
+    let providerId: ProviderID
+
+    let onRefresh: () async -> Void
+
+    @State
+    private var isRefreshing = false
+
+    var body: some View {
+        Form {
+            Section {
+                categoryPicker
+                countryPicker
+                presetPicker
+#if os(iOS)
+                clearFiltersButton
+                    .frame(maxWidth: .infinity, alignment: .center)
+#else
+                HStack {
+                    Spacer()
+                    clearFiltersButton
+                    refreshButton
+                }
+#endif
+            }
+#if os(iOS)
+            Section {
+                refreshButton
+            }
+#endif
+        }
+    }
+}
+
+private extension VPNFiltersView {
+    var categoryPicker: some View {
+        Picker("Category", selection: $manager.filters.categoryName) {
+            Text("Any")
+                .tag(nil as String?)
+            ForEach(categories, id: \.self) {
+                Text($0.capitalized)
+                    .tag($0 as String?)
+            }
+        }
+    }
+
+    var countryPicker: some View {
+        Picker("Country", selection: $manager.filters.countryCode) {
+            Text("Any")
+                .tag(nil as String?)
+            ForEach(countries, id: \.code) {
+                Text($0.description)
+                    .tag($0.code as String?)
+            }
+        }
+    }
+
+    @ViewBuilder
+    var presetPicker: some View {
+        if manager.anyPresets.count > 1 {
+            Picker("Preset", selection: $manager.filters.presetId) {
+                Text("Any")
+                    .tag(nil as String?)
+                ForEach(presets, id: \.presetId) {
+                    Text($0.description)
+                        .tag($0.presetId as String?)
+                }
+            }
+        }
+    }
+
+    var clearFiltersButton: some View {
+        Button("Clear filters", role: .destructive) {
+            Task {
+                await manager.resetFilters()
+            }
+        }
+    }
+
+    var refreshButton: some View {
+        Button {
+            Task {
+                isRefreshing = true
+                await onRefresh()
+                isRefreshing = false
+            }
+        } label: {
+            HStack {
+                Text(Strings.Views.Provider.Vpn.refreshInfrastructure)
+#if os(iOS)
+                if isRefreshing {
+                    Spacer()
+                    ProgressView()
+                }
+#endif
+            }
+        }
+        .disabled(isRefreshing)
+    }
+}
+
+private extension VPNFiltersView {
+    var categories: [String] {
+        let allCategories = manager
+            .allServers
+            .values
+            .map(\.provider.categoryName)
+
+        return Set(allCategories)
+            .sorted()
+    }
+
+    var countries: [(code: String, description: String)] {
+        let allCodes = manager
+            .allServers
+            .values
+            .flatMap(\.countryCodes)
+
+        return Set(allCodes)
+            .map {
+                (code: $0, description: $0.localizedAsRegionCode ?? $0)
+            }
+            .sorted {
+                $0.description < $1.description
+            }
+    }
+
+    var presets: [VPNPreset<Configuration>] {
+        manager
+            .presets(ofType: Configuration.self)
+            .sorted {
+                $0.description < $1.description
+            }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        VPNFiltersView<String>(
+            manager: ProviderFactory.mock.vpnProviderManager,
+            providerId: .hideme,
+            onRefresh: {}
+        )
+    }
+}

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/VPNProviderServerView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/VPNProviderServerView.swift
@@ -1,0 +1,148 @@
+//
+//  VPNProviderServerView.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 10/7/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import AppLibrary
+import PassepartoutKit
+import SwiftUI
+
+struct VPNProviderServerView<Configuration>: View where Configuration: ProviderConfigurationIdentifiable & Hashable & Codable {
+
+    @EnvironmentObject
+    private var providerManager: ProviderManager
+
+    @EnvironmentObject
+    private var vpnProviderManager: VPNProviderManager
+
+    @Environment(\.dismiss)
+    private var dismiss
+
+    var apis: [APIMapper] = API.shared
+
+    let providerId: ProviderID
+
+    let onSelect: (_ server: VPNServer, _ preset: VPNPreset<Configuration>) -> Void
+
+    @State
+    private var isLoading = true
+
+    @State
+    var sortOrder = [
+        KeyPathComparator(\VPNServer.sortableRegion)
+    ]
+
+    @State
+    var sortedServers: [VPNServer] = []
+
+    // FIXME: #703, flickers on appear
+    var body: some View {
+        serversView
+            .modifier(VPNFiltersModifier<Configuration>(
+                manager: vpnProviderManager,
+                providerId: providerId,
+                onRefresh: {
+                    await refreshInfrastructure(for: providerId)
+                }
+            ))
+            .themeAnimation(on: isLoading, category: .providers)
+            .navigationTitle(providerMetadata?.description ?? Strings.Global.servers)
+            .task {
+                await loadInfrastructure(for: providerId)
+            }
+            .onReceive(vpnProviderManager.$filteredServers, perform: onFilteredServers)
+    }
+}
+
+private extension VPNProviderServerView {
+    var providerMetadata: ProviderMetadata? {
+        providerManager.metadata(withId: providerId)
+    }
+}
+
+// MARK: - Actions
+
+extension VPNProviderServerView {
+    func onFilteredServers(_ servers: [String: VPNServer]) {
+        sortedServers = servers
+            .values
+            .sorted(using: sortOrder)
+    }
+
+    func selectServer(_ server: VPNServer) {
+        guard let preset = compatiblePreset(with: server) else {
+            // FIXME: #703, alert select a preset
+            return
+        }
+        onSelect(server, preset)
+        dismiss()
+    }
+}
+
+private extension VPNProviderServerView {
+    func compatiblePreset(with server: VPNServer) -> VPNPreset<Configuration>? {
+        vpnProviderManager
+            .presets(ofType: Configuration.self)
+            .first {
+                if let supportedIds = server.provider.supportedPresetIds {
+                    return supportedIds.contains($0.presetId)
+                }
+                return true
+            }
+    }
+
+    func loadInfrastructure(for providerId: ProviderID) async {
+        await vpnProviderManager.setProvider(providerId)
+        if await vpnProviderManager.lastUpdated() == nil {
+            await refreshInfrastructure(for: providerId)
+        }
+        isLoading = false
+    }
+
+    // FIXME: #704, rate-limit fetch
+    func refreshInfrastructure(for providerId: ProviderID) async {
+        do {
+            isLoading = true
+            try await vpnProviderManager.fetchInfrastructure(
+                from: apis,
+                for: providerId,
+                ofType: Configuration.self
+            )
+            isLoading = false
+        } catch {
+            // FIXME: #703, alert unable to refresh infrastructure
+            pp_log(.app, .error, "Unable to refresh infrastructure: \(error)")
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        VPNProviderServerView<OpenVPN.Configuration>(apis: [API.bundled], providerId: .protonvpn) { _, _ in
+        }
+    }
+    .withMockEnvironment()
+}

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/iOS/VPNFiltersModifier+iOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/iOS/VPNFiltersModifier+iOS.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  VPNFiltersModifier+iOS.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 10/9/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,34 +23,33 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
+#if os(iOS)
 
 import SwiftUI
 
-struct ProfileGeneralView: View {
+// FIXME: #703, providers UI
 
-    @ObservedObject
-    var profileEditor: ProfileEditor
-
-    var body: some View {
-        Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
+extension VPNFiltersModifier {
+    func contentView(with content: Content) -> some View {
+        List {
+            content
         }
-        .themeForm()
+        .toolbar {
+            Button {
+                isFiltersPresented = true
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+            }
+        }
+        .themeModal(isPresented: $isFiltersPresented) {
+            NavigationStack {
+                VPNFiltersView<Configuration>(manager: manager, providerId: providerId, onRefresh: onRefresh)
+                    .navigationTitle("Filters")
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .presentationDetents([.medium])
+        }
     }
-}
-
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
 }
 
 #endif

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/iOS/VPNProviderServerView+iOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/iOS/VPNProviderServerView+iOS.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  VPNProviderServerView+iOS.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 10/9/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,34 +23,22 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
+#if os(iOS)
 
 import SwiftUI
 
-struct ProfileGeneralView: View {
+// FIXME: #703, providers UI
 
-    @ObservedObject
-    var profileEditor: ProfileEditor
-
-    var body: some View {
-        Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
+extension VPNProviderServerView {
+    var serversView: some View {
+        sortedServers.nilIfEmpty.map { servers in
+            ForEach(sortedServers) { server in
+                Button("\(server.hostname ?? server.id) \(server.countryCodes)") {
+                    selectServer(server)
+                }
+            }
         }
-        .themeForm()
     }
-}
-
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
 }
 
 #endif

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/macOS/VPNFiltersModifier+macOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/macOS/VPNFiltersModifier+macOS.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  VPNFiltersModifier+macOS.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 10/9/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -27,30 +27,14 @@
 
 import SwiftUI
 
-struct ProfileGeneralView: View {
-
-    @ObservedObject
-    var profileEditor: ProfileEditor
-
-    var body: some View {
-        Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
+extension VPNFiltersModifier {
+    func contentView(with content: Content) -> some View {
+        VStack {
+            VPNFiltersView<Configuration>(manager: manager, providerId: providerId, onRefresh: onRefresh)
+                .padding()
+            content
         }
-        .themeForm()
     }
-}
-
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
 }
 
 #endif

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/macOS/VPNProviderServerView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/macOS/VPNProviderServerView+macOS.swift
@@ -1,8 +1,8 @@
 //
-//  Array+Extensions.swift
+//  VPNProviderServerView+macOS.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 8/18/24.
+//  Created by Davide De Rosa on 10/9/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,10 +23,30 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Foundation
+#if os(macOS)
 
-extension Array where Element == String {
-    public var isLastEmpty: Bool {
-        last?.trimmingCharacters(in: .whitespaces) == ""
+import SwiftUI
+
+// FIXME: #703, providers UI
+
+extension VPNProviderServerView {
+    var serversView: some View {
+        Table(sortedServers, sortOrder: $sortOrder) {
+            TableColumn("Region", value: \.sortableRegion)
+                .width(max: 200.0)
+
+            TableColumn("Address", value: \.sortableAddresses)
+
+            TableColumn("", value: \.serverId) { server in
+                Button {
+                    selectServer(server)
+                } label: {
+                    Text("Select")
+                }
+            }
+            .width(min: 100.0, max: 100.0)
+        }
     }
 }
+
+#endif

--- a/Passepartout/Library/Sources/AppUI/Views/Theme/Theme+UI.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Theme/Theme+UI.swift
@@ -329,13 +329,15 @@ struct ThemeTipModifier: ViewModifier {
 // MARK: - Views
 
 public enum ThemeAnimationCategory: CaseIterable {
+    case diagnostics
+
+    case modules
+
     case profiles
 
     case profilesLayout
 
-    case modules
-
-    case diagnostics
+    case providers
 }
 
 struct ThemeImage: View {

--- a/Passepartout/Library/Sources/AppUI/Views/Theme/Theme+iOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Theme/Theme+iOS.swift
@@ -30,7 +30,7 @@ import SwiftUI
 extension Theme {
     public convenience init() {
         self.init(dummy: ())
-        animationCategories = [.profiles, .modules, .diagnostics]
+        animationCategories = [.diagnostics, .modules, .profiles, .providers]
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Views/Theme/Theme+macOS.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Theme/Theme+macOS.swift
@@ -32,7 +32,7 @@ extension Theme {
         self.init(dummy: Void())
         rootModalSize = CGSize(width: 700, height: 400)
         secondaryModalSize = CGSize(width: 500.0, height: 200.0)
-        animationCategories = [.profiles, .diagnostics]
+        animationCategories = [.diagnostics, .profiles, .providers]
     }
 }
 

--- a/Passepartout/Library/Sources/AppUI/Views/UI/ConnectionStatusView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/ConnectionStatusView.swift
@@ -75,7 +75,7 @@ private extension ConnectionStatusView {
 #Preview("Connected") {
     ConnectionStatusView(tunnel: .mock)
         .task {
-            try? await Tunnel.mock.connect(with: .mock, processor: IAPManager.mock)
+            try? await Tunnel.mock.connect(with: .mock, processor: .mock)
         }
         .frame(width: 100, height: 100)
         .withMockEnvironment()
@@ -94,7 +94,7 @@ private extension ConnectionStatusView {
     }
     return ConnectionStatusView(tunnel: .mock)
         .task {
-            try? await Tunnel.mock.connect(with: profile, processor: IAPManager.mock)
+            try? await Tunnel.mock.connect(with: profile, processor: .mock)
         }
         .frame(width: 100, height: 100)
         .withMockEnvironment()

--- a/Passepartout/Library/Sources/AppUI/Views/UI/StorageSection.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/StorageSection.swift
@@ -43,7 +43,7 @@ struct StorageSection: View {
             sharingToggle
             ThemeCopiableText(
                 title: Strings.Unlocalized.uuid,
-                value: profileEditor.id.flatString.localizedDescription(style: .quartets),
+                value: profileEditor.profile.id.flatString.localizedDescription(style: .quartets),
                 valueView: {
                     Text($0)
                         .monospaced()

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelRestartButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelRestartButton.swift
@@ -30,7 +30,7 @@ import UtilsLibrary
 struct TunnelRestartButton<Label>: View where Label: View {
 
     @EnvironmentObject
-    private var iapManager: IAPManager
+    private var profileProcessor: ProfileProcessor
 
     @ObservedObject
     var tunnel: Tunnel
@@ -55,7 +55,7 @@ struct TunnelRestartButton<Label>: View where Label: View {
             pendingTask?.cancel()
             pendingTask = Task {
                 do {
-                    try await tunnel.connect(with: profile, processor: iapManager)
+                    try await tunnel.connect(with: profile, processor: profileProcessor)
                 } catch {
                     errorHandler.handle(
                         error,

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
@@ -43,6 +43,9 @@ struct TunnelToggleButton<Label>: View, TunnelContextProviding, ThemeProviding w
     @EnvironmentObject
     private var iapManager: IAPManager
 
+    @EnvironmentObject
+    private var profileProcessor: ProfileProcessor
+
     var style: Style = .plain
 
     @ObservedObject
@@ -127,12 +130,12 @@ private extension TunnelToggleButton {
         do {
             if isInstalled {
                 if canConnect {
-                    try await tunnel.connect(with: profile, processor: iapManager)
+                    try await tunnel.connect(with: profile, processor: profileProcessor)
                 } else {
                     try await tunnel.disconnect()
                 }
             } else {
-                try await tunnel.connect(with: profile, processor: iapManager)
+                try await tunnel.connect(with: profile, processor: profileProcessor)
             }
         } catch {
             errorHandler.handle(

--- a/Passepartout/Library/Sources/AppUI/Views/UI/View+Environment.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/View+Environment.swift
@@ -23,6 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import AppLibrary
 import SwiftUI
 
 @MainActor
@@ -31,6 +32,9 @@ extension View {
         environmentObject(theme)
             .environmentObject(context.iapManager)
             .environmentObject(context.connectionObserver)
+            .environmentObject(context.providerFactory.providerManager)
+            .environmentObject(context.providerFactory.vpnProviderManager)
+            .environmentObject(context.profileProcessor)
     }
 
     public func withMockEnvironment() -> some View {

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/Constants.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/Constants.swift
@@ -38,6 +38,10 @@ public struct Constants: Decodable, Sendable {
     public struct Websites: Decodable, Sendable {
         public let home: URL
 
+        public var api: URL {
+            home.appendingPathComponent("api/")
+        }
+
         public var faq: URL {
             home.appendingPathComponent("faq/")
         }

--- a/Passepartout/Library/Sources/CommonLibrary/Shared.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Shared.swift
@@ -24,6 +24,7 @@
 //
 
 import Foundation
+import PassepartoutAPIBundle
 import PassepartoutKit
 import PassepartoutWireGuardGo
 
@@ -53,5 +54,40 @@ extension UserDefaults {
             fatalError("No access to App Group: \(appGroup)")
         }
         return defaults
+    }()
+}
+
+// TODO: #716, move to Environment
+extension API {
+    public static var shared: [APIMapper] {
+#if DEBUG
+        [API.bundled]
+#else
+        [API.remoteThenBundled]
+#endif
+    }
+
+    private static let remoteThenBundled: [APIMapper] = [
+        Self.remote,
+        Self.bundled
+    ]
+
+    public static let bundled: APIMapper = {
+        guard let url = API.bundledURL else {
+            fatalError("Unable to find bundled API")
+        }
+        let ws = API.V5.DefaultWebServices(
+            url,
+            timeout: Constants.shared.api.timeoutInterval
+        )
+        return API.V5.Mapper(webServices: ws)
+    }()
+
+    public static let remote: APIMapper = {
+        let ws = API.V5.DefaultWebServices(
+            Constants.shared.websites.api,
+            timeout: Constants.shared.api.timeoutInterval
+        )
+        return API.V5.Mapper(webServices: ws)
     }()
 }

--- a/Passepartout/Library/Sources/UtilsLibrary/Extensions/Collection+Extensions.swift
+++ b/Passepartout/Library/Sources/UtilsLibrary/Extensions/Collection+Extensions.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  Collection+Extensions.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 8/18/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,34 +23,16 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
+import Foundation
 
-import SwiftUI
-
-struct ProfileGeneralView: View {
-
-    @ObservedObject
-    var profileEditor: ProfileEditor
-
-    var body: some View {
-        Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
-        }
-        .themeForm()
+extension Array where Element == String {
+    public var isLastEmpty: Bool {
+        last?.trimmingCharacters(in: .whitespaces) == ""
     }
 }
 
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
+extension Collection {
+    public var nilIfEmpty: [Element]? {
+        !isEmpty ? Array(self) : nil
+    }
 }
-
-#endif

--- a/Passepartout/Library/Sources/UtilsLibrary/Extensions/String+Extensions.swift
+++ b/Passepartout/Library/Sources/UtilsLibrary/Extensions/String+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  Strings+Extensions.swift
+//  String+Extensions.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 10/8/24.

--- a/Passepartout/Library/Sources/UtilsLibrary/Extensions/String+Extensions.swift
+++ b/Passepartout/Library/Sources/UtilsLibrary/Extensions/String+Extensions.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  Strings+Extensions.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 10/8/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,34 +23,26 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
+import Foundation
 
-import SwiftUI
-
-struct ProfileGeneralView: View {
-
-    @ObservedObject
-    var profileEditor: ProfileEditor
-
-    var body: some View {
-        Form {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor
-            )
-        }
-        .themeForm()
+extension String {
+    public var nilIfEmpty: String? {
+        !isEmpty ? self : nil
     }
 }
 
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor()
-    )
-    .withMockEnvironment()
-}
+extension String {
+    public var localizedAsRegionCode: String? {
+        Locale
+            .current
+            .localizedString(forRegionCode: self)?
+            .capitalized
+    }
 
-#endif
+    public var localizedAsLanguageCode: String? {
+        Locale
+            .current
+            .localizedString(forLanguageCode: self)?
+            .capitalized
+    }
+}

--- a/Passepartout/Library/Sources/UtilsLibrary/Views/GenericCreditsView.swift
+++ b/Passepartout/Library/Sources/UtilsLibrary/Views/GenericCreditsView.swift
@@ -137,7 +137,7 @@ private extension GenericCreditsView {
 
     var sortedLanguages: [String] {
         credits.translations.keys.sorted {
-            $0.localizedAsCountryCode < $1.localizedAsCountryCode
+            ($0.localizedAsLanguageCode ?? $0) < ($1.localizedAsLanguageCode ?? $1)
         }
     }
 
@@ -178,7 +178,7 @@ private extension GenericCreditsView {
         Section {
             ForEach(sortedLanguages, id: \.self) { code in
                 HStack {
-                    Text(code.localizedAsCountryCode)
+                    Text(code.localizedAsLanguageCode ?? code)
                     Spacer()
                     credits.translations[code].map { authors in
                         VStack(spacing: 4) {
@@ -202,12 +202,6 @@ private extension GenericCreditsView {
                 .padding()
         }
         .navigationTitle(content.name)
-    }
-}
-
-private extension String {
-    var localizedAsCountryCode: String {
-        Locale.current.localizedString(forLanguageCode: self)?.capitalized ?? self
     }
 }
 

--- a/Passepartout/Library/Tests/AppUITests/ProfileEditorTests.swift
+++ b/Passepartout/Library/Tests/AppUITests/ProfileEditorTests.swift
@@ -44,7 +44,7 @@ extension ProfileEditorTests {
             DNSModule.Builder(),
             IPModule.Builder()
         ])
-        XCTAssertTrue(sut.name.isEmpty)
+        XCTAssertTrue(sut.profile.name.isEmpty)
         XCTAssertTrue(sut.modules[0] is DNSModule.Builder)
         XCTAssertTrue(sut.modules[1] is IPModule.Builder)
     }
@@ -60,7 +60,7 @@ extension ProfileEditorTests {
         ).tryBuild()
 
         let sut = ProfileEditor(profile: profile)
-        XCTAssertEqual(sut.name, name)
+        XCTAssertEqual(sut.profile.name, name)
         XCTAssertTrue(sut.modules[0] is DNSModule.Builder)
         XCTAssertTrue(sut.modules[1] is IPModule.Builder)
         XCTAssertEqual(sut.activeModulesIds, [dns.id])
@@ -193,7 +193,7 @@ extension ProfileEditorTests {
     func test_givenProfile_whenBuild_thenSucceeds() throws {
         let wg = WireGuardModule.Builder(configurationBuilder: .default)
         let sut = ProfileEditor(modules: [wg])
-        sut.name = "hello"
+        sut.profile.name = "hello"
 
         let profile = try sut.build()
         XCTAssertEqual(profile.name, "hello")


### PR DESCRIPTION
Initial integration of providers via API:

- Generic views and modifiers for provider/server selection
- Add in OpenVPNView
- Prepare in WireGuardView

Also:

- Introduce ProfileProcessor, move IAP processing there
- Move .asModuleView() to ModuleViewModifier for proper animation
- Use .themeModal() rather than .sheet()