### PR TITLE
Create OpenVPN module without a configuration

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "bec0635fe047e09c8b6c894d103ab8dd741b8340"
+        "revision" : "126392d2614c9d0ffe2aa2d96f6c5509221b8481",
+        "version" : "0.9.0"
       }
     },
     {
@@ -58,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source-wireguard-go",
       "state" : {
-        "revision" : "ea39fa396e98cfd2b9a235f0a801aaf03a37e30a",
-        "version" : "0.8.0"
+        "revision" : "4f766400057b3c8a3ceb7cfce4950393e292858e",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -27,14 +27,14 @@ let package = Package(
         )
     ],
     dependencies: [
-//        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.8.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "bec0635fe047e09c8b6c894d103ab8dd741b8340"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
+//        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "bec0635fe047e09c8b6c894d103ab8dd741b8340"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.8.0"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),
 //        .package(path: "../../../passepartoutkit-source-openvpn-openssl"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-wireguard-go", from: "0.8.0"),
-//            .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-wireguard-go", revision: "ea39fa396e98cfd2b9a235f0a801aaf03a37e30a"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-wireguard-go", from: "0.9.0"),
+//        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-wireguard-go", revision: "ea39fa396e98cfd2b9a235f0a801aaf03a37e30a"),
 //        .package(path: "../../../passepartoutkit-source-wireguard-go"),
         .package(url: "https://github.com/Cocoanetics/Kvitto", from: "1.0.0")
     ],

--- a/Passepartout/Library/Sources/AppUI/Mock/Mock.swift
+++ b/Passepartout/Library/Sources/AppUI/Mock/Mock.swift
@@ -117,8 +117,8 @@ extension Profile {
         do {
             var ovpn = OpenVPNModule.Builder()
             ovpn.configurationBuilder = OpenVPN.Configuration.Builder(withFallbacks: true)
-            ovpn.configurationBuilder.ca = .init(pem: "some CA")
-            ovpn.configurationBuilder.remotes = [
+            ovpn.configurationBuilder?.ca = .init(pem: "some CA")
+            ovpn.configurationBuilder?.remotes = [
                 try .init("1.2.3.4", .init(.udp, 80))
             ]
             profile.modules.append(try ovpn.tryBuild())

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/OpenVPNView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/OpenVPNView.swift
@@ -93,7 +93,7 @@ struct OpenVPNView: View {
 
 private extension OpenVPNView {
     var configuration: OpenVPN.Configuration.Builder {
-        draft.configurationBuilder
+        draft.configurationBuilder ?? .init(withFallbacks: true)
     }
 
     var providerModifier: some ViewModifier {

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/OpenVPNView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/OpenVPNView.swift
@@ -98,6 +98,7 @@ private extension OpenVPNView {
 
     var providerModifier: some ViewModifier {
         ProviderPanelModifier(
+            isRequired: draft.configurationBuilder == nil,
             providerId: $providerId,
             selectedEntity: $providerEntity,
             providerContent: providerContentView

--- a/Passepartout/Library/Sources/AppUI/Views/Modules/WireGuardView.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Modules/WireGuardView.swift
@@ -23,6 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import PassepartoutKit
 import PassepartoutWireGuardGo
 import SwiftUI
@@ -75,7 +76,7 @@ private struct WireGuardView: View {
 
 private extension WireGuardView {
     var configuration: WireGuard.Configuration.Builder {
-        draft.configurationBuilder
+        draft.configurationBuilder ?? .default
     }
 
     @ViewBuilder

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
@@ -105,6 +105,9 @@ private extension ProviderPanelModifier {
     func refreshIndex() async {
         do {
             try await providerManager.fetchIndex(from: apis)
+            if providerId == nil {
+                providerId = supportedProviders.first?.id
+            }
         } catch {
             pp_log(.app, .error, "Unable to fetch index: \(error)")
         }

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
@@ -64,17 +64,15 @@ private extension ProviderPanelModifier {
         }
     }
 
-    var providersPlusEmpty: [ProviderMetadata] {
-        [ProviderMetadata("", description: Strings.Global.none)] + supportedProviders
-    }
-
     var providerPicker: some View {
         let hasProviders = !supportedProviders.isEmpty
         return Picker(Strings.Global.provider, selection: $providerId) {
             if hasProviders {
-                ForEach(providersPlusEmpty, id: \.id) {
+                Text(Strings.Global.none)
+                    .tag(nil as ProviderID?)
+                ForEach(supportedProviders, id: \.id) {
                     Text($0.description)
-                        .tag($0.id.nilIfEmpty)
+                        .tag($0.id as ProviderID?)
                 }
             } else {
                 Text(" ") // enforce constant picker height on iOS

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
@@ -34,6 +34,8 @@ struct ProviderPanelModifier<Entity, ProviderContent>: ViewModifier where Entity
 
     var apis: [APIMapper] = API.shared
 
+    let isRequired: Bool
+
     @Binding
     var providerId: ProviderID?
 
@@ -64,12 +66,22 @@ private extension ProviderPanelModifier {
         }
     }
 
+    var selectedProviderId: Binding<ProviderID?> {
+        Binding {
+            providerId ?? supportedProviders.first?.id
+        } set: {
+            self.providerId = $0
+        }
+    }
+
     var providerPicker: some View {
         let hasProviders = !supportedProviders.isEmpty
-        return Picker(Strings.Global.provider, selection: $providerId) {
+        return Picker(Strings.Global.provider, selection: selectedProviderId) {
             if hasProviders {
-                Text(Strings.Global.none)
-                    .tag(nil as ProviderID?)
+                if !isRequired {
+                    Text(Strings.Global.none)
+                        .tag(nil as ProviderID?)
+                }
                 ForEach(supportedProviders, id: \.id) {
                     Text($0.description)
                         .tag($0.id as ProviderID?)
@@ -118,9 +130,10 @@ private extension ProviderID {
         EmptyView()
             .modifier(ProviderPanelModifier(
                 apis: [API.bundled],
+                isRequired: false,
                 providerId: $providerId,
                 selectedEntity: $vpnEntity,
-                providerContent: { id, entity in
+                providerContent: { _, entity in
                     HStack {
                         Text("Server")
                         Spacer()

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
@@ -105,9 +105,6 @@ private extension ProviderPanelModifier {
     func refreshIndex() async {
         do {
             try await providerManager.fetchIndex(from: apis)
-            if providerId == nil {
-                providerId = supportedProviders.first?.id
-            }
         } catch {
             pp_log(.app, .error, "Unable to fetch index: \(error)")
         }

--- a/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/Provider/ProviderPanelModifier.swift
@@ -53,7 +53,7 @@ struct ProviderPanelModifier<Entity, ProviderContent>: ViewModifier where Entity
 
         if let providerId {
             providerContent(providerId, selectedEntity)
-        } else {
+        } else if !isRequired {
             content
         }
     }
@@ -66,22 +66,12 @@ private extension ProviderPanelModifier {
         }
     }
 
-    var selectedProviderId: Binding<ProviderID?> {
-        Binding {
-            providerId ?? supportedProviders.first?.id
-        } set: {
-            self.providerId = $0
-        }
-    }
-
     var providerPicker: some View {
         let hasProviders = !supportedProviders.isEmpty
-        return Picker(Strings.Global.provider, selection: selectedProviderId) {
+        return Picker(Strings.Global.provider, selection: $providerId) {
             if hasProviders {
-                if !isRequired {
-                    Text(Strings.Global.none)
-                        .tag(nil as ProviderID?)
-                }
+                Text(Strings.Global.none)
+                    .tag(nil as ProviderID?)
                 ForEach(supportedProviders, id: \.id) {
                     Text($0.description)
                         .tag($0.id as ProviderID?)

--- a/Passepartout/Shared/Shared.swift
+++ b/Passepartout/Shared/Shared.swift
@@ -37,8 +37,11 @@ extension Registry {
                 dns: CFDNSResolver(),
                 importer: StandardOpenVPNParser(decrypter: OSSLTLSBox()),
                 sessionBlock: { _, module in
-                    try OpenVPNSession(
-                        configuration: module.configuration,
+                    guard let configuration = module.configuration else {
+                        fatalError("Creating session without OpenVPN configuration?")
+                    }
+                    return try OpenVPNSession(
+                        configuration: configuration,
                         credentials: module.credentials,
                         prng: SecureRandom(),
                         tlsFactory: {


### PR DESCRIPTION
Update library to allow optional VPN configurations. This in turn allows a module to be used with a provider, where the configuration is generated on the fly.