### PR TITLE
Fix shared profile not updated on provider server selection

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -192,7 +192,7 @@ private extension ProfileRowView {
     .task {
         do {
             try await profileManager.observeRemote(true)
-            try await profileManager.save(profile, force: true, remotelyShared: true)
+            try await profileManager.save(profile, isLocal: true, remotelyShared: true)
         } catch {
             fatalError(error.localizedDescription)
         }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProviderEntitySelector.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProviderEntitySelector.swift
@@ -73,7 +73,7 @@ private extension ProviderEntitySelector {
             builder.saveModule(newModule)
             let newProfile = try builder.tryBuild()
 
-            try await profileManager.save(newProfile)
+            try await profileManager.save(newProfile, force: true)
 
             // will reconnect via AppContext observation
         } catch {

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProviderEntitySelector.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProviderEntitySelector.swift
@@ -73,7 +73,7 @@ private extension ProviderEntitySelector {
             builder.saveModule(newModule)
             let newProfile = try builder.tryBuild()
 
-            try await profileManager.save(newProfile, force: true)
+            try await profileManager.save(newProfile, isLocal: true)
 
             // will reconnect via AppContext observation
         } catch {

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -218,12 +218,14 @@ extension ProfileManager {
             pp_log(.App.profiles, .fault, "\tUnable to save profile \(profile.id): \(error)")
             throw error
         }
-        if let remotelyShared, let remoteRepository {
+        if let remoteRepository {
+            let enableSharing = remotelyShared == true || (force && isRemotelyShared(profileWithId: profile.id))
+            let disableSharing = remotelyShared == false
             do {
-                if remotelyShared {
+                if enableSharing {
                     pp_log(.App.profiles, .notice, "\tEnable remote sharing of profile \(profile.id)...")
                     try await remoteRepository.saveProfile(profile)
-                } else {
+                } else if disableSharing {
                     pp_log(.App.profiles, .notice, "\tDisable remote sharing of profile \(profile.id)...")
                     try await remoteRepository.removeProfiles(withIds: [profile.id])
                 }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -186,9 +186,9 @@ extension ProfileManager {
 // MARK: - Edit
 
 extension ProfileManager {
-    public func save(_ originalProfile: Profile, force: Bool = false, remotelyShared: Bool? = nil) async throws {
+    public func save(_ originalProfile: Profile, isLocal: Bool = false, remotelyShared: Bool? = nil) async throws {
         let profile: Profile
-        if force {
+        if isLocal {
             var builder = originalProfile.builder()
             if let processor {
                 builder = try processor.willRebuild(builder)
@@ -219,7 +219,7 @@ extension ProfileManager {
             throw error
         }
         if let remoteRepository {
-            let enableSharing = remotelyShared == true || (force && isRemotelyShared(profileWithId: profile.id))
+            let enableSharing = remotelyShared == true || (isLocal && isRemotelyShared(profileWithId: profile.id))
             let disableSharing = remotelyShared == false
             do {
                 if enableSharing {

--- a/Passepartout/Library/Sources/CommonLibrary/Extensions/ProfileManager+Importer.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Extensions/ProfileManager+Importer.swift
@@ -28,6 +28,6 @@ import PassepartoutKit
 
 extension ProfileManager: MigrationManagerImporter {
     public func importProfile(_ profile: Profile) async throws {
-        try await save(profile, force: true)
+        try await save(profile, isLocal: true)
     }
 }

--- a/Passepartout/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -210,7 +210,7 @@ extension ProfileEditor {
     public func save(to profileManager: ProfileManager) async throws -> Profile {
         do {
             let newProfile = try build()
-            try await profileManager.save(newProfile, force: true, remotelyShared: isShared)
+            try await profileManager.save(newProfile, isLocal: true, remotelyShared: isShared)
             return newProfile
         } catch {
             pp_log(.app, .fault, "Unable to save edited profile: \(error)")

--- a/Passepartout/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
+++ b/Passepartout/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
@@ -206,11 +206,11 @@ extension ProfileManagerTests {
         let profile = newProfile()
         try await sut.save(profile)
         XCTAssertEqual(processor.willRebuildCount, 0)
-        try await sut.save(profile, force: false)
+        try await sut.save(profile, isLocal: false)
         XCTAssertEqual(processor.willRebuildCount, 0)
     }
 
-    func test_givenRepositoryAndProcessor_whenSaveForce_thenProcessorIsInvoked() async throws {
+    func test_givenRepositoryAndProcessor_whenSaveLocal_thenProcessorIsInvoked() async throws {
         let repository = InMemoryProfileRepository(profiles: [])
         let processor = MockProfileProcessor()
         let sut = ProfileManager(repository: repository, remoteRepositoryBlock: nil, processor: processor)
@@ -220,7 +220,7 @@ extension ProfileManagerTests {
         XCTAssertFalse(sut.hasProfiles)
 
         let profile = newProfile()
-        try await sut.save(profile, force: true)
+        try await sut.save(profile, isLocal: true)
         XCTAssertEqual(processor.willRebuildCount, 1)
     }
 


### PR DESCRIPTION
First, rename `force` parameter of ProfileManager.save() to `isLocal`, because it's meant to be used when saving local profiles. In such scenario, a profile that is also remotely shared _must_ be re-saved to the remote repository.

This was not being done when selecting a provider server, and it could be noticed because the other devices would only receive the iCloud update after editing the profile and re-doing a manual "Save". Only at that point would the new profile be re-shared on iCloud.