### PR TITLE
Update profiles requirements on new in-app receipt

### DIFF
--- a/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
@@ -176,6 +176,10 @@ private extension AppContext {
             } catch {
                 pp_log(.App.profiles, .error, "\tUnable to re-observe remote profiles: \(error)")
             }
+
+            // refresh required profile features
+            pp_log(.App.profiles, .info, "\tReload required profiles features...")
+            profileManager.reloadRequiredFeatures()
         }
         await pendingTask?.value
         pendingTask = nil

--- a/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/AppContext.swift
@@ -178,7 +178,7 @@ private extension AppContext {
             }
 
             // refresh required profile features
-            pp_log(.App.profiles, .info, "\tReload required profiles features...")
+            pp_log(.App.profiles, .info, "\tReload profiles required features...")
             profileManager.reloadRequiredFeatures()
         }
         await pendingTask?.value


### PR DESCRIPTION
Required features were only updated when reloading the local profiles, but they may also change on in-app events due to changes in eligibility.