### PR TITLE
Only guard remote fingerprint if local has any

### DIFF
--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -440,9 +440,12 @@ private extension ProfileManager {
                         idsToRemove.append(remoteProfile.id)
                         continue
                     }
-                    guard remoteAttributes[remoteProfile.id]?.fingerprint != localAttributes[remoteProfile.id]?.fingerprint else {
-                        pp_log(.App.profiles, .info, "Skip re-importing local profile \(remoteProfile.id)")
-                        continue
+                    if let localFingerprint = localAttributes[remoteProfile.id]?.fingerprint {
+                        guard let remoteFingerprint = remoteAttributes[remoteProfile.id]?.fingerprint,
+                              remoteFingerprint != localFingerprint else {
+                            pp_log(.App.profiles, .info, "Skip re-importing local profile \(remoteProfile.id)")
+                            continue
+                        }
                     }
                     pp_log(.App.profiles, .notice, "Import remote profile \(remoteProfile.id)...")
                     try await save(remoteProfile)


### PR DESCRIPTION
Otherwise, it would never import remote profiles w/o a fingerprint.

Scenarios (must test in #570):

- No local profile → Import
- Local profile has no fingerprint → Import
- Local profile has fingerprint
  - Remote profile has no fingerprint → Skip
  - Remote profile has same fingerprint → Skip
  - Remote profile has different fingerprint → Import