### PR TITLE
Erase shared profiles from iCloud correctly

### DIFF
--- a/Passepartout/Library/Sources/AppDataProfiles/CDProfileRepositoryV3.swift
+++ b/Passepartout/Library/Sources/AppDataProfiles/CDProfileRepositoryV3.swift
@@ -120,4 +120,8 @@ extension CoreDataRepository: ProfileRepository where T == Profile {
     public func removeProfiles(withIds profileIds: [Profile.ID]) async throws {
         try await removeEntities(withIds: profileIds)
     }
+
+    public func removeAllProfiles() async throws {
+        try await removeEntities(withIds: nil)
+    }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Settings/SettingsSectionGroup.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Settings/SettingsSectionGroup.swift
@@ -88,10 +88,6 @@ private extension SettingsSectionGroup {
                 do {
                     pp_log(.app, .info, "Erase CloudKit profiles...")
                     try await profileManager.eraseRemotelySharedProfiles()
-
-                    let containerId = BundleConfiguration.mainString(for: .cloudKitId)
-                    pp_log(.app, .info, "Erase CloudKit store with identifier \(containerId)...")
-                    try await Utils.eraseCloudKitStore(fromContainerWithId: containerId)
                 } catch {
                     pp_log(.app, .error, "Unable to erase CloudKit store: \(error)")
                 }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/InMemoryProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/InMemoryProfileRepository.swift
@@ -60,4 +60,9 @@ public final class InMemoryProfileRepository: ProfileRepository {
             !ids.contains($0.id)
         }
     }
+
+    public func removeAllProfiles() async throws {
+        pp_log(.App.profiles, .info, "Remove all profiles")
+        profiles = []
+    }
 }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
@@ -85,6 +85,10 @@ public final class NEProfileRepository: ProfileRepository {
             removedIds.insert(id)
         }
     }
+
+    public func removeAllProfiles() async throws {
+        try await removeProfiles(withIds: profilesSubject.value.map(\.id))
+    }
 }
 
 private extension NEProfileRepository {

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -226,7 +226,7 @@ extension ProfileManager {
 
     public func eraseRemotelySharedProfiles() async throws {
         pp_log(.App.profiles, .notice, "Erase remotely shared profiles...")
-        try await remoteRepository?.removeProfiles(withIds: Array(allRemoteProfiles.keys))
+        try await remoteRepository?.removeAllProfiles()
     }
 }
 

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileRepository.swift
@@ -33,4 +33,6 @@ public protocol ProfileRepository {
     func saveProfile(_ profile: Profile) async throws
 
     func removeProfiles(withIds profileIds: [Profile.ID]) async throws
+
+    func removeAllProfiles() async throws
 }

--- a/Passepartout/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
@@ -139,16 +139,18 @@ public actor CoreDataRepository<CD, T>: NSObject,
         }
     }
 
-    public func removeEntities(withIds ids: [UUID]) async throws {
+    public func removeEntities(withIds ids: [UUID]?) async throws {
         try await context.perform { [weak self] in
             guard let self else {
                 return
             }
             let request = newFetchRequest()
-            request.predicate = NSPredicate(
-                format: "any uuid in %@",
-                ids
-            )
+            if let ids {
+                request.predicate = NSPredicate(
+                    format: "any uuid in %@",
+                    ids
+                )
+            }
             do {
                 let existing = try context.fetch(request)
                 existing.forEach(context.delete)

--- a/Passepartout/Library/Sources/CommonUtils/Business/Repository.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Business/Repository.swift
@@ -56,5 +56,5 @@ public protocol Repository {
 
     func saveEntities(_ entities: [Entity]) async throws
 
-    func removeEntities(withIds ids: [UUID]) async throws
+    func removeEntities(withIds ids: [UUID]?) async throws
 }


### PR DESCRIPTION
Do not delete CloudKit zone. Instead, delete Core Data entities and let sync do the rest. It's also a "more standard" approach.

Deleting the zone right after the entities legitimately makes deletion ineffective, because it probably spoils sync.