### PR TITLE
Fix double reload of selected provider server

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/Provider/VPNProviderServerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Provider/VPNProviderServerView.swift
@@ -166,7 +166,7 @@ extension VPNProviderServerView {
                     errorHandler.handle(error, title: Strings.Global.servers)
                 }
             }
-            .onReceive(filtersViewModel.$filters) { newValue in
+            .onReceive(filtersViewModel.$filters.dropFirst()) { newValue in
                 Task {
                     await reloadServers(filters: newValue)
                 }


### PR DESCRIPTION
Skip initial nil filter, overlaps with initial .reloadServers() in task.

Fixes #850 