### PR TITLE
Purge stale NetworkExtension/keychain data

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "de9387965025a1f79e060e6bdc862933fe972598"
+        "revision" : "bec0635fe047e09c8b6c894d103ab8dd741b8340"
       }
     },
     {

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -47,23 +47,25 @@ struct PassepartoutApp: App {
     @StateObject
     private var theme = Theme()
 
-    var body: some Scene {
 #if os(iOS)
-        WindowGroup(content: content)
+    var body: some Scene {
+        WindowGroup(content: contentView)
+    }
 #else
-        Window(appName, id: appName, content: content)
+    var body: some Scene {
+        Window(appName, id: appName, content: contentView)
             .defaultSize(width: 600.0, height: 400.0)
 
         Settings {
             SettingsView(profileManager: context.profileManager)
                 .frame(minWidth: 300, minHeight: 200)
         }
-#endif
     }
+#endif
 }
 
 private extension PassepartoutApp {
-    func content() -> some View {
+    func contentView() -> some View {
         AppCoordinator(
             profileManager: context.profileManager,
             tunnel: context.tunnel,

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -39,6 +39,9 @@ struct PassepartoutApp: App {
     private var appDelegate: AppDelegate
 #endif
 
+    @Environment(\.scenePhase)
+    private var scenePhase
+
     private let context: AppContext = .shared
 //    private let context: AppContext = .mock(withRegistry: .shared)
 
@@ -78,6 +81,21 @@ private extension PassepartoutApp {
                 logsPrivateData: UserDefaults.appGroup.bool(forKey: AppPreference.logsPrivateData.key)
             )
             AppUI.configure(with: context)
+        }
+        .onChange(of: scenePhase) {
+            switch $0 {
+            case .active:
+                Task {
+                    do {
+                        try await context.tunnel.prepare(purge: true)
+                    } catch {
+                        pp_log(.app, .fault, "Unable to prepare tunnel: \(error)")
+                    }
+                }
+
+            default:
+                break
+            }
         }
         .themeLockScreen()
         .withEnvironment(from: context, theme: theme)

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -87,6 +87,7 @@ private extension PassepartoutApp {
             case .active:
                 Task {
                     do {
+                        pp_log(.app, .notice, "Prepare tunnel and purge stale data")
                         try await context.tunnel.prepare(purge: true)
                     } catch {
                         pp_log(.app, .fault, "Unable to prepare tunnel: \(error)")

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.8.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "de9387965025a1f79e060e6bdc862933fe972598"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "bec0635fe047e09c8b6c894d103ab8dd741b8340"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.8.0"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Sources/AppLibrary/Business/InMemoryProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/InMemoryProfileRepository.swift
@@ -46,7 +46,7 @@ public final class InMemoryProfileRepository: ProfileRepository {
     }
 
     public func saveProfile(_ profile: Profile) async throws {
-        print("Save profile: \(profile.id))")
+        pp_log(.app, .info, "Save profile: \(profile.id))")
         if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
             profiles[index] = profile
         } else {
@@ -55,7 +55,7 @@ public final class InMemoryProfileRepository: ProfileRepository {
     }
 
     public func removeProfiles(withIds ids: [Profile.ID]) async throws {
-        print("Remove profiles: \(ids)")
+        pp_log(.app, .info, "Remove profiles: \(ids)")
         profiles = profiles.filter {
             !ids.contains($0.id)
         }

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -55,18 +55,15 @@ public final class NEProfileRepository: ProfileRepository {
                 }
                 self?.profilesSubject.send(profiles)
             }
-
-        Task {
-            do {
-                try await repository.load()
-            } catch {
-                pp_log(.app, .fault, "Unable to load NE profiles: \(error)")
-            }
-        }
     }
 
     public var profilesPublisher: AnyPublisher<[Profile], Never> {
         profilesSubject.eraseToAnyPublisher()
+    }
+
+    // unused in app, rely on Tunnel.prepare()
+    public func loadProfiles(purge: Bool) async throws {
+        try await repository.load(purge: purge)
     }
 
     public func saveProfile(_ profile: Profile) async throws {

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -26,6 +26,7 @@
 import Combine
 import CommonLibrary
 import Foundation
+import NetworkExtension
 import PassepartoutKit
 
 public final class NEProfileRepository: ProfileRepository {
@@ -37,7 +38,7 @@ public final class NEProfileRepository: ProfileRepository {
 
     private var subscription: AnyCancellable?
 
-    public init(repository: NETunnelManagerRepository, title: @escaping (Profile) -> String) {
+    public init(repository: NETunnelManagerRepository, keychain: Keychain, title: @escaping (Profile) -> String) {
         self.repository = repository
         self.title = title
         profilesSubject = CurrentValueSubject([])
@@ -45,15 +46,25 @@ public final class NEProfileRepository: ProfileRepository {
         subscription = repository
             .managersPublisher
             .sink { [weak self] allManagers in
+                var toRemove: [NETunnelProviderManager] = []
                 let profiles = allManagers.values.compactMap {
                     do {
                         return try repository.profile(from: $0)
                     } catch {
+                        pp_log(.app, .error, "Unable to decode profile, will delete NE manager '\($0.localizedDescription ?? "")': \(error)")
+                        toRemove.append($0)
                         pp_log(.app, .error, "Unable to decode profile from NE manager '\($0.localizedDescription ?? "")': \(error)")
                         return nil
                     }
                 }
                 self?.profilesSubject.send(profiles)
+
+                let toRemoveConstant = toRemove
+                Task {
+                    for manager in toRemoveConstant {
+                        try? await repository.remove(manager: manager, keychain: keychain)
+                    }
+                }
             }
 
         Task {

--- a/Passepartout/Library/Sources/AppUI/AppUI.swift
+++ b/Passepartout/Library/Sources/AppUI/AppUI.swift
@@ -30,7 +30,6 @@ import PassepartoutKit
 public enum AppUI {
     public static func configure(with context: AppContext) {
         assertMissingModuleImplementations()
-        cleanUpOrphanedKeychainEntries()
     }
 }
 
@@ -45,8 +44,5 @@ private extension AppUI {
                 fatalError("\(moduleType): is not ModuleViewProviding")
             }
         }
-    }
-
-    static func cleanUpOrphanedKeychainEntries() {
     }
 }

--- a/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
@@ -78,11 +78,6 @@ public final class AppContext: ObservableObject {
         subscriptions = []
 
         Task {
-            do {
-                try await tunnel.prepare(purge: true)
-            } catch {
-                pp_log(.app, .fault, "Unable to prepare tunnel: \(error)")
-            }
             await iapManager.reloadReceipt()
             connectionObserver.observeObjects()
             profileManager.observeObjects()

--- a/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
@@ -78,7 +78,11 @@ public final class AppContext: ObservableObject {
         subscriptions = []
 
         Task {
-            try await tunnel.prepare()
+            do {
+                try await tunnel.prepare(purge: true)
+            } catch {
+                pp_log(.app, .fault, "Unable to prepare tunnel: \(error)")
+            }
             await iapManager.reloadReceipt()
             connectionObserver.observeObjects()
             profileManager.observeObjects()

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/OnDemandView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/OnDemandView.swift
@@ -193,7 +193,6 @@ private extension OnDemandView {
                 }
                 draft.withSSIDs[$0] = false
             }
-//            print(">>> withSSIDs (allSSIDs): \(withSSIDs)")
         }
     }
 
@@ -219,7 +218,6 @@ private extension OnDemandView {
                 }
                 draft.withSSIDs[$0] = true
             }
-//            print(">>> withSSIDs (onSSIDs): \(withSSIDs)")
         }
     }
 

--- a/Passepartout/Shared/Shared+App.swift
+++ b/Passepartout/Shared/Shared+App.swift
@@ -185,7 +185,10 @@ extension Tunnel {
 }
 
 private var localProfileRepository: ProfileRepository {
-    NEProfileRepository(repository: neRepository) {
+    NEProfileRepository(
+        repository: neRepository,
+        keychain: Registry.sharedKeychain
+    ) {
         sharedProfileTitle($0)
     }
 }

--- a/Passepartout/Shared/Shared+App.swift
+++ b/Passepartout/Shared/Shared+App.swift
@@ -185,10 +185,7 @@ extension Tunnel {
 }
 
 private var localProfileRepository: ProfileRepository {
-    NEProfileRepository(
-        repository: neRepository,
-        keychain: Registry.sharedKeychain
-    ) {
+    NEProfileRepository(repository: neRepository) {
         sharedProfileTitle($0)
     }
 }

--- a/Passepartout/Shared/Shared.swift
+++ b/Passepartout/Shared/Shared.swift
@@ -60,12 +60,16 @@ extension Registry {
         ]
     )
 
+    static var sharedKeychain: Keychain & Sendable {
+        AppleKeychain(group: BundleConfiguration.mainString(for: .keychainGroupId))
+    }
+
     static var sharedProtocolCoder: KeychainNEProtocolCoder {
         KeychainNEProtocolCoder(
             tunnelBundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
             registry: .shared,
             coder: CodableProfileCoder(),
-            keychain: AppleKeychain(group: BundleConfiguration.mainString(for: .keychainGroupId))
+            keychain: sharedKeychain
         )
     }
 }

--- a/Passepartout/Shared/Shared.swift
+++ b/Passepartout/Shared/Shared.swift
@@ -60,16 +60,12 @@ extension Registry {
         ]
     )
 
-    static var sharedKeychain: Keychain & Sendable {
-        AppleKeychain(group: BundleConfiguration.mainString(for: .keychainGroupId))
-    }
-
     static var sharedProtocolCoder: KeychainNEProtocolCoder {
         KeychainNEProtocolCoder(
             tunnelBundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
             registry: .shared,
             coder: CodableProfileCoder(),
-            keychain: sharedKeychain
+            keychain: AppleKeychain(group: BundleConfiguration.mainString(for: .keychainGroupId))
         )
     }
 }


### PR DESCRIPTION
- [x] NE managers were not deleted when unable to be decoded to a profile
- [x] Keychain items were not deleted on profile removal
- [x] Perform clean-up on app launch
- [x] Perform clean-up on app active

Prematurely merged as #727 then reverted, this is the complete PR.