### PR TITLE
Reload receipt on purchase

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -48,7 +48,7 @@ struct InstalledProfileView: View, Routable {
     @Binding
     var nextProfileId: Profile.ID?
 
-    var flow: ProfileContainerView.Flow?
+    var flow: ProfileFlow?
 
     var body: some View {
         debugChanges()

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -109,7 +109,7 @@ private struct ContainerModifier: ViewModifier {
     @ObservedObject
     var profileManager: ProfileManager
 
-    let flow: ProfileContainerView.Flow?
+    let flow: ProfileFlow?
 
     @State
     private var search = ""

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -43,7 +43,7 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
 
     let errorHandler: ErrorHandler
 
-    var flow: ProfileContainerView.Flow?
+    var flow: ProfileFlow?
 
     @State
     private var nextProfileId: Profile.ID?

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -49,7 +49,7 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
 
     let errorHandler: ErrorHandler
 
-    var flow: ProfileContainerView.Flow?
+    var flow: ProfileFlow?
 
     @State
     private var nextProfileId: Profile.ID?

--- a/Passepartout/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -224,6 +224,9 @@ private extension PaywallView {
     func onComplete(_ productIdentifier: String, result: InAppPurchaseResult) {
         switch result {
         case .done:
+            Task {
+                await iapManager.reloadReceipt()
+            }
             isPresented = false
 
         case .pending:


### PR DESCRIPTION
StoreKit ProductView performs the purchases internally without calling IAPManager.purchase(), which causes the IAPManager state to be momentarily outdated.

Leverage PaywallView.onComplete() to reload the receipt and eventually trigger IAPManager.objectWillChange, so that the app is immediately unlocked on a successful purchase.