### PR TITLE
Review ProfileManager observation logic

### DIFF
--- a/Passepartout/App/Platforms/App+iOS.swift
+++ b/Passepartout/App/Platforms/App+iOS.swift
@@ -30,7 +30,7 @@ import SwiftUI
 
 extension AppDelegate: UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        configure(with: AppUIMain())
+        configure(with: AppUIMain(isStartedFromLoginItem: false))
         return true
     }
 }

--- a/Passepartout/App/Platforms/App+macOS.swift
+++ b/Passepartout/App/Platforms/App+macOS.swift
@@ -32,7 +32,7 @@ import SwiftUI
 
 extension AppDelegate: NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
-        configure(with: AppUIMain())
+        configure(with: AppUIMain(isStartedFromLoginItem: isStartedFromLoginItem))
         hideIfLoginItem()
     }
 

--- a/Passepartout/Library/Sources/AppUIMain/AppUIMain.swift
+++ b/Passepartout/Library/Sources/AppUIMain/AppUIMain.swift
@@ -27,11 +27,21 @@ import Foundation
 @_exported import UILibrary
 
 public final class AppUIMain: UILibraryConfiguring {
-    public init() {
+    private let isStartedFromLoginItem: Bool
+
+    public init(isStartedFromLoginItem: Bool) {
+        self.isStartedFromLoginItem = isStartedFromLoginItem
     }
 
     public func configure(with context: AppContext) {
         assertMissingImplementations()
+
+        // keep this for login item because scenePhase is not triggered
+        if isStartedFromLoginItem {
+            Task {
+                try await context.tunnel.prepare(purge: true)
+            }
+        }
     }
 }
 

--- a/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
@@ -118,7 +118,9 @@ private extension NEProfileRepository {
                 "\($0.name)(\($0.id)"
             }
 
-        pp_log(.app, .info, "Sync profiles removed externally: \(removedProfilesDescription)")
+        if !removedProfilesDescription.isEmpty {
+            pp_log(.app, .info, "Sync profiles removed externally: \(removedProfilesDescription)")
+        }
 
         profilesSubject.send(profiles)
     }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -326,7 +326,7 @@ private extension ProfileManager {
                 .map(\.key)
 
             if !idsToRemove.isEmpty {
-                pp_log(.app, .info, "Delete non-included local profile: \(idsToRemove)")
+                pp_log(.app, .info, "Delete non-included local profiles: \(idsToRemove)")
                 Task.detached {
                     try await self.repository.removeProfiles(withIds: idsToRemove)
                 }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -130,7 +130,7 @@ extension ProfileManager {
         }
     }
 
-    public func save(_ profile: Profile, isShared: Bool? = nil) async throws {
+    public func save(_ profile: Profile, force: Bool = false, isShared: Bool? = nil) async throws {
         let wasModified: Bool
         let existingProfile = allProfiles[profile.id]
         if let existingProfile {
@@ -140,7 +140,7 @@ extension ProfileManager {
         }
 
         let historifiedProfile: Profile
-        if wasModified {
+        if force {
             var builder = profile.builder()
             builder.attributes.lastUpdate = Date()
             builder.attributes.fingerprint = UUID()

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -154,26 +154,27 @@ extension ProfileManager {
                 allProfiles[profile.id] = profile
                 didChange.send(.save(profile))
             } else {
-                pp_log(.app, .notice, "Profile \(profile.id) not modified, not saving")
+                pp_log(.app, .notice, "\tProfile \(profile.id) not modified, not saving")
             }
         } catch {
-            pp_log(.app, .fault, "Unable to save profile \(profile.id): \(error)")
+            pp_log(.app, .fault, "\tUnable to save profile \(profile.id): \(error)")
             throw error
         }
         do {
             if let isShared, let remoteRepository {
                 if isShared {
-                    pp_log(.app, .notice, "Enable remote sharing of profile \(profile.id)...")
+                    pp_log(.app, .notice, "\tEnable remote sharing of profile \(profile.id)...")
                     try await remoteRepository.saveProfile(profile)
                 } else {
-                    pp_log(.app, .notice, "Disable remote sharing of profile \(profile.id)...")
+                    pp_log(.app, .notice, "\tDisable remote sharing of profile \(profile.id)...")
                     try await remoteRepository.removeProfiles(withIds: [profile.id])
                 }
             }
         } catch {
-            pp_log(.app, .fault, "Unable to save/remove remote profile \(profile.id): \(error)")
+            pp_log(.app, .fault, "\tUnable to save/remove remote profile \(profile.id): \(error)")
             throw error
         }
+        pp_log(.app, .notice, "Finished saving profile \(profile.id)")
     }
 
     public func remove(withId profileId: Profile.ID) async {
@@ -363,7 +364,7 @@ private extension ProfileManager {
             pp_log(.app, .info, "Start importing remote profiles...")
             var idsToRemove: [Profile.ID] = []
             if !remotelyDeletedIds.isEmpty {
-                pp_log(.app, .info, "Will \(deletingRemotely ? "delete" : "retain") local profiles not present in remote repository: \(remotelyDeletedIds)")
+                pp_log(.app, .info, "\tWill \(deletingRemotely ? "delete" : "retain") local profiles not present in remote repository: \(remotelyDeletedIds)")
 
                 if deletingRemotely {
                     idsToRemove.append(contentsOf: remotelyDeletedIds)
@@ -372,20 +373,20 @@ private extension ProfileManager {
             for remoteProfile in profilesToImport {
                 do {
                     guard isIncluded?(remoteProfile) ?? true else {
-                        pp_log(.app, .info, "Will delete non-included remote profile \(remoteProfile.id)")
+                        pp_log(.app, .info, "\tWill delete non-included remote profile \(remoteProfile.id)")
                         idsToRemove.append(remoteProfile.id)
                         continue
                     }
                     if let localFingerprint = allFingerprints[remoteProfile.id] {
                         guard remoteProfile.attributes.fingerprint != localFingerprint else {
-                            pp_log(.app, .info, "Skip re-importing local profile \(remoteProfile.id)")
+                            pp_log(.app, .info, "\tSkip re-importing local profile \(remoteProfile.id)")
                             continue
                         }
                     }
-                    pp_log(.app, .notice, "Import remote profile \(remoteProfile.id)...")
+                    pp_log(.app, .notice, "\tImport remote profile \(remoteProfile.id)...")
                     try await save(remoteProfile)
                 } catch {
-                    pp_log(.app, .error, "Unable to import remote profile: \(error)")
+                    pp_log(.app, .error, "\tUnable to import remote profile: \(error)")
                 }
             }
             pp_log(.app, .notice, "Finished importing remote profiles, delete stale profiles: \(idsToRemove)")

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -387,7 +387,7 @@ private extension ProfileManager {
                     pp_log(.app, .error, "Unable to import remote profile: \(error)")
                 }
             }
-            pp_log(.app, .notice, "Finished importing remote profiles, delete profiles: \(idsToRemove)")
+            pp_log(.app, .notice, "Finished importing remote profiles, delete stale profiles: \(idsToRemove)")
             try? await repository.removeProfiles(withIds: idsToRemove)
         }
     }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -266,6 +266,7 @@ extension ProfileManager {
     public func observeObjects(searchDebounce: Int = 200) {
         repository
             .profilesPublisher
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.reloadLocalProfiles($0)
@@ -274,7 +275,7 @@ extension ProfileManager {
 
         remoteRepository?
             .profilesPublisher
-            .zip(repository.profilesPublisher) // wait for local profiles first
+            .zip(repository.profilesPublisher.dropFirst()) // wait for local profiles first
             .first()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] remote, _ in
@@ -284,7 +285,7 @@ extension ProfileManager {
 
         remoteRepository?
             .profilesPublisher
-            .zip(repository.profilesPublisher) // wait for local profiles first
+            .zip(repository.profilesPublisher.dropFirst()) // wait for local profiles first
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] remote, _ in

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -281,7 +281,6 @@ extension ProfileManager {
     public func observeObjects(searchDebounce: Int = 200) {
         repository
             .profilesPublisher
-            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.reloadLocalProfiles($0)
@@ -291,7 +290,7 @@ extension ProfileManager {
         // observe remote after first local profiles
         let remotePublisher = remoteRepository?
             .profilesPublisher
-            .zip(repository.profilesPublisher.dropFirst())
+            .zip(repository.profilesPublisher)
 
         remotePublisher?
             .first()

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -273,9 +273,12 @@ extension ProfileManager {
             }
             .store(in: &subscriptions)
 
-        remoteRepository?
+        // observe remote after first local profiles
+        let remotePublisher = remoteRepository?
             .profilesPublisher
-            .zip(repository.profilesPublisher.dropFirst()) // wait for local profiles first
+            .zip(repository.profilesPublisher.dropFirst())
+
+        remotePublisher?
             .first()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] remote, _ in
@@ -283,9 +286,7 @@ extension ProfileManager {
             }
             .store(in: &subscriptions)
 
-        remoteRepository?
-            .profilesPublisher
-            .zip(repository.profilesPublisher.dropFirst()) // wait for local profiles first
+        remotePublisher?
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] remote, _ in

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -274,19 +274,21 @@ extension ProfileManager {
 
         remoteRepository?
             .profilesPublisher
+            .zip(repository.profilesPublisher) // wait for local profiles first
             .first()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                self?.loadInitialRemoteProfiles($0)
+            .sink { [weak self] remote, _ in
+                self?.loadInitialRemoteProfiles(remote)
             }
             .store(in: &subscriptions)
 
         remoteRepository?
             .profilesPublisher
+            .zip(repository.profilesPublisher) // wait for local profiles first
             .dropFirst()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                self?.reloadRemoteProfiles($0)
+            .sink { [weak self] remote, _ in
+                self?.reloadRemoteProfiles(remote)
             }
             .store(in: &subscriptions)
 

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -360,6 +360,7 @@ private extension ProfileManager {
             guard let self else {
                 return
             }
+            pp_log(.app, .info, "Start importing remote profiles...")
             var idsToRemove: [Profile.ID] = []
             if !remotelyDeletedIds.isEmpty {
                 pp_log(.app, .info, "Will \(deletingRemotely ? "delete" : "retain") local profiles not present in remote repository: \(remotelyDeletedIds)")

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -317,7 +317,7 @@ private extension ProfileManager {
             $0[$1.id] = $1
         }
 
-        // should never be imported in the first place but you never know
+        // should not be imported at all, but you never know
         if let isIncluded {
             let idsToRemove: [Profile.ID] = allProfiles
                 .filter {

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/ProfileAttributes.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/ProfileAttributes.swift
@@ -47,6 +47,10 @@ public struct ProfileAttributes: Hashable, Codable {
         self.lastUpdate = lastUpdate
         self.fingerprint = fingerprint
     }
+
+    public func isEquivalent(to other: Self) -> Bool {
+        isAvailableForTV == other.isAvailableForTV
+    }
 }
 
 // FIXME: #570, test user info encoding/decoding with JSONSerialization

--- a/Passepartout/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -198,7 +198,7 @@ extension ProfileEditor {
     public func save(to profileManager: ProfileManager) async throws {
         do {
             let newProfile = try build()
-            try await profileManager.save(newProfile, isShared: isShared)
+            try await profileManager.save(newProfile, force: true, isShared: isShared)
         } catch {
             pp_log(.app, .fault, "Unable to save edited profile: \(error)")
             throw error

--- a/Passepartout/Library/Sources/UILibrary/UILibrary.swift
+++ b/Passepartout/Library/Sources/UILibrary/UILibrary.swift
@@ -45,15 +45,9 @@ public final class UILibrary: UILibraryConfiguring {
             parameters: Constants.shared.log,
             logsPrivateData: UserDefaults.appGroup.bool(forKey: AppPreference.logsPrivateData.key)
         )
-
-        uiConfiguring?.configure(with: context)
-
         Task {
             try await context.providerManager.fetchIndex(from: API.shared)
-#if os(macOS)
-            // keep this for login item because scenePhase is not triggered
-            try await context.tunnel.prepare(purge: true)
-#endif
         }
+        uiConfiguring?.configure(with: context)
     }
 }


### PR DESCRIPTION
- Perform profiles removal in a single publisher, in reloadRemoteProfiles() after importing remote profiles
- Only force a new lastUpdate/fingerprint if profile is saved locally, DO NOT alter them if imported from remote repository because this would cause a re-save on iCloud
- Profiles were purged twice on launch in the main macOS app