### PR TITLE
Reassign environment objects in .sheet()

### DIFF
--- a/Passepartout/Library/Sources/UILibrary/Extensions/View+Environment.swift
+++ b/Passepartout/Library/Sources/UILibrary/Extensions/View+Environment.swift
@@ -28,10 +28,11 @@ import SwiftUI
 @MainActor
 extension View {
     public func withEnvironment(from context: AppContext, theme: Theme) -> some View {
-        environmentObject(theme)
+        environmentObject(context) // for reuse in .sheet
             .environmentObject(context.iapManager)
             .environmentObject(context.migrationManager)
             .environmentObject(context.providerManager)
+            .environmentObject(theme)
     }
 
     public func withMockEnvironment() -> some View {

--- a/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+iOS.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+iOS.swift
@@ -59,6 +59,9 @@ extension View {
 struct ThemeBooleanPopoverModifier<Popover>: ViewModifier, SizeClassProviding where Popover: View {
 
     @EnvironmentObject
+    private var context: AppContext
+
+    @EnvironmentObject
     private var theme: Theme
 
     @Environment(\.horizontalSizeClass)
@@ -86,6 +89,7 @@ struct ThemeBooleanPopoverModifier<Popover>: ViewModifier, SizeClassProviding wh
                 .sheet(isPresented: $isPresented) {
                     popover
                         .themeLockScreen()
+                        .withEnvironment(from: context, theme: theme)
                 }
         }
     }

--- a/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
@@ -203,6 +203,9 @@ extension View {
 struct ThemeBooleanModalModifier<Modal>: ViewModifier where Modal: View {
 
     @EnvironmentObject
+    private var context: AppContext
+
+    @EnvironmentObject
     private var theme: Theme
 
     @Binding
@@ -221,6 +224,7 @@ struct ThemeBooleanModalModifier<Modal>: ViewModifier where Modal: View {
                     .frame(minWidth: modalSize?.width, minHeight: modalSize?.height)
                     .interactiveDismissDisabled(!isInteractive)
                     .themeLockScreen()
+                    .withEnvironment(from: context, theme: theme)
             }
     }
 
@@ -230,6 +234,9 @@ struct ThemeBooleanModalModifier<Modal>: ViewModifier where Modal: View {
 }
 
 struct ThemeItemModalModifier<Modal, T>: ViewModifier where Modal: View, T: Identifiable {
+
+    @EnvironmentObject
+    private var context: AppContext
 
     @EnvironmentObject
     private var theme: Theme
@@ -250,6 +257,7 @@ struct ThemeItemModalModifier<Modal, T>: ViewModifier where Modal: View, T: Iden
                     .frame(minWidth: modalSize?.width, minHeight: modalSize?.height)
                     .interactiveDismissDisabled(!isInteractive)
                     .themeLockScreen()
+                    .withEnvironment(from: context, theme: theme)
             }
     }
 


### PR DESCRIPTION
https://oleb.net/2020/sheet-environment/

Reportedly fixed but #867 crashed on macOS when importing a migrated profile:

```
Thread 1: Fatal error: No ObservableObject of type Theme found. A View.environmentObject(_:) for Theme may be missing as an ancestor of this view.
```

Triggered somewhere on `ThemeImage(.failure)`.