### PR TITLE
Run tests before building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - "bugfix/test-before-build"
     tags:
       - "builds/*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - "bugfix/test-before-build"
     tags:
       - "builds/*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  run_tests:
+    name: Run tests
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - uses: passepartoutvpn/action-prepare-xcode-build@master
+        with:
+          access_token: ${{ secrets.ACCESS_TOKEN }}
+      - run: |
+        bundle exec fastlane test
   build_upload:
     name: Upload to ASC
     runs-on: macos-14
+    needs: run_tests
     strategy:
       fail-fast: true
       matrix:
@@ -29,11 +40,6 @@ jobs:
       - uses: passepartoutvpn/action-prepare-xcode-build@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-      - name: Run tests
-        id: run_tests
-        timeout-minutes: 15
-        run: |
-          bundle exec fastlane test
       - name: Upload ${{ matrix.platform }} app
         id: upload_app
         timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
       - run: |
-        bundle exec fastlane test
+          bundle exec fastlane test
   build_upload:
     name: Upload to ASC
     runs-on: macos-14


### PR DESCRIPTION
Workflow from #855 was incorrect, as it was running tests for each build in the matrix. Do it only once before the matrix.

Fixes #717 