### PR TITLE
Reconnect on provider server selection

### DIFF
--- a/Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
@@ -464,8 +464,8 @@ public enum Strings {
       public static let onDemandSuffix = Strings.tr("Localizable", "ui.connection_status.on_demand_suffix", fallback: " (on-demand)")
     }
     public enum ProfileContext {
-      /// Move to...
-      public static let moveTo = Strings.tr("Localizable", "ui.profile_context.move_to", fallback: "Move to...")
+      /// Connect to...
+      public static let connectTo = Strings.tr("Localizable", "ui.profile_context.connect_to", fallback: "Connect to...")
     }
   }
   public enum Views {

--- a/Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
@@ -235,7 +235,7 @@
 // MARK: - Components
 
 "ui.connection_status.on_demand_suffix" = " (on-demand)";
-"ui.profile_context.move_to" = "Move to...";
+"ui.profile_context.connect_to" = "Connect to...";
 
 // MARK: - Alerts
 

--- a/Passepartout/Library/Sources/AppUI/Views/App/AppInlineCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/App/AppInlineCoordinator.swift
@@ -145,6 +145,7 @@ private extension AppInlineCoordinator {
         case .editProviderEntity(let profile, let module, let provider):
             ProviderSelectorView(
                 profileManager: profileManager,
+                tunnel: tunnel,
                 profile: profile,
                 module: module,
                 provider: provider

--- a/Passepartout/Library/Sources/AppUI/Views/App/AppModalCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/App/AppModalCoordinator.swift
@@ -137,6 +137,7 @@ extension AppModalCoordinator {
         case .editProviderEntity(let profile, let module, let provider):
             ProviderSelectorView(
                 profileManager: profileManager,
+                tunnel: tunnel,
                 profile: profile,
                 module: module,
                 provider: provider

--- a/Passepartout/Library/Sources/AppUI/Views/UI/ProfileContextMenu.swift
+++ b/Passepartout/Library/Sources/AppUI/Views/UI/ProfileContextMenu.swift
@@ -45,7 +45,7 @@ struct ProfileContextMenu: View, Routable {
 
     var body: some View {
         tunnelToggleButton
-        providerEntityButton
+        providerConnectToButton
         if isInstalledProfile {
             tunnelRestartButton
         }
@@ -78,11 +78,11 @@ private extension ProfileContextMenu {
         }
     }
 
-    var providerEntityButton: some View {
+    var providerConnectToButton: some View {
         profile?
             .firstProviderModule
             .map { _ in
-                Button(Strings.Ui.ProfileContext.moveTo) {
+                Button(Strings.Ui.ProfileContext.connectTo) {
                     flow?.onEditProviderEntity(profile!)
                 }
             }


### PR DESCRIPTION
Trigger reconnection on server selection, otherwise the installed profile would display an outdated region. It's also more convenient.