### PR TITLE
Always read local receipt in TestFlight

### DIFF
--- a/Passepartout/Library/Sources/CommonLibrary/IAP/FallbackReceiptReader.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/IAP/FallbackReceiptReader.swift
@@ -72,12 +72,6 @@ private extension FallbackReceiptReader {
                 .deletingLastPathComponent()
                 .appendingPathComponent("receipt")
 
-            guard releaseURL != localURL else {
-#if !os(macOS) && !targetEnvironment(simulator)
-                assertionFailure("How can release URL be equal to Sandbox URL in TestFlight?")
-#endif
-                return nil
-            }
             let release = localReader(releaseURL)
             return await release?.receipt()
         }()


### PR DESCRIPTION
The condition came from v2, but the flow was different. Drop the condition because it would always fail in TestFlight for macOS, where sandbox and release receipts have the same URL.