### PR TITLE
Prevent iPad dismiss when tapping outside

### DIFF
--- a/Passepartout/Library/Sources/AppUI/Views/App/AppModalCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/App/AppModalCoordinator.swift
@@ -55,7 +55,7 @@ struct AppModalCoordinator: View {
             contentView
                 .toolbar(content: toolbarContent)
         }
-        .themeModal(item: $modalRoute, isRoot: true, content: modalDestination)
+        .themeModal(item: $modalRoute, isRoot: true, isInteractive: false, content: modalDestination)
     }
 }
 


### PR DESCRIPTION
The user may tap outside accidentally while editing a profile, thus losing all the edits. Avoid that.

Fixes #734 