### PR TITLE
Decouple library from PassepartoutKit implementations

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "e7bd9636ac31d6111b0bc7c171398e68eeb384b5"
+        "revision" : "fe192115ca6f8e49447717dbe0a64347bd722aec"
       }
     },
     {

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -35,7 +35,7 @@ final class AppDelegate: NSObject {
 
     func configure(with uiConfiguring: UILibraryConfiguring) {
         UILibrary(uiConfiguring)
-            .configure()
+            .configure(with: context)
 
         Task {
             pp_log(.app, .notice, "Fetch providers index...")

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -15,7 +15,10 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "AppUI",
-            targets: ["AppUI"]
+            targets: [
+                "AppUI",
+                "PassepartoutImplementations"
+            ]
         ),
         .library(
             name: "AppUIMain",
@@ -31,7 +34,10 @@ let package = Package(
         ),
         .library(
             name: "TunnelLibrary",
-            targets: ["CommonLibrary"]
+            targets: [
+                "CommonLibrary",
+                "PassepartoutImplementations"
+            ]
         ),
         .library(
             name: "UILibrary",
@@ -40,7 +46,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "e7bd9636ac31d6111b0bc7c171398e68eeb384b5"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "fe192115ca6f8e49447717dbe0a64347bd722aec"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),
@@ -109,9 +115,7 @@ let package = Package(
             name: "CommonLibrary",
             dependencies: [
                 "CommonUtils",
-                .product(name: "PassepartoutKit", package: "passepartoutkit-source"),
-                .product(name: "PassepartoutOpenVPNOpenSSL", package: "passepartoutkit-source-openvpn-openssl"),
-                .product(name: "PassepartoutWireGuardGo", package: "passepartoutkit-source-wireguard-go")
+                .product(name: "PassepartoutKit", package: "passepartoutkit-source")
             ],
             resources: [
                 .process("Resources")
@@ -129,6 +133,13 @@ let package = Package(
             ],
             resources: [
                 .process("Profiles.xcdatamodeld")
+            ]
+        ),
+        .target(
+            name: "PassepartoutImplementations",
+            dependencies: [
+                .product(name: "PassepartoutOpenVPNOpenSSL", package: "passepartoutkit-source-openvpn-openssl"),
+                .product(name: "PassepartoutWireGuardGo", package: "passepartoutkit-source-wireguard-go")
             ]
         ),
         .target(

--- a/Passepartout/Library/Sources/AppUIMain/AppUIMain.swift
+++ b/Passepartout/Library/Sources/AppUIMain/AppUIMain.swift
@@ -24,24 +24,25 @@
 //
 
 import Foundation
+import PassepartoutKit
 @_exported import UILibrary
 
 public final class AppUIMain: UILibraryConfiguring {
     public init() {
     }
 
-    public func configure() {
-        assertMissingImplementations()
+    public func configure(with context: AppContext) {
+        assertMissingImplementations(with: context.registry)
     }
 }
 
 private extension AppUIMain {
-    func assertMissingImplementations() {
+    func assertMissingImplementations(with registry: Registry) {
         let providerModuleTypes: Set<ModuleType> = [
             .openVPN
         ]
         ModuleType.allCases.forEach { moduleType in
-            let builder = moduleType.newModule()
+            let builder = moduleType.newModule(with: registry)
             guard builder is any ModuleViewProviding else {
                 fatalError("\(moduleType): is not ModuleViewProviding")
             }

--- a/Passepartout/Library/Sources/AppUIMain/Extensions/EditableModule+Previews.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Extensions/EditableModule+Previews.swift
@@ -31,7 +31,7 @@ extension ModuleBuilder where Self: ModuleViewProviding {
     @MainActor
     func preview(title: String = "") -> some View {
         NavigationStack {
-            moduleView(with: ProfileEditor(modules: [self]))
+            moduleView(with: ProfileEditor(modules: [self]), impl: nil)
                 .navigationTitle(title)
         }
         .withMockEnvironment()

--- a/Passepartout/Library/Sources/AppUIMain/Protocols/DefaultModuleViewFactory.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Protocols/DefaultModuleViewFactory.swift
@@ -38,7 +38,7 @@ final class DefaultModuleViewFactory: ModuleViewFactory {
     func view(with editor: ProfileEditor, moduleId: UUID) -> some View {
         let result = editor.moduleViewProvider(withId: moduleId, registry: registry)
         if let result {
-            AnyView(result.provider.moduleView(with: editor))
+            AnyView(result.provider.moduleView(with: editor, impl: result.impl))
                 .navigationTitle(result.title)
         }
     }

--- a/Passepartout/Library/Sources/AppUIMain/Protocols/ModuleViewProviding.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Protocols/ModuleViewProviding.swift
@@ -23,11 +23,12 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import PassepartoutKit
 import SwiftUI
 
 protocol ModuleViewProviding {
     associatedtype Content: View
 
     @MainActor
-    func moduleView(with editor: ProfileEditor) -> Content
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> Content
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -157,6 +157,7 @@ extension AppCoordinator {
             ProfileCoordinator(
                 profileManager: profileManager,
                 profileEditor: profileEditor,
+                registry: registry,
                 moduleViewFactory: DefaultModuleViewFactory(),
                 modally: true,
                 path: $profilePath,

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -158,7 +158,7 @@ extension AppCoordinator {
                 profileManager: profileManager,
                 profileEditor: profileEditor,
                 registry: registry,
-                moduleViewFactory: DefaultModuleViewFactory(),
+                moduleViewFactory: DefaultModuleViewFactory(registry: registry),
                 modally: true,
                 path: $profilePath,
                 onDismiss: {

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/DNSModule+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/DNSModule+Extensions.swift
@@ -27,7 +27,7 @@ import PassepartoutKit
 import SwiftUI
 
 extension DNSModule.Builder: ModuleViewProviding {
-    func moduleView(with editor: ProfileEditor) -> some View {
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> some View {
         DNSView(editor: editor, module: self)
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/HTTPProxyModule+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/HTTPProxyModule+Extensions.swift
@@ -27,7 +27,7 @@ import PassepartoutKit
 import SwiftUI
 
 extension HTTPProxyModule.Builder: ModuleViewProviding {
-    func moduleView(with editor: ProfileEditor) -> some View {
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> some View {
         HTTPProxyView(editor: editor, module: self)
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/IPModule+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/IPModule+Extensions.swift
@@ -27,7 +27,7 @@ import PassepartoutKit
 import SwiftUI
 
 extension IPModule.Builder: ModuleViewProviding {
-    func moduleView(with editor: ProfileEditor) -> some View {
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> some View {
         IPView(editor: editor, module: self)
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/OnDemandModule+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/OnDemandModule+Extensions.swift
@@ -27,7 +27,7 @@ import PassepartoutKit
 import SwiftUI
 
 extension OnDemandModule.Builder: ModuleViewProviding {
-    func moduleView(with editor: ProfileEditor) -> some View {
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> some View {
         OnDemandView(editor: editor, module: self)
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
@@ -28,8 +28,8 @@ import PassepartoutKit
 import SwiftUI
 
 extension OpenVPNModule.Builder: ModuleViewProviding {
-    func moduleView(with editor: ProfileEditor) -> some View {
-        OpenVPNView(editor: editor, module: self)
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> some View {
+        OpenVPNView(editor: editor, module: self, impl: impl as? OpenVPNModule.Implementation)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/WireGuardModule+Extensions.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/Extensions/WireGuardModule+Extensions.swift
@@ -27,7 +27,7 @@ import PassepartoutKit
 import SwiftUI
 
 extension WireGuardModule.Builder: ModuleViewProviding {
-    func moduleView(with editor: ProfileEditor) -> some View {
-        WireGuardView(editor: editor, module: self)
+    func moduleView(with editor: ProfileEditor, impl: ModuleImplementation?) -> some View {
+        WireGuardView(editor: editor, module: self, impl: impl as? WireGuardModule.Implementation)
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import CPassepartoutOpenVPNOpenSSL
 import PassepartoutKit
 import SwiftUI
 
@@ -179,10 +178,11 @@ private extension OpenVPNView {
             }
             importURL = url
 
-            let parsed = try StandardOpenVPNParser(decrypter: OSSLTLSBox())
-                .parsed(fromURL: url, passphrase: importPassphrase)
-
-            draft.wrappedValue.configurationBuilder = parsed.configuration.builder()
+            // FIXME: ###, requires Registry
+//            let parsed = try StandardOpenVPNParser(decrypter: OSSLTLSBox())
+//                .parsed(fromURL: url, passphrase: importPassphrase)
+//
+//            draft.wrappedValue.configurationBuilder = parsed.configuration.builder()
         } catch StandardOpenVPNParserError.encryptionPassphrase,
                 StandardOpenVPNParserError.unableToDecrypt {
             Task {

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/WireGuardView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/WireGuardView.swift
@@ -34,6 +34,8 @@ struct WireGuardView: View, ModuleDraftEditing {
 
     let module: WireGuardModule.Builder
 
+    let impl: WireGuardModule.Implementation?
+
     var body: some View {
         contentView
             .moduleView(editor: editor, draft: draft.wrappedValue)
@@ -43,11 +45,11 @@ struct WireGuardView: View, ModuleDraftEditing {
 // MARK: - Content
 
 private extension WireGuardView {
-
-    // FIXME: ###, requires Registry
     var configuration: WireGuard.Configuration.Builder {
-//        draft.wrappedValue.configurationBuilder ?? .init(keyGenerator: .default)
-        draft.wrappedValue.configurationBuilder ?? .init(privateKey: "")
+        guard let impl else {
+            fatalError("Requires WireGuardModule implementation")
+        }
+        return draft.wrappedValue.configurationBuilder ?? .init(keyGenerator: impl.keyGenerator)
     }
 
     @ViewBuilder

--- a/Passepartout/Library/Sources/AppUIMain/Views/Modules/WireGuardView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Modules/WireGuardView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import PassepartoutKit
-import PassepartoutWireGuardGo
 import SwiftUI
 
 struct WireGuardView: View, ModuleDraftEditing {
@@ -44,8 +43,11 @@ struct WireGuardView: View, ModuleDraftEditing {
 // MARK: - Content
 
 private extension WireGuardView {
+
+    // FIXME: ###, requires Registry
     var configuration: WireGuard.Configuration.Builder {
-        draft.wrappedValue.configurationBuilder ?? .default
+//        draft.wrappedValue.configurationBuilder ?? .init(keyGenerator: .default)
+        draft.wrappedValue.configurationBuilder ?? .init(privateKey: "")
     }
 
     @ViewBuilder
@@ -143,7 +145,7 @@ private extension WireGuardView {
 
 // swiftlint: disable force_try
 #Preview {
-    let gen = StandardWireGuardKeyGenerator()
+    let gen = MockGenerator()
 
     var builder = WireGuard.Configuration.Builder(keyGenerator: gen)
     builder.interface.addresses = ["1.1.1.1", "2.2.2.2"]
@@ -166,3 +168,21 @@ private extension WireGuardView {
     return module.preview()
 }
 // swiftlint: enable force_try
+
+private final class MockGenerator: WireGuardKeyGenerator {
+    func newPrivateKey() -> String {
+        "private-key"
+    }
+
+    func privateKey(from string: String) throws -> String {
+        "private-key"
+    }
+
+    func publicKey(from string: String) throws -> String {
+        "public-key"
+    }
+
+    func publicKey(for privateKey: String) throws -> String {
+        "public-key"
+    }
+}

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/ModuleDetailView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/ModuleDetailView.swift
@@ -62,7 +62,7 @@ private extension ModuleDetailView {
     ModuleDetailView(
         profileEditor: ProfileEditor(profile: .mock),
         moduleId: Profile.mock.modules.first?.id,
-        moduleViewFactory: DefaultModuleViewFactory()
+        moduleViewFactory: DefaultModuleViewFactory(registry: Registry())
     )
     .withMockEnvironment()
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -155,7 +155,7 @@ private extension ProfileCoordinator {
         profileManager: .mock,
         profileEditor: ProfileEditor(profile: .newMockProfile()),
         registry: Registry(),
-        moduleViewFactory: DefaultModuleViewFactory(),
+        moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
         modally: false,
         path: .constant(NavigationPath()),
         onDismiss: {}

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -47,6 +47,8 @@ struct ProfileCoordinator: View {
 
     let profileEditor: ProfileEditor
 
+    let registry: Registry
+
     let moduleViewFactory: any ModuleViewFactory
 
     let modally: Bool
@@ -125,7 +127,7 @@ private extension ProfileCoordinator {
             return
         }
 
-        let module = moduleType.newModule()
+        let module = moduleType.newModule(with: registry)
         withAnimation(theme.animation(for: .modules)) {
             profileEditor.saveModule(module, activating: true)
         }
@@ -152,6 +154,7 @@ private extension ProfileCoordinator {
     ProfileCoordinator(
         profileManager: .mock,
         profileEditor: ProfileEditor(profile: .newMockProfile()),
+        registry: Registry(),
         moduleViewFactory: DefaultModuleViewFactory(),
         modally: false,
         path: .constant(NavigationPath()),

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
@@ -123,7 +123,7 @@ private extension ProfileSplitView {
 #Preview {
     ProfileSplitView(
         profileEditor: ProfileEditor(profile: .newMockProfile()),
-        moduleViewFactory: DefaultModuleViewFactory()
+        moduleViewFactory: DefaultModuleViewFactory(registry: Registry())
     )
     .withMockEnvironment()
 }

--- a/Passepartout/Library/Sources/AppUITV/AppUITV.swift
+++ b/Passepartout/Library/Sources/AppUITV/AppUITV.swift
@@ -30,6 +30,6 @@ public final class AppUITV: UILibraryConfiguring {
     public init() {
     }
 
-    public func configure() {
+    public func configure(with context: AppContext) {
     }
 }

--- a/Passepartout/Library/Sources/CommonLibrary/Shared.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Shared.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import PassepartoutKit
-import PassepartoutWireGuardGo
 
 extension LoggerDestination {
     public static let app = LoggerDestination(category: "app")
@@ -34,12 +33,6 @@ extension LoggerDestination {
         public static let iap = LoggerDestination(category: "app.iap")
 
         public static let profiles = LoggerDestination(category: "app.profiles")
-    }
-}
-
-extension WireGuard.Configuration.Builder {
-    public static var `default`: Self {
-        .init(keyGenerator: StandardWireGuardKeyGenerator())
     }
 }
 

--- a/Passepartout/Library/Sources/PassepartoutImplementations/Dummy.swift
+++ b/Passepartout/Library/Sources/PassepartoutImplementations/Dummy.swift
@@ -1,8 +1,8 @@
 //
-//  UILibrary.swift
+//  Dummy.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 7/31/24.
+//  Created by Davide De Rosa on 11/8/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,29 +23,4 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonAPI
-import CommonLibrary
 import Foundation
-import PassepartoutKit
-
-@MainActor
-public protocol UILibraryConfiguring {
-    func configure(with context: AppContext)
-}
-
-public final class UILibrary: UILibraryConfiguring {
-    private let uiConfiguring: UILibraryConfiguring?
-
-    public init(_ uiConfiguring: UILibraryConfiguring?) {
-        self.uiConfiguring = uiConfiguring
-    }
-
-    public func configure(with context: AppContext) {
-        PassepartoutConfiguration.shared.configureLogging(
-            to: BundleConfiguration.urlForAppLog,
-            parameters: Constants.shared.log,
-            logsPrivateData: UserDefaults.appGroup.bool(forKey: AppPreference.logsPrivateData.key)
-        )
-        uiConfiguring?.configure(with: context)
-    }
-}

--- a/Passepartout/Library/Sources/UILibrary/Domain/ModuleType+New.swift
+++ b/Passepartout/Library/Sources/UILibrary/Domain/ModuleType+New.swift
@@ -27,13 +27,17 @@ import Foundation
 import PassepartoutKit
 
 extension ModuleType {
-    public func newModule() -> any ModuleBuilder {
+    public func newModule(with registry: Registry) -> any ModuleBuilder {
         switch self {
         case .openVPN:
             return OpenVPNModule.Builder()
 
         case .wireGuard:
-            return WireGuardModule.Builder(configurationBuilder: .default)
+            let impl = registry.implementation(for: WireGuardModule.moduleHandler.id)
+            guard let wireGuard = impl as? WireGuardModule.Implementation else {
+                fatalError("Missing WireGuardModule implementation from Registry?")
+            }
+            return WireGuardModule.Builder(configurationBuilder: .init(keyGenerator: wireGuard.keyGenerator))
 
         case .dns:
             return DNSModule.Builder()

--- a/Passepartout/Library/Sources/UILibrary/Domain/ModuleType.swift
+++ b/Passepartout/Library/Sources/UILibrary/Domain/ModuleType.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import PassepartoutKit
-import PassepartoutWireGuardGo
 
 public struct ModuleType: RawRepresentable, Hashable {
     public let rawValue: String

--- a/Passepartout/Library/Tests/UILibraryTests/ProfileEditorTests.swift
+++ b/Passepartout/Library/Tests/UILibraryTests/ProfileEditorTests.swift
@@ -255,3 +255,9 @@ extension ProfileEditorTests {
         await fulfillment(of: [exp])
     }
 }
+
+private extension WireGuard.Configuration.Builder {
+    static var `default`: WireGuard.Configuration.Builder {
+        WireGuard.Configuration.Builder(privateKey: "")
+    }
+}

--- a/Passepartout/Shared/Shared.swift
+++ b/Passepartout/Shared/Shared.swift
@@ -55,6 +55,7 @@ extension Registry {
                 }
             ),
             WireGuardModule.Implementation(
+                keyGenerator: StandardWireGuardKeyGenerator(),
                 importer: StandardWireGuardParser(),
                 connectionBlock: { parameters, module in
                     try GoWireGuardConnection(parameters: parameters, module: module)


### PR DESCRIPTION
Move the following dependencies:

- OpenVPN/OpenSSL
- WireGuard/Go

up the chain until the main App/Tunnel targets, so that UILibrary and CommonLibrary can abstract from these unnecessary details. Instead, give module views access to generic implementations via Registry.

Incidentally, this fixes an issue preventing TV previews from working due to OpenSSL linkage.