### PR TITLE
Improve macOS window lifecycle

### DIFF
--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -30,10 +30,6 @@ import SwiftUI
 
 @MainActor
 final class AppDelegate: NSObject {
-
-    @AppStorage(AppPreference.confirmsQuit.key)
-    var confirmsQuit = true
-
     let context: AppContext = .shared
 //    let context: AppContext = .mock(withRegistry: .shared)
 

--- a/Passepartout/App/Platforms/App+macOS.swift
+++ b/Passepartout/App/Platforms/App+macOS.swift
@@ -26,6 +26,7 @@
 #if os(macOS)
 
 import AppUIMain
+import CommonLibrary
 import PassepartoutKit
 import SwiftUI
 
@@ -35,16 +36,9 @@ extension AppDelegate: NSApplicationDelegate {
         configure()
     }
 
-    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        if confirmsQuit {
-            return quitConfirmationAlert()
-        }
-        return .terminateNow
-    }
-
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         AppWindow.shared.isVisible = false
-        return false
+        return !keepsInMenu
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
@@ -53,6 +47,15 @@ extension AppDelegate: NSApplicationDelegate {
 }
 
 private extension AppDelegate {
+    var keepsInMenu: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: AppPreference.keepsInMenu.key)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: AppPreference.keepsInMenu.key)
+        }
+    }
+
     var isStartedFromLoginItem: Bool {
         NSApp.isHidden
     }
@@ -61,28 +64,6 @@ private extension AppDelegate {
         if isStartedFromLoginItem {
             AppWindow.shared.isVisible = false
         }
-    }
-
-    func quitConfirmationAlert() -> NSApplication.TerminateReply {
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = Strings.Alerts.ConfirmQuit.title(BundleConfiguration.mainDisplayName)
-        alert.informativeText = Strings.Alerts.ConfirmQuit.message
-        alert.addButton(withTitle: Strings.Global.ok)
-        alert.addButton(withTitle: Strings.Global.cancel)
-        alert.addButton(withTitle: Strings.Global.doNotAskAgain)
-
-        switch alert.runModal() {
-        case .alertSecondButtonReturn:
-            return .terminateCancel
-
-        case .alertThirdButtonReturn:
-            confirmsQuit = false
-
-        default:
-            break
-        }
-        return .terminateNow
     }
 }
 

--- a/Passepartout/App/Platforms/App+macOS.swift
+++ b/Passepartout/App/Platforms/App+macOS.swift
@@ -31,7 +31,7 @@ import SwiftUI
 
 extension AppDelegate: NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
-        configureAppWindow()
+        hideIfLoginItem()
         configure()
     }
 
@@ -40,6 +40,11 @@ extension AppDelegate: NSApplicationDelegate {
             return quitConfirmationAlert()
         }
         return .terminateNow
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        AppWindow.shared.isVisible = false
+        return false
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
@@ -52,11 +57,10 @@ private extension AppDelegate {
         NSApp.isHidden
     }
 
-    func configureAppWindow() {
+    func hideIfLoginItem() {
         if isStartedFromLoginItem {
             AppWindow.shared.isVisible = false
         }
-        AppWindow.shared.removeCloseButton()
     }
 
     func quitConfirmationAlert() -> NSApplication.TerminateReply {

--- a/Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
@@ -11,14 +11,6 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 public enum Strings {
   public enum Alerts {
-    public enum ConfirmQuit {
-      /// The VPN, if enabled, will still run in the background. Do you want to quit?
-      public static let message = Strings.tr("Localizable", "alerts.confirm_quit.message", fallback: "The VPN, if enabled, will still run in the background. Do you want to quit?")
-      /// Quit %@
-      public static func title(_ p1: Any) -> String {
-        return Strings.tr("Localizable", "alerts.confirm_quit.title", String(describing: p1), fallback: "Quit %@")
-      }
-    }
     public enum Iap {
       public enum Restricted {
         /// The requested feature is unavailable in this build.
@@ -663,15 +655,15 @@ public enum Strings {
     }
     public enum Settings {
       public enum Rows {
-        /// Ask before quit
-        public static let confirmQuit = Strings.tr("Localizable", "views.settings.rows.confirm_quit", fallback: "Ask before quit")
         /// Erase iCloud store
         public static let eraseIcloud = Strings.tr("Localizable", "views.settings.rows.erase_icloud", fallback: "Erase iCloud store")
+        /// Keep in menu bar
+        public static let keepsInMenu = Strings.tr("Localizable", "views.settings.rows.keeps_in_menu", fallback: "Keep in menu bar")
         /// Lock in background
-        public static let lockInBackground = Strings.tr("Localizable", "views.settings.rows.lock_in_background", fallback: "Lock in background")
-        public enum LockInBackground {
+        public static let locksInBackground = Strings.tr("Localizable", "views.settings.rows.locks_in_background", fallback: "Lock in background")
+        public enum LocksInBackground {
           /// Passepartout is locked
-          public static let message = Strings.tr("Localizable", "views.settings.rows.lock_in_background.message", fallback: "Passepartout is locked")
+          public static let message = Strings.tr("Localizable", "views.settings.rows.locks_in_background.message", fallback: "Passepartout is locked")
         }
       }
       public enum Sections {

--- a/Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
@@ -134,9 +134,9 @@
 "views.profile.module_list.section.footer" = "Drag modules to rearrange them, as their order determines priority.";
 
 "views.settings.sections.icloud.footer" = "To erase the iCloud store securely, do so on all your synced devices. This will not affect local profiles.";
-"views.settings.rows.confirm_quit" = "Ask before quit";
-"views.settings.rows.lock_in_background" = "Lock in background";
-"views.settings.rows.lock_in_background.message" = "Passepartout is locked";
+"views.settings.rows.keeps_in_menu" = "Keep in menu bar";
+"views.settings.rows.locks_in_background" = "Lock in background";
+"views.settings.rows.locks_in_background.message" = "Passepartout is locked";
 "views.settings.rows.erase_icloud" = "Erase iCloud store";
 
 "views.about.title" = "About";
@@ -259,9 +259,6 @@
 
 "alerts.iap.restricted.title" = "Restricted";
 "alerts.iap.restricted.message" = "The requested feature is unavailable in this build.";
-
-"alerts.confirm_quit.title" = "Quit %@";
-"alerts.confirm_quit.message" = "The VPN, if enabled, will still run in the background. Do you want to quit?";
 
 // MARK: - Errors
 

--- a/Passepartout/Library/Sources/AppUI/Theme/Theme+UI.swift
+++ b/Passepartout/Library/Sources/AppUI/Theme/Theme+UI.swift
@@ -343,7 +343,7 @@ struct ThemeLockScreenModifier: ViewModifier {
         do {
             let isAuthorized = try await context.evaluatePolicy(
                 policy,
-                localizedReason: Strings.Views.Settings.Rows.LockInBackground.message
+                localizedReason: Strings.Views.Settings.Rows.LocksInBackground.message
             )
             return isAuthorized
         } catch {

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppMenu.swift
@@ -50,7 +50,7 @@ public struct AppMenu: View {
     public var body: some View {
         versionItem
         Divider()
-        dockToggle
+        showToggle
         loginToggle
         Divider()
         profilesList
@@ -65,12 +65,9 @@ private extension AppMenu {
         Text(BundleConfiguration.mainVersionString)
     }
 
-    var dockToggle: some View {
-        Button(model.isVisible ? Strings.Global.hide : Strings.Global.show) {
-            model.isVisible.toggle()
-            if !model.isVisible {
-                AppWindow.shared.close()
-            }
+    var showToggle: some View {
+        Button(Strings.Global.show) {
+            model.isVisible = true
         }
     }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppMenu.swift
@@ -55,6 +55,7 @@ public struct AppMenu: View {
         Divider()
         profilesList
         Divider()
+        aboutButton
         quitButton
     }
 }
@@ -103,6 +104,13 @@ private extension AppMenu {
                     pp_log(.app, .error, "Unable to toggle profile \(header.id) from menu: \(error)")
                 }
             }
+        }
+    }
+
+    var aboutButton: some View {
+        Button("\(Strings.Global.about)...") {
+            NSApp.activate(ignoringOtherApps: true)
+            NSApp.orderFrontStandardAboutPanel(self)
         }
     }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppMenu.swift
@@ -67,6 +67,9 @@ private extension AppMenu {
     var dockToggle: some View {
         Button(model.isVisible ? Strings.Global.hide : Strings.Global.show) {
             model.isVisible.toggle()
+            if !model.isVisible {
+                AppWindow.shared.close()
+            }
         }
     }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppWindow.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppWindow.swift
@@ -47,6 +47,10 @@ public final class AppWindow {
     private init() {
     }
 
+    public func close() {
+        window.close()
+    }
+
     public func removeCloseButton() {
         window.styleMask.remove(.closable)
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppWindow.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppWindow.swift
@@ -36,7 +36,7 @@ public final class AppWindow {
             NSApp.activationPolicy() == .regular && window.isVisible
         }
         set {
-            NSApp.setActivationPolicy(newValue ? .regular : .prohibited)
+            NSApp.setActivationPolicy(newValue ? .regular : .accessory)
             if newValue {
                 NSApp.activate(ignoringOtherApps: true)
                 window.makeKeyAndOrderFront(self)

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppWindow.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/AppWindow.swift
@@ -50,10 +50,6 @@ public final class AppWindow {
     public func close() {
         window.close()
     }
-
-    public func removeCloseButton() {
-        window.styleMask.remove(.closable)
-    }
 }
 
 private extension AppWindow {

--- a/Passepartout/Library/Sources/AppUIMain/Views/Settings/SettingsSectionGroup.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Settings/SettingsSectionGroup.swift
@@ -31,8 +31,8 @@ import UtilsLibrary
 
 struct SettingsSectionGroup: View {
 
-    @AppStorage(AppPreference.confirmsQuit.key)
-    private var confirmsQuit = true
+    @AppStorage(AppPreference.keepsInMenu.key)
+    private var keepsInMenu = false
 
     @AppStorage(AppPreference.locksInBackground.key)
     private var locksInBackground = false
@@ -48,7 +48,7 @@ struct SettingsSectionGroup: View {
     var body: some View {
         Group {
 #if os(macOS)
-            confirmsQuitToggle
+            keepsInMenuToggle
 #endif
 #if os(iOS)
             lockInBackgroundToggle
@@ -66,12 +66,12 @@ struct SettingsSectionGroup: View {
 }
 
 private extension SettingsSectionGroup {
-    var confirmsQuitToggle: some View {
-        Toggle(Strings.Views.Settings.Rows.confirmQuit, isOn: $confirmsQuit)
+    var keepsInMenuToggle: some View {
+        Toggle(Strings.Views.Settings.Rows.keepsInMenu, isOn: $keepsInMenu)
     }
 
     var lockInBackgroundToggle: some View {
-        Toggle(Strings.Views.Settings.Rows.lockInBackground, isOn: $locksInBackground)
+        Toggle(Strings.Views.Settings.Rows.locksInBackground, isOn: $locksInBackground)
     }
 
     var eraseCloudKitButton: some View {

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/AppPreference.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/AppPreference.swift
@@ -26,7 +26,7 @@
 import Foundation
 
 public enum AppPreference: String {
-    case confirmsQuit
+    case keepsInMenu
 
     case locksInBackground
 


### PR DESCRIPTION
- Let the user close the window, the app will just remain alive in the status bar
- Accordingly, replace "Confirm quit" preference with the option to stay alive in the status bar
- Add "About..." item