### PR TITLE
Use hidden icons for stable alignment

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -42,10 +42,12 @@ struct ProfileAttributesView: View {
             }
             .hidden()
 
-            if isTV {
-                tvImage
-            } else if isShared {
-                sharedImage
+            HStack(alignment: .firstTextBaseline) {
+                if isTV {
+                    tvImage
+                } else if isShared {
+                    sharedImage
+                }
             }
         }
         .foregroundStyle(.secondary)

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -33,7 +33,15 @@ struct ProfileAttributesView: View {
     let isRemoteImportingEnabled: Bool
 
     var body: some View {
-        Group {
+        HStack(alignment: .firstTextBaseline) {
+            Group {
+                ThemeImage(.cloudOn)
+                ThemeImage(.cloudOff)
+                ThemeImage(.tvOn)
+                ThemeImage(.tvOff)
+            }
+            .hidden()
+
             if isTV {
                 tvImage
             } else if isShared {

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -63,13 +63,13 @@ struct ProfileAttributesView: View {
             switch $0 {
             case .shared:
                 return (
-                    isRemoteImportingEnabled ? .tvOn : .tvOff,
+                    isRemoteImportingEnabled ? .cloudOn : .cloudOff,
                     Strings.Modules.General.Rows.shared
                 )
 
             case .tv:
                 return (
-                    isRemoteImportingEnabled ? .cloudOn : .cloudOff,
+                    isRemoteImportingEnabled ? .tvOn : .tvOff,
                     Strings.Modules.General.Rows.appleTv(Strings.Unlocalized.appleTV)
                 )
             }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -33,7 +33,7 @@ struct ProfileAttributesView: View {
     let isRemoteImportingEnabled: Bool
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline) {
+        ZStack(alignment: .centerFirstTextBaseline) {
             Group {
                 ThemeImage(.cloudOn)
                 ThemeImage(.cloudOff)

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -37,7 +37,7 @@ struct ProfileAttributesView: View {
     let isRemoteImportingEnabled: Bool
 
     var body: some View {
-        if !imageModels.isEmpty {
+        if !attributes.isEmpty {
             ZStack(alignment: .centerFirstTextBaseline) {
                 Group {
                     ThemeImage(.cloudOn)

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -1,0 +1,102 @@
+//
+//  ProfileAttributesView.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 11/10/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+struct ProfileAttributesView: View {
+    let isShared: Bool
+
+    let isTV: Bool
+
+    let isRemoteImportingEnabled: Bool
+
+    var body: some View {
+        Group {
+            if isTV {
+                tvImage
+            } else if isShared {
+                sharedImage
+            }
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    var sharedImage: some View {
+        ThemeImage(isRemoteImportingEnabled ? .cloudOn : .cloudOff)
+            .help(Strings.Modules.General.Rows.shared)
+    }
+
+    var tvImage: some View {
+        ThemeImage(isRemoteImportingEnabled ? .tvOn : .tvOff)
+            .help(Strings.Modules.General.Rows.appleTv(Strings.Unlocalized.appleTV))
+    }
+}
+
+#Preview {
+    struct ContentView: View {
+
+        @State
+        private var isRemoteImportingEnabled = false
+
+        let timer = Timer.publish(every: 1, on: .main, in: .common)
+            .autoconnect()
+
+        var body: some View {
+            ProfileAttributesView(
+                isShared: true,
+                isTV: true,
+                isRemoteImportingEnabled: isRemoteImportingEnabled
+            )
+            .onReceive(timer) { _ in
+                isRemoteImportingEnabled.toggle()
+            }
+            .border(.black)
+            .padding()
+            .withMockEnvironment()
+        }
+    }
+
+    return ContentView()
+}
+
+#Preview("Row Alignment") {
+    IconsPreview()
+        .withMockEnvironment()
+}
+
+struct IconsPreview: View {
+    var body: some View {
+        Form {
+            HStack(alignment: .firstTextBaseline) {
+                ThemeImage(.cloudOn)
+                ThemeImage(.cloudOff)
+                ThemeImage(.tvOn)
+                ThemeImage(.tvOff)
+                ThemeImage(.info)
+            }
+        }
+        .themeForm()
+    }
+}

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -26,9 +26,13 @@
 import SwiftUI
 
 struct ProfileAttributesView: View {
-    let isShared: Bool
+    enum Attribute {
+        case shared
 
-    let isTV: Bool
+        case tv
+    }
+
+    let attributes: [Attribute]
 
     let isRemoteImportingEnabled: Bool
 
@@ -50,24 +54,25 @@ struct ProfileAttributesView: View {
                     }
                 }
             }
-            .border(.black)
             .foregroundStyle(.secondary)
         }
     }
 
     var imageModels: [(name: Theme.ImageName, help: String)] {
-        if isTV {
-            return [(
-                isRemoteImportingEnabled ? .tvOn : .tvOff,
-                Strings.Modules.General.Rows.shared
-            )]
-        } else if isShared {
-            return [(
-                isRemoteImportingEnabled ? .cloudOn : .cloudOff,
-                Strings.Modules.General.Rows.appleTv(Strings.Unlocalized.appleTV)
-            )]
-        } else {
-            return []
+        attributes.map {
+            switch $0 {
+            case .shared:
+                return (
+                    isRemoteImportingEnabled ? .tvOn : .tvOff,
+                    Strings.Modules.General.Rows.shared
+                )
+
+            case .tv:
+                return (
+                    isRemoteImportingEnabled ? .cloudOn : .cloudOff,
+                    Strings.Modules.General.Rows.appleTv(Strings.Unlocalized.appleTV)
+                )
+            }
         }
     }
 }
@@ -83,8 +88,7 @@ struct ProfileAttributesView: View {
 
         var body: some View {
             ProfileAttributesView(
-                isShared: true,
-                isTV: true,
+                attributes: [.shared, .tv],
                 isRemoteImportingEnabled: isRemoteImportingEnabled
             )
             .onReceive(timer) { _ in

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileAttributesView.swift
@@ -33,34 +33,42 @@ struct ProfileAttributesView: View {
     let isRemoteImportingEnabled: Bool
 
     var body: some View {
-        ZStack(alignment: .centerFirstTextBaseline) {
-            Group {
-                ThemeImage(.cloudOn)
-                ThemeImage(.cloudOff)
-                ThemeImage(.tvOn)
-                ThemeImage(.tvOff)
-            }
-            .hidden()
+        if !imageModels.isEmpty {
+            ZStack(alignment: .centerFirstTextBaseline) {
+                Group {
+                    ThemeImage(.cloudOn)
+                    ThemeImage(.cloudOff)
+                    ThemeImage(.tvOn)
+                    ThemeImage(.tvOff)
+                }
+                .hidden()
 
-            HStack(alignment: .firstTextBaseline) {
-                if isTV {
-                    tvImage
-                } else if isShared {
-                    sharedImage
+                HStack(alignment: .firstTextBaseline) {
+                    ForEach(imageModels, id: \.name) {
+                        ThemeImage($0.name)
+                            .help($0.help)
+                    }
                 }
             }
+            .border(.black)
+            .foregroundStyle(.secondary)
         }
-        .foregroundStyle(.secondary)
     }
 
-    var sharedImage: some View {
-        ThemeImage(isRemoteImportingEnabled ? .cloudOn : .cloudOff)
-            .help(Strings.Modules.General.Rows.shared)
-    }
-
-    var tvImage: some View {
-        ThemeImage(isRemoteImportingEnabled ? .tvOn : .tvOff)
-            .help(Strings.Modules.General.Rows.appleTv(Strings.Unlocalized.appleTV))
+    var imageModels: [(name: Theme.ImageName, help: String)] {
+        if isTV {
+            return [(
+                isRemoteImportingEnabled ? .tvOn : .tvOff,
+                Strings.Modules.General.Rows.shared
+            )]
+        } else if isShared {
+            return [(
+                isRemoteImportingEnabled ? .cloudOn : .cloudOff,
+                Strings.Modules.General.Rows.appleTv(Strings.Unlocalized.appleTV)
+            )]
+        } else {
+            return []
+        }
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -64,8 +64,7 @@ struct ProfileRowView: View, Routable {
             Spacer()
             HStack(spacing: 10.0) {
                 ProfileAttributesView(
-                    isShared: isShared,
-                    isTV: isTV,
+                    attributes: attributes,
                     isRemoteImportingEnabled: profileManager.isRemoteImportingEnabled
                 )
                 ProfileInfoButton(header: header) {
@@ -134,6 +133,15 @@ private extension ProfileRowView {
             }
         )
         .foregroundStyle(.primary)
+    }
+
+    var attributes: [ProfileAttributesView.Attribute] {
+        if isTV {
+            return [.tv]
+        } else if isShared {
+            return [.shared]
+        }
+        return []
     }
 
     var isShared: Bool {

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -73,7 +73,9 @@ public final class ProfileManager: ObservableObject {
     public init(profiles: [Profile]) {
         repository = InMemoryProfileRepository(profiles: profiles)
         backupRepository = nil
-        remoteRepositoryBlock = nil
+        remoteRepositoryBlock = { _ in
+            InMemoryProfileRepository()
+        }
         mirrorsRemoteRepository = false
         processor = nil
         self.profiles = []


### PR DESCRIPTION
Align SF Symbols to the text baseline, but also include all possible icons in ProfileAttributesView to precalculate a stable height for the HStack.