### PR TITLE
Optimize updates in NEProfileRepository

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "a3c09e1427ec58a6ac14d13244f309009886c66e"
+        "revision" : "ead8d1652fc6875f8865a1c8610b0cc35828dee6"
       }
     },
     {

--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "9a43e23e9134c3e93926271b2d630be607433fa0"
+        "revision" : "377677cab4fd2ab45fccd807a886c3d41d3ff32b"
       }
     },
     {

--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "377677cab4fd2ab45fccd807a886c3d41d3ff32b"
+        "revision" : "a3c09e1427ec58a6ac14d13244f309009886c66e"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "9a43e23e9134c3e93926271b2d630be607433fa0"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "377677cab4fd2ab45fccd807a886c3d41d3ff32b"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "377677cab4fd2ab45fccd807a886c3d41d3ff32b"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "a3c09e1427ec58a6ac14d13244f309009886c66e"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "a3c09e1427ec58a6ac14d13244f309009886c66e"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "ead8d1652fc6875f8865a1c8610b0cc35828dee6"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -113,13 +113,16 @@ private extension NEProfileRepository {
                 managers.keys.contains($0.id)
             }
 
-        let removedProfiles = profilesSubject
+        let removedProfilesDesc = profilesSubject
             .value
             .filter {
                 !managers.keys.contains($0.id)
             }
+            .map {
+                "\($0.name)(\($0.id)"
+            }
 
-        pp_log(.app, .info, "Sync profiles removed externally: \(removedProfiles)")
+        pp_log(.app, .info, "Sync profiles removed externally: \(removedProfilesDesc)")
 
         profilesSubject.send(profiles)
     }

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -113,6 +113,14 @@ private extension NEProfileRepository {
                 managers.keys.contains($0.id)
             }
 
+        let removedProfiles = profilesSubject
+            .value
+            .filter {
+                !managers.keys.contains($0.id)
+            }
+
+        pp_log(.app, .info, "Sync profiles removed externally: \(removedProfiles)")
+
         profilesSubject.send(profiles)
     }
 }

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -80,11 +80,15 @@ public final class NEProfileRepository: ProfileRepository {
     }
 
     public func removeProfiles(withIds profileIds: [Profile.ID]) async throws {
+        var removedIds: Set<Profile.ID> = []
+        defer {
+            profilesSubject.value.removeAll {
+                removedIds.contains($0.id)
+            }
+        }
         for id in profileIds {
             try await repository.remove(profileId: id)
-        }
-        profilesSubject.value.removeAll {
-            profileIds.contains($0.id)
+            removedIds.insert(id)
         }
     }
 }


### PR DESCRIPTION
Currently, NEProfileRepository decodes profiles from ALL NE managers on any update. This is undesirable considering that:

- Profiles are only _added_ by the app
- Externally, profiles can only be _removed_

Therefore:

- Observe the initial managers to decode the initial profiles from them
- Publish values manually on save/delete (to ProfileManager eventually)
- Observe the subsequent updates for when a profile is removed externally, i.e. its ID doesn't appear in managers

Fixes #741