### PR TITLE
Provider configuration is persisted into module

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "126392d2614c9d0ffe2aa2d96f6c5509221b8481",
-        "version" : "0.9.0"
+        "revision" : "0bfd4578b71a905584cdd5c9c39ab3087521af78"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -27,8 +27,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-//        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "bec0635fe047e09c8b6c894d103ab8dd741b8340"),
+//        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "0bfd4578b71a905584cdd5c9c39ab3087521af78"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.8.0"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Shared/Shared+App.swift
+++ b/Passepartout/Shared/Shared+App.swift
@@ -136,13 +136,14 @@ extension ProfileProcessor {
             }
         }
 
-        let processed = try builder.tryBuild()
+        let profile = try builder.tryBuild()
         do {
-            return try processed.withProviderModules()
+            _ = try profile.withProviderModules()
+            return profile
         } catch {
             // FIXME: #703, alert unable to build provider server
             pp_log(.app, .error, "Unable to inject provider modules: \(error)")
-            return processed
+            throw error
         }
     }
 }

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -36,15 +36,16 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             parameters: Constants.shared.log,
             logsPrivateData: UserDefaults.appGroup.bool(forKey: AppPreference.logsPrivateData.key)
         )
-        fwd = try await NEPTPForwarder(
-            provider: self,
-            decoder: Registry.sharedProtocolCoder,
-            registry: .shared,
-            environment: .shared
-        )
         do {
+            fwd = try await NEPTPForwarder(
+                provider: self,
+                decoder: Registry.sharedProtocolCoder,
+                registry: .shared,
+                environment: .shared
+            )
             try await fwd?.startTunnel(options: options)
         } catch {
+            pp_log(.app, .fault, "Unable to start tunnel: \(error)")
             PassepartoutConfiguration.shared.flushLog()
             throw error
         }


### PR DESCRIPTION
When e.g. a OpenVPNModule is created without a configuration and a provider/server is then selected, the ProfileProcessor class serializes the profile with the provider configuration injected. When the module is re-edited, we can see the provider server configuration in the module after selecting "None" as provider.

Instead, validate the provider modules in ProfileProcessor, but let the tunnel generate the provider configuration on the fly.

https://github.com/passepartoutvpn/passepartoutkit-source/pull/355