### PR TITLE
 Rewrite AppContext event handlers

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "b31816d060e40583a27d22ea5c59cc686c057aaf"
+        "revision" : "3a4c78af67dfe181acc657a5539ee3d62d1c9361"
       }
     },
     {

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -36,10 +36,5 @@ final class AppDelegate: NSObject {
     func configure(with uiConfiguring: UILibraryConfiguring) {
         UILibrary(uiConfiguring)
             .configure(with: context)
-
-        Task {
-            pp_log(.app, .notice, "Fetch providers index...")
-            try await context.providerManager.fetchIndex(from: API.shared)
         }
-    }
 }

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.9.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "b31816d060e40583a27d22ea5c59cc686c057aaf"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "3a4c78af67dfe181acc657a5539ee3d62d1c9361"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Sources/AppDataProfiles/CDProfileRepositoryV3.swift
+++ b/Passepartout/Library/Sources/AppDataProfiles/CDProfileRepositoryV3.swift
@@ -41,19 +41,23 @@ extension AppData {
     ) -> ProfileRepository {
         let repository = CoreDataRepository<CDProfileV3, Profile>(
             context: context,
-            observingResults: observingResults
-        ) {
-            $0.sortDescriptors = [
-                .init(key: "name", ascending: true, selector: #selector(NSString.caseInsensitiveCompare)),
-                .init(key: "lastUpdate", ascending: false)
-            ]
-        } fromMapper: {
-            try fromMapper($0, registry: registry, coder: coder)
-        } toMapper: {
-            try toMapper($0, $1, registry: registry, coder: coder)
-        } onResultError: {
-            onResultError?($0) ?? .ignore
-        }
+            observingResults: observingResults,
+            beforeFetch: {
+                $0.sortDescriptors = [
+                    .init(key: "name", ascending: true, selector: #selector(NSString.caseInsensitiveCompare)),
+                    .init(key: "lastUpdate", ascending: false)
+                ]
+            },
+            fromMapper: {
+                try fromMapper($0, registry: registry, coder: coder)
+            },
+            toMapper: {
+                try toMapper($0, $1, registry: registry, coder: coder)
+            },
+            onResultError: {
+                onResultError?($0) ?? .ignore
+            }
+        )
         return repository
     }
 }

--- a/Passepartout/Library/Sources/AppDataProfiles/CDProfileRepositoryV3.swift
+++ b/Passepartout/Library/Sources/AppDataProfiles/CDProfileRepositoryV3.swift
@@ -116,6 +116,10 @@ extension CoreDataRepository: ProfileRepository where T == Profile {
             .eraseToAnyPublisher()
     }
 
+    public func fetchProfiles() async throws -> [Profile] {
+        try await fetchAllEntities()
+    }
+
     public func saveProfile(_ profile: Profile) async throws {
         try await saveEntities([profile])
     }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ExtendedTunnel.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ExtendedTunnel.swift
@@ -98,11 +98,6 @@ extension ExtendedTunnel {
         tunnel.currentProfile
     }
 
-    public func prepare(purge: Bool) async throws {
-        pp_log(.app, .notice, "Prepare tunnel and purge stale data (\(purge))...")
-        try await tunnel.prepare(purge: purge)
-    }
-
     public func install(_ profile: Profile) async throws {
         pp_log(.app, .notice, "Install profile \(profile.id)...")
         let newProfile = try processedProfile(profile)

--- a/Passepartout/Library/Sources/CommonLibrary/Business/InMemoryProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/InMemoryProfileRepository.swift
@@ -45,6 +45,10 @@ public final class InMemoryProfileRepository: ProfileRepository {
         profilesSubject.eraseToAnyPublisher()
     }
 
+    public func fetchProfiles() async throws -> [Profile] {
+        profiles
+    }
+
     public func saveProfile(_ profile: Profile) {
         pp_log(.App.profiles, .info, "Save profile: \(profile.id))")
         if let index = profiles.firstIndex(where: { $0.id == profile.id }) {

--- a/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
@@ -45,14 +45,6 @@ public final class NEProfileRepository: ProfileRepository {
 
         repository
             .managersPublisher
-            .first()
-            .sink { [weak self] in
-                self?.onLoadedManagers($0)
-            }
-            .store(in: &subscriptions)
-
-        repository
-            .managersPublisher
             .dropFirst()
             .sink { [weak self] in
                 self?.onUpdatedManagers($0)
@@ -62,6 +54,20 @@ public final class NEProfileRepository: ProfileRepository {
 
     public var profilesPublisher: AnyPublisher<[Profile], Never> {
         profilesSubject.eraseToAnyPublisher()
+    }
+
+    public func fetchProfiles() async throws -> [Profile] {
+        let managers = try await repository.fetch()
+        let profiles = managers.compactMap {
+            do {
+                return try repository.profile(from: $0)
+            } catch {
+                pp_log(.App.profiles, .error, "Unable to decode profile from NE manager '\($0.localizedDescription ?? "")': \(error)")
+                return nil
+            }
+        }
+        profilesSubject.send(profiles)
+        return profiles
     }
 
     public func saveProfile(_ profile: Profile) async throws {
@@ -92,18 +98,6 @@ public final class NEProfileRepository: ProfileRepository {
 }
 
 private extension NEProfileRepository {
-    func onLoadedManagers(_ managers: [Profile.ID: NETunnelProviderManager]) {
-        let profiles = managers.values.compactMap {
-            do {
-                return try repository.profile(from: $0)
-            } catch {
-                pp_log(.App.profiles, .error, "Unable to decode profile from NE manager '\($0.localizedDescription ?? "")': \(error)")
-                return nil
-            }
-        }
-        profilesSubject.send(profiles)
-    }
-
     func onUpdatedManagers(_ managers: [Profile.ID: NETunnelProviderManager]) {
         let profiles = profilesSubject
             .value

--- a/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/NEProfileRepository.swift
@@ -80,6 +80,9 @@ public final class NEProfileRepository: ProfileRepository {
     }
 
     public func removeProfiles(withIds profileIds: [Profile.ID]) async throws {
+        guard !profileIds.isEmpty else {
+            return
+        }
         var removedIds: Set<Profile.ID> = []
         defer {
             profilesSubject.value.removeAll {

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileRepository.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileRepository.swift
@@ -30,6 +30,8 @@ import PassepartoutKit
 public protocol ProfileRepository {
     var profilesPublisher: AnyPublisher<[Profile], Never> { get }
 
+    func fetchProfiles() async throws -> [Profile]
+
     func saveProfile(_ profile: Profile) async throws
 
     func removeProfiles(withIds profileIds: [Profile.ID]) async throws

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/AppError.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/AppError.swift
@@ -27,6 +27,8 @@ import Foundation
 import PassepartoutKit
 
 public enum AppError: Error {
+    case couldNotLaunch(reason: Error)
+
     case emptyProducts
 
     case emptyProfileName

--- a/Passepartout/Library/Sources/CommonLibrary/IAP/IAPManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/IAP/IAPManager.swift
@@ -279,6 +279,9 @@ private extension IAPManager {
             pp_log(.App.iap, .info, "App level (custom): \(userLevel)")
         } else {
             let isBeta = await SandboxChecker().isBeta
+            guard userLevel == .undefined else {
+                return
+            }
             userLevel = isBeta ? .beta : .freemium
             pp_log(.App.iap, .info, "App level: \(userLevel)")
         }

--- a/Passepartout/Library/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -32,6 +32,9 @@ extension AppError: LocalizedError {
     public var errorDescription: String? {
         let V = Strings.Errors.App.self
         switch self {
+        case .couldNotLaunch(let reason):
+            return reason.localizedDescription
+
         case .emptyProducts:
             return V.emptyProducts
 


### PR DESCRIPTION
Loading remote profiles before local profiles may cause duplicated NE managers. This happened because if local profiles are empty, any remote profile is imported regardless of their former existence in the local store. The importer just doesn't know.

Therefore, revisit the sequence of AppContext registrations:

- First off
  - Skip Tunnel prepare() because NEProfileRepository.fetch() does it already
  - NE is both Tunnel and ProfileRepository, so calling tunnel.prepare() loads local NE profiles twice
- onLaunch() - **run this once and before anything else**
  - Read local profiles
  - Reload in-app receipt
  - Observe in-app eligibility → Triggers onEligibleFeatures()
  - Observe profile save → Triggers onSaveProfile()
  - Fetch providers index
- onForeground()
  - Read local profiles
  - Read remote profiles, and toggle CloudKit sync based on eligibility
- onEligibleFeatures()
  - Read remote profiles, and toggle CloudKit sync based on eligibility
- onSaveProfile()
  - Reconnect if necessary