### PR TITLE
Add the option to migrate old profiles

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/About/DonateView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/About/DonateView.swift
@@ -152,3 +152,10 @@ private extension DonateView {
         }
     }
 }
+
+// MARK: - Previews
+
+#Preview {
+    DonateView()
+        .withMockEnvironment()
+}

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -41,8 +41,7 @@ struct AddProfileMenu: View {
         Menu {
             newProfileButton
             importProfileButton
-            // FIXME: ###, migrations UI
-//            migrateProfilesButton
+            migrateProfilesButton
         } label: {
             ThemeImage(.add)
         }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -168,6 +168,9 @@ extension AppCoordinator {
                         return
                     }
                     present(.editProviderEntity($0, pair.0, pair.1))
+                },
+                onMigrateProfiles: {
+                    modalRoute = .migrateProfiles
                 }
             )
         )
@@ -240,7 +243,7 @@ extension AppCoordinator {
 
     var migrateViewStyle: MigrateView.Style {
 #if os(iOS)
-        .section
+        .list
 #else
         .table
 #endif

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -52,7 +52,8 @@ struct ProfileContainerView: View, Routable {
         debugChanges()
         return innerView
             .modifier(ContainerModifier(
-                profileManager: profileManager
+                profileManager: profileManager,
+                flow: flow
             ))
             .modifier(ProfileImporterModifier(
                 profileManager: profileManager,
@@ -108,6 +109,8 @@ private struct ContainerModifier: ViewModifier {
     @ObservedObject
     var profileManager: ProfileManager
 
+    let flow: ProfileContainerView.Flow?
+
     @State
     private var search = ""
 
@@ -117,7 +120,16 @@ private struct ContainerModifier: ViewModifier {
             .themeProgress(
                 if: !profileManager.isReady,
                 isEmpty: !profileManager.hasProfiles,
-                emptyMessage: Strings.Views.Profiles.Folders.noProfiles
+                emptyContent: {
+                    VStack(spacing: 16) {
+                        Text(Strings.Views.Profiles.Folders.noProfiles)
+                            .themeEmptyMessage(fullScreen: false)
+
+                        Button(Strings.Views.Profiles.Folders.NoProfiles.migrate) {
+                            flow?.onMigrateProfiles()
+                        }
+                    }
+                }
             )
             .searchable(text: $search)
             .onChange(of: search) {

--- a/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateButton.swift
@@ -1,0 +1,68 @@
+//
+//  MigrateButton.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 11/16/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+struct MigrateButton: View {
+    let step: MigrateViewStep
+
+    let action: () -> Void
+
+    var body: some View {
+        Button(title, action: action)
+            .disabled(!isEnabled)
+    }
+}
+
+private extension MigrateButton {
+    var title: String {
+        switch step {
+        case .initial, .fetching, .fetched:
+            return Strings.Views.Migrate.Items.migrate
+
+        case .migrating, .migrated:
+            return Strings.Views.Migrate.Items.import
+
+        case .importing, .imported:
+            return Strings.Global.done
+        }
+    }
+
+    var isEnabled: Bool {
+        switch step {
+        case .initial, .fetching, .migrating, .importing:
+            return false
+
+        case .fetched(let profiles):
+            return !profiles.isEmpty
+
+        case .migrated(let profiles):
+            return !profiles.isEmpty
+
+        case .imported:
+            return true
+        }
+    }
+}

--- a/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateViewStep.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateViewStep.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileFlow.swift
+//  MigrateViewStep.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 10/23/24.
+//  Created by Davide De Rosa on 11/16/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,13 +23,29 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
 import PassepartoutKit
 
-struct ProfileFlow {
-    let onEditProfile: (ProfileHeader) -> Void
+enum MigrateViewStep: Equatable {
+    case initial
 
-    let onEditProviderEntity: (Profile) -> Void
+    case fetching
 
-    let onMigrateProfiles: () -> Void
+    case fetched([MigratableProfile])
+
+    case migrating
+
+    case migrated([Profile])
+
+    case importing
+
+    case imported
+
+    var canSelect: Bool {
+        guard case .fetched = self else {
+            return false
+        }
+        return true
+    }
 }

--- a/Passepartout/Library/Sources/CommonLibrary/Strategy/ProfileMigrationStrategy.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Strategy/ProfileMigrationStrategy.swift
@@ -30,4 +30,6 @@ public protocol ProfileMigrationStrategy {
     func fetchMigratableProfiles() async throws -> [MigratableProfile]
 
     func fetchProfile(withId profileId: UUID) async throws -> Profile?
+
+    func deleteProfiles(withIds profileIds: Set<UUID>) async throws
 }

--- a/Passepartout/Library/Sources/LegacyV2/Strategy/CDProfileRepositoryV2.swift
+++ b/Passepartout/Library/Sources/LegacyV2/Strategy/CDProfileRepositoryV2.swift
@@ -92,6 +92,19 @@ final class CDProfileRepositoryV2: Sendable {
         )
         return profiles
     }
+
+    func deleteProfiles(withIds profileIds: Set<UUID>) async throws {
+        try await context.perform { [weak self] in
+            guard let self else {
+                return
+            }
+            let request = CDProfile.fetchRequest()
+            request.predicate = NSPredicate(format: "any uuid in %@", profileIds.map(\.uuidString))
+            let existing = try context.fetch(request)
+            existing.forEach(context.delete)
+            try context.save()
+        }
+    }
 }
 
 extension CDProfileRepositoryV2 {

--- a/Passepartout/Library/Sources/LegacyV2/Strategy/ProfileV2MigrationStrategy.swift
+++ b/Passepartout/Library/Sources/LegacyV2/Strategy/ProfileV2MigrationStrategy.swift
@@ -71,6 +71,10 @@ extension ProfileV2MigrationStrategy {
             return nil
         }
     }
+
+    public func deleteProfiles(withIds profileIds: Set<UUID>) async throws {
+        try await profilesRepository.deleteProfiles(withIds: profileIds)
+    }
 }
 
 // MARK: - Internal

--- a/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -231,6 +231,8 @@ public enum Strings {
     public static let country = Strings.tr("Localizable", "global.country", fallback: "Country")
     /// Default
     public static let `default` = Strings.tr("Localizable", "global.default", fallback: "Default")
+    /// Delete
+    public static let delete = Strings.tr("Localizable", "global.delete", fallback: "Delete")
     /// Destination
     public static let destination = Strings.tr("Localizable", "global.destination", fallback: "Destination")
     /// Disable
@@ -720,8 +722,34 @@ public enum Strings {
       }
     }
     public enum Migrate {
+      /// Nothing to migrate
+      public static let noProfiles = Strings.tr("Localizable", "views.migrate.no_profiles", fallback: "Nothing to migrate")
       /// Migrate
       public static let title = Strings.tr("Localizable", "views.migrate.title", fallback: "Migrate")
+      public enum Alerts {
+        public enum Delete {
+          /// Do you want to discard these profiles? You will not be able to recover them later.
+          /// 
+          /// %@
+          public static func message(_ p1: Any) -> String {
+            return Strings.tr("Localizable", "views.migrate.alerts.delete.message", String(describing: p1), fallback: "Do you want to discard these profiles? You will not be able to recover them later.\n\n%@")
+          }
+          /// Discard
+          public static let title = Strings.tr("Localizable", "views.migrate.alerts.delete.title", fallback: "Discard")
+        }
+      }
+      public enum Items {
+        /// Import
+        public static let `import` = Strings.tr("Localizable", "views.migrate.items.import", fallback: "Import")
+        /// Proceed
+        public static let migrate = Strings.tr("Localizable", "views.migrate.items.migrate", fallback: "Proceed")
+      }
+      public enum Sections {
+        public enum Main {
+          /// Select below the profiles from old versions of Passepartout that you want to import. Profiles will disappear from this list once imported successfully.
+          public static let header = Strings.tr("Localizable", "views.migrate.sections.main.header", fallback: "Select below the profiles from old versions of Passepartout that you want to import. Profiles will disappear from this list once imported successfully.")
+        }
+      }
     }
     public enum Profile {
       public enum ModuleList {
@@ -755,6 +783,10 @@ public enum Strings {
         public static let `default` = Strings.tr("Localizable", "views.profiles.folders.default", fallback: "My profiles")
         /// No profiles
         public static let noProfiles = Strings.tr("Localizable", "views.profiles.folders.no_profiles", fallback: "No profiles")
+        public enum NoProfiles {
+          /// Migrate old profiles...
+          public static let migrate = Strings.tr("Localizable", "views.profiles.folders.no_profiles.migrate", fallback: "Migrate old profiles...")
+        }
       }
       public enum Rows {
         /// %d modules

--- a/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "global.connection" = "Connection";
 "global.country" = "Country";
 "global.default" = "Default";
+"global.delete" = "Delete";
 "global.destination" = "Destination";
 "global.disable" = "Disable";
 "global.disabled" = "Disabled";
@@ -121,6 +122,7 @@
 "views.profiles.folders.default" = "My profiles";
 "views.profiles.folders.add_profile" = "Add profile";
 "views.profiles.folders.no_profiles" = "No profiles";
+"views.profiles.folders.no_profiles.migrate" = "Migrate old profiles...";
 "views.profiles.toolbar.new_profile" = "New profile";
 "views.profiles.toolbar.import_profile" = "Import profile";
 "views.profiles.toolbar.migrate_profiles" = "Migrate profiles";
@@ -158,6 +160,12 @@
 "views.about.credits.translations" = "Translations";
 
 "views.migrate.title" = "Migrate";
+"views.migrate.no_profiles" = "Nothing to migrate";
+"views.migrate.items.migrate" = "Proceed";
+"views.migrate.items.import" = "Import";
+"views.migrate.sections.main.header" = "Select below the profiles from old versions of Passepartout that you want to import. Profiles will disappear from this list once imported successfully.";
+"views.migrate.alerts.delete.title" = "Discard";
+"views.migrate.alerts.delete.message" = "Do you want to discard these profiles? You will not be able to recover them later.\n\n%@";
 
 "views.donate.title" = "Make a donation";
 "views.donate.sections.main.footer" = "If you want to display gratitude for my work, here are a couple amounts you can donate instantly.\n\nYou will only be charged once per donation, and you can donate multiple times.";

--- a/Passepartout/Library/Sources/UILibrary/Theme/Theme+ImageName.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Theme+ImageName.swift
@@ -55,6 +55,8 @@ extension Theme {
         case progress
         case remove
         case search
+        case selectionOff
+        case selectionOn
         case settings
         case share
         case show
@@ -102,6 +104,8 @@ extension Theme.ImageName {
             case .progress: return "clock"
             case .remove: return "minus"
             case .search: return "magnifyingglass"
+            case .selectionOff: return "circle"
+            case .selectionOn: return "checkmark.circle.fill"
             case .settings: return "gearshape"
             case .share: return "square.and.arrow.up"
             case .show: return "eye"

--- a/Passepartout/Tests/MigrationManagerTests.swift
+++ b/Passepartout/Tests/MigrationManagerTests.swift
@@ -79,7 +79,7 @@ extension MigrationManagerTests {
         let sut = newManager()
 
         let id = try XCTUnwrap(UUID(uuidString: "8A568345-85C4-44C1-A9C4-612E8B07ADC5"))
-        let migrated = try await sut.migrateProfile(withId: id)
+        let migrated = try await sut.migratedProfile(withId: id)
         let profile = try XCTUnwrap(migrated)
 
         XCTAssertEqual(profile.id, id)
@@ -114,7 +114,7 @@ extension MigrationManagerTests {
         let sut = newManager()
 
         let id = try XCTUnwrap(UUID(uuidString: "981E7CBD-7733-4CF3-9A51-2777614ED5D4"))
-        let migrated = try await sut.migrateProfile(withId: id)
+        let migrated = try await sut.migratedProfile(withId: id)
         let profile = try XCTUnwrap(migrated)
 
         XCTAssertEqual(profile.id, id)
@@ -138,7 +138,7 @@ extension MigrationManagerTests {
         let sut = newManager()
 
         let id = try XCTUnwrap(UUID(uuidString: "239AD322-7440-4198-990A-D91379916FE2"))
-        let migrated = try await sut.migrateProfile(withId: id)
+        let migrated = try await sut.migratedProfile(withId: id)
         let profile = try XCTUnwrap(migrated)
 
         XCTAssertEqual(profile.id, id)
@@ -171,7 +171,7 @@ extension MigrationManagerTests {
         let sut = newManager()
 
         let id = try XCTUnwrap(UUID(uuidString: "069F76BD-1F6B-425C-AD83-62477A8B6558"))
-        let migrated = try await sut.migrateProfile(withId: id)
+        let migrated = try await sut.migratedProfile(withId: id)
         let profile = try XCTUnwrap(migrated)
 
         XCTAssertEqual(profile.id, id)


### PR DESCRIPTION
Finalize migration flow:

- Add entry to "Add" menu
- Suggest to migrate old profiles when there are no profiles
- Add informational message
- Keep included profiles on top
- Allow deletion of migratable profiles
- Fix duplicated Form in preview
- Rename views and models

Improve some Theme modifiers:

- Empty message with full screen option
- Progress modifier with custom view
- Confirmation dialog with custom message