### PR TITLE
Fix regression about handling of Core Data duplicates

### DIFF
--- a/Passepartout/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
@@ -205,7 +205,7 @@ private extension CoreDataRepository {
 
     @discardableResult
     func unsafeSendResults(from controller: NSFetchedResultsController<CD>) -> [T] {
-        guard let cdEntities = controller.fetchedObjects else {
+        guard var cdEntities = controller.fetchedObjects else {
             return []
         }
 
@@ -226,6 +226,9 @@ private extension CoreDataRepository {
         }
 
         do {
+            cdEntities.removeAll {
+                entitiesToDelete.contains($0)
+            }
             let entities = try cdEntities.compactMap {
                 do {
                     return try fromMapper($0)
@@ -243,7 +246,6 @@ private extension CoreDataRepository {
                     return nil
                 }
             }
-
             if !entitiesToDelete.isEmpty {
                 do {
                     entitiesToDelete.forEach(context.delete)


### PR DESCRIPTION
Regression in #839 due to how NSFetchedResultsController was refactored. Duplicated entities were not excluded from mapping.

Could "crash" the app with these easy steps:

- Pick a profile
- Unshare the profile on iOS
- Unshare the profile on macOS
- Re-share the profile on iCloud on both iOS and macOS
- Save the profile simultaneously on iOS/macOS
- Assertion failure due to duplicates in ProfileManager.reloadRemoteProfiles() → "Remote repository must not have duplicates"
