### PR TITLE
React on providers eligibility

### DIFF
--- a/Passepartout/Library/Sources/CommonLibrary/IAP/AppFeature.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/IAP/AppFeature.swift
@@ -52,3 +52,9 @@ extension AppFeature: Identifiable {
         rawValue
     }
 }
+
+extension AppFeature: CustomStringConvertible {
+    public var description: String {
+        rawValue
+    }
+}

--- a/Passepartout/Library/Sources/CommonLibrary/IAP/AppProduct.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/IAP/AppProduct.swift
@@ -54,3 +54,9 @@ extension AppProduct {
         }
     }
 }
+
+extension AppProduct: CustomStringConvertible {
+    public var description: String {
+        rawValue
+    }
+}

--- a/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
@@ -144,10 +144,12 @@ private extension AppContext {
 
         pp_log(.app, .notice, "Application did update eligible features")
         pendingTask = Task {
-            let isEligible = features.contains(.sharing)
+
+            // toggle sync based on .sharing eligibility
+            let isEligibleForSharing = features.contains(.sharing)
             do {
-                pp_log(.App.profiles, .info, "Refresh remote profiles observers (eligible=\(isEligible), CloudKit=\(isCloudKitEnabled))...")
-                try await profileManager.observeRemote(isEligible && isCloudKitEnabled)
+                pp_log(.App.profiles, .info, "Refresh remote profiles observers (eligible=\(isEligibleForSharing), CloudKit=\(isCloudKitEnabled))...")
+                try await profileManager.observeRemote(isEligibleForSharing && isCloudKitEnabled)
             } catch {
                 pp_log(.App.profiles, .error, "Unable to re-observe remote profiles: \(error)")
             }

--- a/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
@@ -153,31 +153,6 @@ private extension AppContext {
             } catch {
                 pp_log(.App.profiles, .error, "Unable to re-observe remote profiles: \(error)")
             }
-
-            // reset provider selection if ineligible for .providers
-            // otherwise still able to pick provider servers
-            if !features.contains(.providers) {
-                let profiles = profileManager
-                    .headers
-                    .compactMap {
-                        profileManager.profile(withId: $0.id)
-                    }
-
-                for profile in profiles {
-                    guard let module = profile.firstProviderModuleWithMetadata?.0 else {
-                        continue
-                    }
-                    do {
-                        pp_log(.App.profiles, .info, "Reset provider for profile \(profile.id)...")
-                        var builder = profile.builder()
-                        builder.setProviderId(nil, forModuleWithId: module.id)
-                        let profile = try builder.tryBuild()
-                        try await profileManager.save(profile, force: true)
-                    } catch {
-                        pp_log(.App.profiles, .error, "Unable to reset provider for profile \(profile.id): \(error)")
-                    }
-                }
-            }
         }
         await pendingTask?.value
         pendingTask = nil

--- a/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
@@ -153,6 +153,31 @@ private extension AppContext {
             } catch {
                 pp_log(.App.profiles, .error, "Unable to re-observe remote profiles: \(error)")
             }
+
+            // reset provider selection if ineligible for .providers
+            // otherwise still able to pick provider servers
+            if !features.contains(.providers) {
+                let profiles = profileManager
+                    .headers
+                    .compactMap {
+                        profileManager.profile(withId: $0.id)
+                    }
+
+                for profile in profiles {
+                    guard let module = profile.firstProviderModuleWithMetadata?.0 else {
+                        continue
+                    }
+                    do {
+                        pp_log(.App.profiles, .info, "Reset provider for profile \(profile.id)...")
+                        var builder = profile.builder()
+                        builder.setProviderId(nil, forModuleWithId: module.id)
+                        let profile = try builder.tryBuild()
+                        try await profileManager.save(profile, force: true)
+                    } catch {
+                        pp_log(.App.profiles, .error, "Unable to reset provider for profile \(profile.id): \(error)")
+                    }
+                }
+            }
         }
         await pendingTask?.value
         pendingTask = nil


### PR DESCRIPTION
~~Reset provider selections if ineligible for .providers feature, otherwise user is still able to pick a server.~~

Check .providers eligibility in tunnel to prevent from starting if profile has an active provider module. Do not alter original profile.