### PR TITLE
Resolve issues when toggling/switching profiles

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "ead8d1652fc6875f8865a1c8610b0cc35828dee6"
+        "revision" : "288ccbf1e1a984c8dc3a7cd2fd23d3d3fc4464f6"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "ead8d1652fc6875f8865a1c8610b0cc35828dee6"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "288ccbf1e1a984c8dc3a7cd2fd23d3d3fc4464f6"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -71,7 +71,7 @@ public final class NEProfileRepository: ProfileRepository {
     }
 
     public func saveProfile(_ profile: Profile) async throws {
-        try await repository.save(profile, connect: false, title: title)
+        try await repository.save(profile, forConnecting: false, title: title)
         if let index = profilesSubject.value.firstIndex(where: { $0.id == profile.id }) {
             profilesSubject.value[index] = profile
         } else {

--- a/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/AppLibrary/Business/NEProfileRepository.swift
@@ -65,12 +65,9 @@ public final class NEProfileRepository: ProfileRepository {
         profilesSubject.eraseToAnyPublisher()
     }
 
-    // unused in app, rely on Tunnel.prepare()
-    public func loadProfiles(purge: Bool) async throws {
-        try await repository.load(purge: purge)
-    }
-
     public func saveProfile(_ profile: Profile) async throws {
+
+        // FIXME: #379, save + reconnect in some scenarios
         try await repository.save(profile, forConnecting: false, title: title)
         if let index = profilesSubject.value.firstIndex(where: { $0.id == profile.id }) {
             profilesSubject.value[index] = profile

--- a/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
@@ -81,43 +81,6 @@ public final class AppContext: ObservableObject {
             await iapManager.reloadReceipt()
             connectionObserver.observeObjects()
             profileManager.observeObjects()
-            observeObjects()
-        }
-    }
-}
-
-// MARK: - Observation
-
-private extension AppContext {
-    func observeObjects() {
-        profileManager
-            .didChange
-            .sink { [weak self] event in
-                switch event {
-                case .save(let profile):
-                    self?.syncTunnelIfCurrentProfile(profile)
-
-                default:
-                    break
-                }
-            }
-            .store(in: &subscriptions)
-    }
-}
-
-private extension AppContext {
-    func syncTunnelIfCurrentProfile(_ profile: Profile) {
-        guard profile.id == tunnel.currentProfile?.id else {
-            return
-        }
-        Task {
-            if profile.isInteractive {
-                try await tunnel.disconnect()
-                return
-            }
-            if tunnel.status == .active {
-                try await tunnel.connect(with: profile, processor: profileProcessor)
-            }
         }
     }
 }

--- a/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/AppUI/Business/AppContext.swift
@@ -115,9 +115,6 @@ private extension AppContext {
                 try await tunnel.disconnect()
                 return
             }
-            if tunnel.status == .active {
-                try await tunnel.connect(with: profile, processor: profileProcessor)
-            }
         }
     }
 }

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelRestartButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelRestartButton.swift
@@ -52,6 +52,8 @@ struct TunnelRestartButton<Label>: View where Label: View {
             Task {
                 do {
                     try await tunnel.connect(with: profile, processor: profileProcessor)
+                } catch is CancellationError {
+                    //
                 } catch {
                     errorHandler.handle(
                         error,

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelRestartButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelRestartButton.swift
@@ -41,9 +41,6 @@ struct TunnelRestartButton<Label>: View where Label: View {
 
     let label: () -> Label
 
-    @State
-    private var pendingTask: Task<Void, Error>?
-
     var body: some View {
         Button {
             guard let profile else {
@@ -52,8 +49,7 @@ struct TunnelRestartButton<Label>: View where Label: View {
             guard tunnel.status == .active else {
                 return
             }
-            pendingTask?.cancel()
-            pendingTask = Task {
+            Task {
                 do {
                     try await tunnel.connect(with: profile, processor: profileProcessor)
                 } catch {

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
@@ -135,6 +135,8 @@ private extension TunnelToggleButton {
             } else {
                 try await tunnel.connect(with: profile, processor: profileProcessor)
             }
+        } catch is CancellationError {
+            //
         } catch {
             errorHandler.handle(
                 error,

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
@@ -105,7 +105,9 @@ private extension TunnelToggleButton {
             guard let profile else {
                 return
             }
-            nextProfileId = profile.id
+            if !isInstalled {
+                nextProfileId = profile.id
+            }
             defer {
                 if nextProfileId == profile.id {
                     nextProfileId = nil

--- a/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/TunnelToggleButton.swift
@@ -62,9 +62,6 @@ struct TunnelToggleButton<Label>: View, TunnelContextProviding, ThemeProviding w
 
     let label: (Bool) -> Label
 
-    @State
-    private var pendingTask: Task<Void, Error>?
-
     var body: some View {
         Button(action: tryPerform) {
             label(canConnect)
@@ -100,8 +97,7 @@ private extension TunnelToggleButton {
 
 private extension TunnelToggleButton {
     func tryPerform() {
-        pendingTask?.cancel()
-        pendingTask = Task {
+        Task {
             guard let profile else {
                 return
             }

--- a/Passepartout/Shared/Shared+App.swift
+++ b/Passepartout/Shared/Shared+App.swift
@@ -182,19 +182,19 @@ private extension ProfileManager {
 
 extension Tunnel {
     static let shared = Tunnel(
-        strategy: NETunnelStrategy(repository: ProfileManager.neRepository)
+        strategy: ProfileManager.neStrategy
     )
 }
 
 private extension ProfileManager {
     static let localProfileRepository: ProfileRepository = {
-        NEProfileRepository(repository: neRepository) {
+        NEProfileRepository(repository: neStrategy) {
             ProfileManager.sharedTitle($0)
         }
     }()
 
-    static let neRepository: NETunnelManagerRepository = {
-        NETunnelManagerRepository(
+    static let neStrategy: NETunnelStrategy = {
+        NETunnelStrategy(
             bundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
             coder: Registry.sharedProtocolCoder,
             environment: .shared


### PR DESCRIPTION
- Drop logic behind connection button tasks, let the library handle concurrency
- Drop AppContext observation of saved profiles for reconnection, let save() actively decide
- NETunnelStrategy and NETunnelManagerRepository are now a single entity
- Avoid flickering when toggling same profile