### PR TITLE
Add explicit environment objects to TableColumn

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView+Table.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView+Table.swift
@@ -45,17 +45,13 @@ extension MigrateView {
                     Text($0.timestamp)
                         .foregroundStyle(statuses.style(for: $0.id))
                 }
-                TableColumn("") { profile in
-                    switch step {
-                    case .initial, .fetching, .fetched:
-                        Toggle("", isOn: isIncludedBinding(for: profile.id))
-                            .labelsHidden()
-
-                    default:
-                        if let status = statuses[profile.id] {
-                            StatusView(status: status)
-                        }
-                    }
+                TableColumn("") {
+                    ControlView(
+                        step: step,
+                        isIncluded: isIncludedBinding(for: $0.id),
+                        status: statuses[$0.id]
+                    )
+                    .environmentObject(theme)
                 }
             }
         }
@@ -77,10 +73,27 @@ private extension MigrateView.TableView {
 }
 
 private extension MigrateView.TableView {
-    struct StatusView: View {
-        let status: MigrationStatus
+    struct ControlView: View {
+        let step: MigrateView.Model.Step
+
+        @Binding
+        var isIncluded: Bool
+
+        let status: MigrationStatus?
 
         var body: some View {
+            switch step {
+            case .initial, .fetching, .fetched:
+                Toggle("", isOn: $isIncluded)
+                    .labelsHidden()
+
+            default:
+                statusView
+            }
+        }
+
+        @ViewBuilder
+        var statusView: some View {
             switch status {
             case .excluded:
                 Text("--")
@@ -93,6 +106,9 @@ private extension MigrateView.TableView {
 
             case .failed:
                 ThemeImage(.failure)
+
+            case .none:
+                EmptyView()
             }
         }
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView+Table.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView+Table.swift
@@ -55,7 +55,7 @@ extension MigrateView {
                         isIncluded: isIncludedBinding(for: $0.id),
                         status: statuses[$0.id]
                     )
-                    .environmentObject(theme)
+                    .environmentObject(theme) // TODO: #873, Table loses environment
                 }
             }
         }

--- a/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView+Table.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView+Table.swift
@@ -28,6 +28,10 @@ import SwiftUI
 
 extension MigrateView {
     struct TableView: View {
+
+        @EnvironmentObject
+        private var theme: Theme
+
         let step: Model.Step
 
         let profiles: [MigratableProfile]

--- a/Passepartout/Library/Sources/AppUIMain/Views/Provider/macOS/VPNProviderServerView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Provider/macOS/VPNProviderServerView+macOS.swift
@@ -73,14 +73,14 @@ extension VPNProviderServerView {
                 TableColumn("") { server in
                     ThemeImage(.marked)
                         .opaque(server.id == selectedServer?.id)
-                        .environmentObject(theme)
+                        .environmentObject(theme) // TODO: #873, Table loses environment
                 }
                 .width(10.0)
 
                 TableColumn(Strings.Global.region) { server in
                     ThemeCountryText(server.provider.countryCode, title: server.region)
                         .help(server.region)
-                        .environmentObject(theme)
+                        .environmentObject(theme) // TODO: #873, Table loses environment
                 }
 
                 TableColumn(Strings.Global.address, value: \.address)
@@ -90,7 +90,7 @@ extension VPNProviderServerView {
                         value: server.serverId,
                         selection: $favoritesManager.serverIds
                     )
-                    .environmentObject(theme)
+                    .environmentObject(theme) // TODO: #873, Table loses environment
                 }
                 .width(15.0)
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/Provider/macOS/VPNProviderServerView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Provider/macOS/VPNProviderServerView+macOS.swift
@@ -44,6 +44,10 @@ extension VPNProviderServerView {
 
 extension VPNProviderServerView {
     struct ServersSubview: View {
+
+        @EnvironmentObject
+        private var theme: Theme
+
         let servers: [VPNServer]
 
         let selectedServer: VPNServer?
@@ -69,12 +73,14 @@ extension VPNProviderServerView {
                 TableColumn("") { server in
                     ThemeImage(.marked)
                         .opaque(server.id == selectedServer?.id)
+                        .environmentObject(theme)
                 }
                 .width(10.0)
 
                 TableColumn(Strings.Global.region) { server in
                     ThemeCountryText(server.provider.countryCode, title: server.region)
                         .help(server.region)
+                        .environmentObject(theme)
                 }
 
                 TableColumn(Strings.Global.address, value: \.address)
@@ -84,6 +90,7 @@ extension VPNProviderServerView {
                         value: server.serverId,
                         selection: $favoritesManager.serverIds
                     )
+                    .environmentObject(theme)
                 }
                 .width(15.0)
 

--- a/Passepartout/LoginItem/AppDelegate.swift
+++ b/Passepartout/LoginItem/AppDelegate.swift
@@ -85,11 +85,11 @@ private extension AppDelegate {
 
 // MARK: - Preconcurrency warnings
 
-extension NSWorkspace: @unchecked Sendable {
+extension NSWorkspace: @retroactive @unchecked Sendable {
 }
 
 extension NSRunningApplication: @unchecked Sendable {
 }
 
-extension NSWorkspace.OpenConfiguration: @unchecked Sendable {
+extension NSWorkspace.OpenConfiguration: @retroactive @unchecked Sendable {
 }


### PR DESCRIPTION
For some reason, Table doesn't seem to inherit the environment in some cases. Reapply environment to each TableColumn (only Theme is required).

Work around what clearly seems to be a SwiftUI bug.

Fixes #872 