### PR TITLE
Test IAPManager

### DIFF
--- a/Passepartout/Library/Sources/CommonIAP/Strategy/FakeAppReceiptReader.swift
+++ b/Passepartout/Library/Sources/CommonIAP/Strategy/FakeAppReceiptReader.swift
@@ -56,15 +56,37 @@ public actor FakeAppReceiptReader: AppReceiptReader {
         localReceipt
     }
 
-    public func addPurchase(with identifier: String) {
+    public func addPurchase(with identifier: String) async {
+        await addPurchase(with: identifier, expirationDate: nil, cancellationDate: nil)
+    }
+}
+
+extension FakeAppReceiptReader {
+    public func addPurchase(
+        with product: AppProduct,
+        expirationDate: Date? = nil,
+        cancellationDate: Date? = nil
+    ) async {
+        await addPurchase(
+            with: product.rawValue,
+            expirationDate: expirationDate,
+            cancellationDate: cancellationDate
+        )
+    }
+
+    public func addPurchase(
+        with identifier: String,
+        expirationDate: Date? = nil,
+        cancellationDate: Date? = nil
+    ) async {
         guard let localReceipt else {
             fatalError("Call setReceipt() first")
         }
         var purchaseReceipts = localReceipt.purchaseReceipts ?? []
         purchaseReceipts.append(.init(
             productIdentifier: identifier,
-            expirationDate: nil,
-            cancellationDate: nil,
+            expirationDate: expirationDate,
+            cancellationDate: cancellationDate,
             originalPurchaseDate: nil
         ))
         let newReceipt = InAppReceipt(

--- a/Passepartout/Library/Sources/CommonLibrary/Strategy/FallbackReceiptReader.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Strategy/FallbackReceiptReader.swift
@@ -53,6 +53,10 @@ public actor FallbackReceiptReader: AppReceiptReader {
         pendingTask = nil
         return receipt
     }
+
+    public func addPurchase(with identifier: String) async {
+        //
+    }
 }
 
 private extension FallbackReceiptReader {

--- a/Passepartout/Library/Sources/CommonUtils/Business/BetaChecker.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Business/BetaChecker.swift
@@ -1,8 +1,8 @@
 //
-//  AppReceiptReader.swift
+//  BetaChecker.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 11/6/24.
+//  Created by Davide De Rosa on 11/21/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,11 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonUtils
 import Foundation
 
-public protocol AppReceiptReader {
-    func receipt(at userLevel: AppUserLevel) async -> InAppReceipt?
-
-    func addPurchase(with identifier: String) async
+public protocol BetaChecker {
+    func isBeta() async -> Bool
 }

--- a/Passepartout/Library/Sources/CommonUtils/Business/TestFlightChecker.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Business/TestFlightChecker.swift
@@ -1,5 +1,5 @@
 //
-//  SandboxChecker.swift
+//  TestFlightChecker.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 5/18/22.
@@ -28,7 +28,7 @@ import Foundation
 // https://stackoverflow.com/a/32238344/784615
 // https://gist.github.com/lukaskubanek/cbfcab29c0c93e0e9e0a16ab09586996
 
-public final class SandboxChecker {
+public final class TestFlightChecker: BetaChecker {
     public init() {
     }
 
@@ -41,7 +41,7 @@ public final class SandboxChecker {
 
 // MARK: Shared
 
-private extension SandboxChecker {
+private extension TestFlightChecker {
 
     // IMPORTANT: check Mac first because os(iOS) holds true for Catalyst
     func verifyBetaBuild() -> Bool {
@@ -62,7 +62,7 @@ private extension SandboxChecker {
 // MARK: iOS
 
 #if os(iOS)
-private extension SandboxChecker {
+private extension TestFlightChecker {
     var isiOSSandboxBuild: Bool {
         bundle.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
     }
@@ -72,7 +72,7 @@ private extension SandboxChecker {
 // MARK: macOS
 
 #if os(macOS) || targetEnvironment(macCatalyst)
-private extension SandboxChecker {
+private extension TestFlightChecker {
     var isMacTestFlightBuild: Bool {
         var status = noErr
 

--- a/Passepartout/Library/Sources/UILibrary/Mock/AppContext+Mock.swift
+++ b/Passepartout/Library/Sources/UILibrary/Mock/AppContext+Mock.swift
@@ -36,6 +36,7 @@ extension AppContext {
         let iapManager = IAPManager(
             inAppHelper: FakeAppProductHelper(),
             receiptReader: FakeAppReceiptReader(),
+            betaChecker: TestFlightChecker(),
             unrestrictedFeatures: [
                 .interactiveLogin,
                 .onDemand

--- a/Passepartout/Library/Tests/CommonLibraryTests/Mock/MockBetaChecker.swift
+++ b/Passepartout/Library/Tests/CommonLibraryTests/Mock/MockBetaChecker.swift
@@ -1,8 +1,8 @@
 //
-//  AppReceiptReader.swift
+//  MockBetaChecker.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 11/6/24.
+//  Created by Davide De Rosa on 11/21/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -26,8 +26,10 @@
 import CommonUtils
 import Foundation
 
-public protocol AppReceiptReader {
-    func receipt(at userLevel: AppUserLevel) async -> InAppReceipt?
+final class MockBetaChecker: BetaChecker {
+    var isBeta = false
 
-    func addPurchase(with identifier: String) async
+    func isBeta() async -> Bool {
+        isBeta
+    }
 }


### PR DESCRIPTION
Refactoring:

- Split tests
- Report purchase to receipt reader (real impl does nothing)
- Abstract BetaChecker from now TestFlightChecker

Bugfixing:

- Fix duplicated code in fetchLevelIfNeeded()
- Fix observeObjects() missing .didUpdate publisher