### PR TITLE
OpenVPN OTP is persisted with the password

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "212bbf0c21e116d9703009c38bd0f0c2dd9e80b2"
+        "revision" : "8b4c47f716120fab3f219593cf4ae0e6e2c86677"
       }
     },
     {

--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "7426954e8ec84e6ddf6c8cd415bfa2c5c7064534"
+        "revision" : "212bbf0c21e116d9703009c38bd0f0c2dd9e80b2"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "212bbf0c21e116d9703009c38bd0f0c2dd9e80b2"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "8b4c47f716120fab3f219593cf4ae0e6e2c86677"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "7426954e8ec84e6ddf6c8cd415bfa2c5c7064534"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "212bbf0c21e116d9703009c38bd0f0c2dd9e80b2"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),


### PR DESCRIPTION
Encode OpenVPN password + OTP in tunnel rather than in the app.

Encoding them upfront in the app ends up persisting the profile with the combined password. Update the library with a new OTP field in OpenVPN.Credentials, so that the password encoding is performed [on the fly in the tunnel](https://github.com/passepartoutvpn/passepartoutkit-source/pull/398). Similar to how provider modules are generated.

This is likely a regression caused by migrating to NEProfileRepository, because starting a connection causes the profile to be saved to NE with the encoded password. Later, the profile is restored from NE and therefore contains the encoded password.