### PR TITLE
Refactor and improve interactive login

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -92,7 +92,7 @@ private extension ProfileContainerView {
     }
 
     func interactiveDestination() -> some View {
-        InteractiveView(manager: interactiveManager) {
+        InteractiveCoordinator(manager: interactiveManager) {
             errorHandler.handle(
                 $0,
                 title: Strings.Global.connection,

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -92,7 +92,7 @@ private extension ProfileContainerView {
     }
 
     func interactiveDestination() -> some View {
-        InteractiveCoordinator(manager: interactiveManager) {
+        InteractiveCoordinator(style: .modal, manager: interactiveManager) {
             errorHandler.handle(
                 $0,
                 title: Strings.Global.connection,

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -99,6 +99,7 @@ private extension ProfileContainerView {
                 message: Strings.Views.Profiles.Errors.tunnel
             )
         }
+        .presentationDetents([.medium])
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -226,10 +226,13 @@ private extension OpenVPNView {
             }
 
         case .credentials:
-            OpenVPNCredentialsView(
-                isInteractive: draft.isInteractive,
-                credentials: draft.credentials
-            )
+            Form {
+                OpenVPNCredentialsView(
+                    isInteractive: draft.isInteractive,
+                    credentials: draft.credentials
+                )
+            }
+            .themeForm()
             .themeAnimation(on: draft.wrappedValue.isInteractive, category: .modules)
             .modifier(PaywallModifier(reason: $paywallReason))
         }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -232,6 +232,7 @@ private extension OpenVPNView {
                     credentials: draft.credentials
                 )
             }
+            .navigationTitle(Strings.Modules.Openvpn.credentials)
             .themeForm()
             .themeAnimation(on: draft.wrappedValue.isInteractive, category: .modules)
             .modifier(PaywallModifier(reason: $paywallReason))

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -80,7 +80,7 @@ private extension ProfileEditView {
 
     @ToolbarContentBuilder
     func toolbarContent() -> some ToolbarContent {
-        ToolbarItem {
+        ToolbarItem(placement: .confirmationAction) {
             ProfileSaveButton(
                 title: Strings.Global.save,
                 errorModuleIds: $malformedModuleIds

--- a/Passepartout/Library/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -48,10 +48,10 @@ public struct AppCoordinator: View, AppCoordinatorConforming {
                     Text(Strings.Global.profile)
                 }
 
-            searchView
-                .tabItem {
-                    ThemeImage(.search)
-                }
+//            searchView
+//                .tabItem {
+//                    ThemeImage(.search)
+//                }
 
             settingsView
                 .tabItem {
@@ -66,12 +66,11 @@ private extension AppCoordinator {
         ProfileView(profileManager: profileManager, tunnel: tunnel)
     }
 
-    // FIXME: #788, UI for TV
-    var searchView: some View {
-        VStack {
-            Text("Search")
-        }
-    }
+//    var searchView: some View {
+//        VStack {
+//            Text("Search")
+//        }
+//    }
 
     // FIXME: #788, UI for TV
     var settingsView: some View {

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -70,6 +70,7 @@ private extension ProfileListView {
                 toggleView(for: header)
             }
         )
+        .focused($focusedField, equals: .profile(header.id))
     }
 
     func toggleView(for header: ProfileHeader) -> some View {
@@ -81,6 +82,5 @@ private extension ProfileListView {
             }
         }
         .font(.headline)
-        .focused($focusedField, equals: .profile(header.id))
     }
 }

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -71,11 +71,16 @@ struct ProfileView: View, TunnelInstallationProviding {
                         .focusSection()
                 }
                 .frame(maxWidth: .infinity)
+                .disabled(interactiveManager.isPresented)
 
-                if isSwitching {
+                if interactiveManager.isPresented {
+                    interactiveView
+                        .font(.body)
+                        .padding(.horizontal, 100)
+                } else if isSwitching {
                     listView
                         .padding(.horizontal)
-                        .frame(width: geo.size.width * 0.5)
+//                        .frame(width: geo.size.width * 0.5) // seems redundant
                         .focusSection()
                 }
             }
@@ -84,15 +89,6 @@ struct ProfileView: View, TunnelInstallationProviding {
         .background(theme.primaryColor.gradient)
         .animation(.default, value: isSwitching)
         .withErrorHandler(errorHandler)
-        .themeModal(isPresented: $interactiveManager.isPresented) {
-            InteractiveCoordinator(style: .modal, manager: interactiveManager) {
-                errorHandler.handle(
-                    $0,
-                    title: Strings.Global.connection,
-                    message: Strings.Views.Profiles.Errors.tunnel
-                )
-            }
-        }
         .onLoad {
             focusedField = .switchProfile
         }
@@ -140,6 +136,16 @@ private extension ProfileView {
             interactiveManager: interactiveManager,
             errorHandler: errorHandler
         )
+    }
+
+    var interactiveView: some View {
+        InteractiveCoordinator(style: .inline, manager: interactiveManager) {
+            errorHandler.handle(
+                $0,
+                title: Strings.Global.connection,
+                message: Strings.Views.Profiles.Errors.tunnel
+            )
+        }
     }
 
     var listView: some View {

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -73,14 +73,19 @@ struct ProfileView: View, TunnelInstallationProviding {
                 .frame(maxWidth: .infinity)
                 .disabled(interactiveManager.isPresented)
 
-                if interactiveManager.isPresented {
-                    interactiveView
-                        .padding(.horizontal, 100)
-                } else if isSwitching {
-                    listView
-                        .padding(.horizontal)
-//                        .frame(width: geo.size.width * 0.5) // seems redundant
-                        .focusSection()
+                if isSwitching {
+                    ZStack {
+                        listView
+                            .padding(.horizontal)
+                            .opacity(interactiveManager.isPresented ? 0.0 : 1.0)
+
+                        if interactiveManager.isPresented {
+                            interactiveView
+                                .padding(.horizontal, 100)
+                        }
+                    }
+//                    .frame(width: geo.size.width * 0.5) // seems redundant
+                    .focusSection()
                 }
             }
         }

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -150,6 +150,8 @@ private extension ProfileView {
         }
         .font(.body)
         .onExitCommand {
+            let formerProfileId = interactiveManager.editor.profile.id
+            focusedField = .profile(formerProfileId)
             interactiveManager.isPresented = false
         }
     }

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -85,7 +85,7 @@ struct ProfileView: View, TunnelInstallationProviding {
         .animation(.default, value: isSwitching)
         .withErrorHandler(errorHandler)
         .themeModal(isPresented: $interactiveManager.isPresented) {
-            InteractiveCoordinator(manager: interactiveManager) {
+            InteractiveCoordinator(style: .modal, manager: interactiveManager) {
                 errorHandler.handle(
                     $0,
                     title: Strings.Global.connection,

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -139,12 +139,15 @@ private extension ProfileView {
     }
 
     var interactiveView: some View {
-        InteractiveCoordinator(style: .inline, manager: interactiveManager) {
+        InteractiveCoordinator(style: .inline(withCancel: false), manager: interactiveManager) {
             errorHandler.handle(
                 $0,
                 title: Strings.Global.connection,
                 message: Strings.Views.Profiles.Errors.tunnel
             )
+        }
+        .onExitCommand {
+            interactiveManager.isPresented = false
         }
     }
 

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -99,6 +99,7 @@ struct ProfileView: View, TunnelInstallationProviding {
         .onChange(of: tunnel.status) { _, new in
             if new == .activating {
                 isSwitching = false
+                focusedField = .connect
             }
         }
         .onChange(of: tunnel.currentProfile) { _, new in

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -75,7 +75,6 @@ struct ProfileView: View, TunnelInstallationProviding {
 
                 if interactiveManager.isPresented {
                     interactiveView
-                        .font(.body)
                         .padding(.horizontal, 100)
                 } else if isSwitching {
                     listView
@@ -146,6 +145,7 @@ private extension ProfileView {
                 message: Strings.Views.Profiles.Errors.tunnel
             )
         }
+        .font(.body)
         .onExitCommand {
             interactiveManager.isPresented = false
         }

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -85,7 +85,7 @@ struct ProfileView: View, TunnelInstallationProviding {
         .animation(.default, value: isSwitching)
         .withErrorHandler(errorHandler)
         .themeModal(isPresented: $interactiveManager.isPresented) {
-            InteractiveView(manager: interactiveManager) {
+            InteractiveCoordinator(manager: interactiveManager) {
                 errorHandler.handle(
                     $0,
                     title: Strings.Global.connection,

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -93,9 +93,7 @@ struct ProfileView: View, TunnelInstallationProviding {
         .background(theme.primaryColor.gradient)
         .animation(.default, value: isSwitching)
         .withErrorHandler(errorHandler)
-        .onLoad {
-            focusedField = .switchProfile
-        }
+        .defaultFocus($focusedField, .switchProfile)
         .onChange(of: tunnel.status) { _, new in
             if new == .activating {
                 isSwitching = false

--- a/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -531,6 +531,10 @@ public enum Strings {
       ///  (on-demand)
       public static let onDemandSuffix = Strings.tr("Localizable", "ui.connection_status.on_demand_suffix", fallback: " (on-demand)")
     }
+    public enum InteractiveCoordinator {
+      /// Interactive
+      public static let title = Strings.tr("Localizable", "ui.interactive_coordinator.title", fallback: "Interactive")
+    }
     public enum ProfileContext {
       /// Connect to...
       public static let connectTo = Strings.tr("Localizable", "ui.profile_context.connect_to", fallback: "Connect to...")

--- a/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -246,6 +246,7 @@
 // MARK: - Components
 
 "ui.connection_status.on_demand_suffix" = " (on-demand)";
+"ui.interactive_coordinator.title" = "Interactive";
 "ui.profile_context.connect_to" = "Connect to...";
 
 // MARK: - Paywalls

--- a/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+tvOS.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+tvOS.swift
@@ -67,13 +67,13 @@ extension ThemeSectionWithHeaderFooterModifier {
 
 extension ThemeTextField {
     public var body: some View {
-        fieldView
+        TextField(placeholder, text: $text)
     }
 }
 
 extension ThemeSecureField {
     public var body: some View {
-        fieldView
+        SecureField(placeholder, text: $text)
     }
 }
 

--- a/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+tvOS.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+tvOS.swift
@@ -67,13 +67,13 @@ extension ThemeSectionWithHeaderFooterModifier {
 
 extension ThemeTextField {
     public var body: some View {
-        TextField(placeholder, text: $text)
+        TextField(title ?? "", text: $text)
     }
 }
 
 extension ThemeSecureField {
     public var body: some View {
-        SecureField(placeholder, text: $text)
+        SecureField(title ?? "", text: $text)
     }
 }
 

--- a/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+tvOS.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+tvOS.swift
@@ -67,13 +67,13 @@ extension ThemeSectionWithHeaderFooterModifier {
 
 extension ThemeTextField {
     public var body: some View {
-        TextField(placeholder, text: $text)
+        fieldView
     }
 }
 
 extension ThemeSecureField {
     public var body: some View {
-        SecureField(placeholder, text: $text)
+        fieldView
     }
 }
 

--- a/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Views.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Views.swift
@@ -182,7 +182,7 @@ public struct ThemeSecureField: View {
 
     let placeholder: String
 
-    public init(title: String?, text: Binding<String>, placeholder: String) {
+    public init(_ title: String?, text: Binding<String>, placeholder: String) {
         self.title = title
         _text = text
         self.placeholder = placeholder

--- a/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Views.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Views.swift
@@ -182,7 +182,7 @@ public struct ThemeSecureField: View {
 
     let placeholder: String
 
-    public init(_ title: String?, text: Binding<String>, placeholder: String) {
+    public init(title: String?, text: Binding<String>, placeholder: String) {
         self.title = title
         _text = text
         self.placeholder = placeholder

--- a/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -63,7 +63,6 @@ public struct OpenVPNCredentialsView: View {
             inputSection
         }
         .themeManualInput()
-        .navigationTitle(Strings.Modules.Openvpn.credentials)
         .onLoad {
             builder = credentials?.builder() ?? OpenVPN.Credentials.Builder()
             builder.otp = nil

--- a/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -138,12 +138,12 @@ private extension OpenVPNCredentialsView {
         Group {
             ThemeTextField(Strings.Global.username, text: $builder.username, placeholder: Strings.Placeholders.username)
                 .textContentType(.username)
-            ThemeSecureField(title: Strings.Global.password, text: $builder.password, placeholder: Strings.Placeholders.secret)
+            ThemeSecureField(Strings.Global.password, text: $builder.password, placeholder: Strings.Placeholders.secret)
                 .textContentType(.password)
 
             if isEligibleForInteractiveLogin, isAuthenticating, builder.otpMethod != .none {
                 ThemeSecureField(
-                    title: Strings.Unlocalized.otp,
+                    Strings.Unlocalized.otp,
                     text: $builder.otp ?? "",
                     placeholder: Strings.Placeholders.secret
                 )

--- a/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -58,12 +58,11 @@ public struct OpenVPNCredentialsView: View {
     }
 
     public var body: some View {
-        Form {
+        Group {
             restrictedArea
             inputSection
         }
         .themeManualInput()
-        .themeForm()
         .navigationTitle(Strings.Modules.Openvpn.credentials)
         .onLoad {
             builder = credentials?.builder() ?? OpenVPN.Credentials.Builder()

--- a/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -135,11 +135,12 @@ private extension OpenVPNCredentialsView {
 
     var inputSection: some View {
         Group {
-            ThemeTextField(Strings.Global.username, text: $builder.username, placeholder: Strings.Placeholders.username)
-                .textContentType(.username)
-            ThemeSecureField(title: Strings.Global.password, text: $builder.password, placeholder: Strings.Placeholders.secret)
-                .textContentType(.password)
-
+            if !isAuthenticating || builder.otpMethod == .none {
+                ThemeTextField(Strings.Global.username, text: $builder.username, placeholder: Strings.Placeholders.username)
+                    .textContentType(.username)
+                ThemeSecureField(title: Strings.Global.password, text: $builder.password, placeholder: Strings.Placeholders.secret)
+                    .textContentType(.password)
+            }
             if isEligibleForInteractiveLogin, isAuthenticating, builder.otpMethod != .none {
                 ThemeSecureField(
                     title: Strings.Unlocalized.otp,

--- a/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -138,12 +138,12 @@ private extension OpenVPNCredentialsView {
         Group {
             ThemeTextField(Strings.Global.username, text: $builder.username, placeholder: Strings.Placeholders.username)
                 .textContentType(.username)
-            ThemeSecureField(Strings.Global.password, text: $builder.password, placeholder: Strings.Placeholders.secret)
+            ThemeSecureField(title: Strings.Global.password, text: $builder.password, placeholder: Strings.Placeholders.secret)
                 .textContentType(.password)
 
             if isEligibleForInteractiveLogin, isAuthenticating, builder.otpMethod != .none {
                 ThemeSecureField(
-                    Strings.Unlocalized.otp,
+                    title: Strings.Unlocalized.otp,
                     text: $builder.otp ?? "",
                     placeholder: Strings.Placeholders.secret
                 )

--- a/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  InteractiveView.swift
+//  InteractiveCoordinator.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 9/8/24.
@@ -26,7 +26,7 @@
 import PassepartoutKit
 import SwiftUI
 
-public struct InteractiveView: View {
+public struct InteractiveCoordinator: View {
 
     @ObservedObject
     private var manager: InteractiveManager
@@ -47,7 +47,7 @@ public struct InteractiveView: View {
 }
 
 @MainActor
-private extension InteractiveView {
+private extension InteractiveCoordinator {
     func stackView(with provider: any InteractiveViewProviding) -> some View {
         NavigationStack {
             AnyView(provider.interactiveView(with: manager.editor))

--- a/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
@@ -31,7 +31,7 @@ public struct InteractiveCoordinator: View {
     public enum Style {
         case modal
 
-        case inline
+        case inline(withCancel: Bool)
     }
 
     private let style: Style
@@ -56,10 +56,11 @@ public struct InteractiveCoordinator: View {
                     cancel: cancel
                 ))
 
-        case .inline:
+        case .inline(let withCancel):
             interactiveView
                 .modifier(InlineInteractiveModifier(
                     title: manager.editor.profile.name,
+                    withCancel: withCancel,
                     confirm: confirm,
                     cancel: cancel
                 ))
@@ -111,6 +112,8 @@ private extension InteractiveCoordinator {
     struct InlineInteractiveModifier: ViewModifier {
         let title: String
 
+        let withCancel: Bool
+
         let confirm: () -> Void
 
         let cancel: () -> Void
@@ -135,9 +138,11 @@ private extension InteractiveCoordinator {
                     Text(Strings.Global.connect)
                         .frame(maxWidth: .infinity)
                 }
-                Button(role: .cancel, action: cancel) {
-                    Text(Strings.Global.cancel)
-                        .frame(maxWidth: .infinity)
+                if withCancel {
+                    Button(role: .cancel, action: cancel) {
+                        Text(Strings.Global.cancel)
+                            .frame(maxWidth: .infinity)
+                    }
                 }
             }
             .frame(maxWidth: .infinity)

--- a/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
@@ -23,55 +23,145 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonUtils
 import PassepartoutKit
 import SwiftUI
 
 public struct InteractiveCoordinator: View {
+    public enum Style {
+        case modal
+
+        case inline
+    }
+
+    private let style: Style
 
     @ObservedObject
     private var manager: InteractiveManager
 
     private let onError: (Error) -> Void
 
-    public init(manager: InteractiveManager, onError: @escaping (Error) -> Void) {
+    public init(style: Style, manager: InteractiveManager, onError: @escaping (Error) -> Void) {
+        self.style = style
         self.manager = manager
         self.onError = onError
     }
 
     public var body: some View {
-        manager
-            .editor
-            .interactiveProvider
-            .map(stackView)
+        switch style {
+        case .modal:
+            interactiveView
+                .modifier(ModalInteractiveModifier(
+                    confirmButton: confirmButton,
+                    cancelButton: cancelButton
+                ))
+
+        case .inline:
+            interactiveView
+                .modifier(InlineInteractiveModifier(
+                    title: manager.editor.profile.name,
+                    confirmButton: confirmButton,
+                    cancelButton: cancelButton
+                ))
+        }
     }
 }
 
-@MainActor
+// MARK: - Modal
+
 private extension InteractiveCoordinator {
-    func stackView(with provider: any InteractiveViewProviding) -> some View {
-        NavigationStack {
-            AnyView(provider.interactiveView(with: manager.editor))
-                .toolbar(content: toolbarContent)
+    struct ModalInteractiveModifier<ConfirmButton, CancelButton>: ViewModifier where ConfirmButton: View, CancelButton: View {
+        let confirmButton: () -> ConfirmButton
+
+        let cancelButton: () -> CancelButton
+
+        func body(content: Content) -> some View {
+            NavigationStack {
+                Form {
+                    content
+                }
+                .themeForm()
+                .toolbar(content: modalToolbar)
+            }
+        }
+
+        @ToolbarContentBuilder
+        func modalToolbar() -> some ToolbarContent {
+            ToolbarItem(placement: .confirmationAction, content: confirmButton)
+            ToolbarItem(placement: .cancellationAction, content: cancelButton)
+        }
+    }
+}
+
+// MARK: - Inline
+
+private extension InteractiveCoordinator {
+    struct InlineInteractiveModifier<ConfirmButton, CancelButton>: ViewModifier where ConfirmButton: View, CancelButton: View {
+        let title: String
+
+        let confirmButton: () -> ConfirmButton
+
+        let cancelButton: () -> CancelButton
+
+        func body(content: Content) -> some View {
+            VStack {
+                Text(title)
+                    .font(.title2)
+                content
+                toolbar
+                    .padding(.top)
+                Spacer()
+            }
+#if os(tvOS)
+            .scrollClipDisabled()
+#endif
+        }
+
+        var toolbar: some View {
+            VStack {
+                confirmButton()
+                cancelButton()
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+// MARK: - Common
+
+private extension InteractiveCoordinator {
+    var interactiveView: some View {
+        manager
+            .editor
+            .interactiveProvider
+            .map(innerView)
+    }
+
+    func innerView(with provider: any InteractiveViewProviding) -> some View {
+        AnyView(provider.interactiveView(with: manager.editor))
+    }
+
+    func confirmButton() -> some View {
+        Button {
+            Task {
+                do {
+                    try await manager.complete()
+                } catch {
+                    onError(error)
+                }
+            }
+        } label: {
+            Text(Strings.Global.ok)
+                .frame(maxWidth: .infinity)
         }
     }
 
-    @ToolbarContentBuilder
-    func toolbarContent() -> some ToolbarContent {
-        ToolbarItem(placement: .cancellationAction) {
-            Button(Strings.Global.cancel, role: .cancel) {
-                manager.isPresented = false
-            }
-        }
-        ToolbarItem(placement: .confirmationAction) {
-            Button(Strings.Global.ok) {
-                Task {
-                    do {
-                        try await manager.complete()
-                    } catch {
-                        onError(error)
-                    }
-                }
-            }
+    func cancelButton() -> some View {
+        Button(role: .cancel) {
+            manager.isPresented = false
+        } label: {
+            Text(Strings.Global.cancel)
+                .frame(maxWidth: .infinity)
         }
     }
 }

--- a/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
@@ -82,6 +82,8 @@ private extension InteractiveCoordinator {
                     content
                 }
                 .themeForm()
+                .themeNavigationDetail()
+                .navigationTitle(Strings.Ui.InteractiveCoordinator.title)
                 .toolbar(content: modalToolbar)
             }
         }

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -1,9 +1,9 @@
 strings:
   inputs:
-    - Passepartout/Library/Sources/AppUI/Resources/en.lproj/Localizable.strings
+    - Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
   outputs:
     - templateName: structured-swift5
-      output: Passepartout/Library/Sources/AppUI/L10n/SwiftGen+Strings.swift
+      output: Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
       params:
         bundle: Bundle.main
         enumName: Strings


### PR DESCRIPTION
Define two styles for interactive login:

- Modal (iOS/macOS) - Form inside NavigationStack
- Inline (tvOS) - VStack

Requires OpenVPN credentials view to be container-agnostic.

Play with focus to improve the overall TV experience.