### PR TITLE
Replace active modules count with a description

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -124,7 +124,7 @@ private extension InstalledProfileView {
         ProfileContextMenu(
             profileManager: profileManager,
             tunnel: tunnel,
-            header: .init(profile ?? .mock),
+            preview: .init(profile ?? .mock),
             interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             isInstalledProfile: true,
@@ -324,7 +324,7 @@ private struct ContentView: View {
                 style: .full,
                 profileManager: .mock,
                 tunnel: .mock,
-                header: .init(.mock),
+                preview: .init(.mock),
                 interactiveManager: InteractiveManager(),
                 errorHandler: .default(),
                 nextProfileId: .constant(nil),

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -124,7 +124,7 @@ private extension InstalledProfileView {
         ProfileContextMenu(
             profileManager: profileManager,
             tunnel: tunnel,
-            header: (profile ?? .mock).header(),
+            header: .init(profile ?? .mock),
             interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             isInstalledProfile: true,
@@ -324,7 +324,7 @@ private struct ContentView: View {
                 style: .full,
                 profileManager: .mock,
                 tunnel: .mock,
-                header: Profile.mock.header(),
+                header: .init(.mock),
                 interactiveManager: InteractiveManager(),
                 errorHandler: .default(),
                 nextProfileId: .constant(nil),

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import PassepartoutKit
 import SwiftUI
 
 struct ProfileCardView: View {
@@ -36,7 +35,7 @@ struct ProfileCardView: View {
 
     let style: Style
 
-    let header: ProfileHeader
+    let header: ProfilePreview
 
     var body: some View {
         switch style {
@@ -50,7 +49,7 @@ struct ProfileCardView: View {
                 Text(header.name)
                     .font(.headline)
                     .themeTruncating()
-                Text(Strings.Views.Profiles.Rows.modules(header.modules.count))
+                Text(header.subtitle ?? "")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -66,13 +65,13 @@ struct ProfileCardView: View {
         Section {
             ProfileCardView(
                 style: .compact,
-                header: Profile.mock.header()
+                header: .init(.mock)
             )
         }
         Section {
             ProfileCardView(
                 style: .full,
-                header: Profile.mock.header()
+                header: .init(.mock)
             )
         }
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
@@ -35,21 +35,21 @@ struct ProfileCardView: View {
 
     let style: Style
 
-    let header: ProfilePreview
+    let preview: ProfilePreview
 
     var body: some View {
         switch style {
         case .compact:
-            Text(header.name)
+            Text(preview.name)
                 .themeTruncating()
                 .frame(maxWidth: .infinity, alignment: .leading)
 
         case .full:
             VStack(alignment: .leading) {
-                Text(header.name)
+                Text(preview.name)
                     .font(.headline)
                     .themeTruncating()
-                Text(header.subtitle ?? "")
+                Text(preview.subtitle ?? "")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -65,13 +65,13 @@ struct ProfileCardView: View {
         Section {
             ProfileCardView(
                 style: .compact,
-                header: .init(.mock)
+                preview: .init(.mock)
             )
         }
         Section {
             ProfileCardView(
                 style: .full,
-                header: .init(.mock)
+                preview: .init(.mock)
             )
         }
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
@@ -49,7 +49,8 @@ struct ProfileCardView: View {
                 Text(preview.name)
                     .font(.headline)
                     .themeTruncating()
-                Text(preview.subtitle ?? "")
+
+                Text(preview.subtitle ?? Strings.Views.Profiles.Rows.noModules)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -136,7 +136,7 @@ private struct ContainerModifier: ViewModifier {
                 profileManager.search(byName: $0)
             }
             .themeAnimation(on: profileManager.isReady, category: .profiles)
-            .themeAnimation(on: profileManager.headers, category: .profiles)
+            .themeAnimation(on: profileManager.previews, category: .profiles)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
@@ -33,7 +33,7 @@ struct ProfileContextMenu: View, Routable {
 
     let tunnel: ExtendedTunnel
 
-    let header: ProfilePreview
+    let preview: ProfilePreview
 
     let interactiveManager: InteractiveManager
 
@@ -60,7 +60,7 @@ struct ProfileContextMenu: View, Routable {
 @MainActor
 private extension ProfileContextMenu {
     var profile: Profile? {
-        profileManager.profile(withId: header.id)
+        profileManager.profile(withId: preview.id)
     }
 
     var tunnelToggleButton: some View {
@@ -111,7 +111,7 @@ private extension ProfileContextMenu {
 
     var profileEditButton: some View {
         Button {
-            flow?.onEditProfile(header)
+            flow?.onEditProfile(preview)
         } label: {
             ThemeImageLabel(Strings.Global.edit.withTrailingDots, .profileEdit)
         }
@@ -120,7 +120,7 @@ private extension ProfileContextMenu {
     var profileDuplicateButton: some View {
         ProfileDuplicateButton(
             profileManager: profileManager,
-            header: header,
+            preview: preview,
             errorHandler: errorHandler
         ) {
             ThemeImageLabel(Strings.Global.duplicate, .contextDuplicate)
@@ -130,7 +130,7 @@ private extension ProfileContextMenu {
     var profileRemoveButton: some View {
         ProfileRemoveButton(
             profileManager: profileManager,
-            header: header
+            preview: preview
         ) {
             ThemeImageLabel(Strings.Global.remove, .contextRemove)
         }
@@ -143,7 +143,7 @@ private extension ProfileContextMenu {
             ProfileContextMenu(
                 profileManager: .mock,
                 tunnel: .mock,
-                header: .init(.mock),
+                preview: .init(.mock),
                 interactiveManager: InteractiveManager(),
                 errorHandler: .default(),
                 isInstalledProfile: true

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
@@ -33,7 +33,7 @@ struct ProfileContextMenu: View, Routable {
 
     let tunnel: ExtendedTunnel
 
-    let header: ProfileHeader
+    let header: ProfilePreview
 
     let interactiveManager: InteractiveManager
 
@@ -143,7 +143,7 @@ private extension ProfileContextMenu {
             ProfileContextMenu(
                 profileManager: .mock,
                 tunnel: .mock,
-                header: Profile.mock.header(),
+                header: .init(.mock),
                 interactiveManager: InteractiveManager(),
                 errorHandler: .default(),
                 isInstalledProfile: true

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileDuplicateButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileDuplicateButton.swift
@@ -31,7 +31,7 @@ import SwiftUI
 struct ProfileDuplicateButton<Label>: View where Label: View {
     let profileManager: ProfileManager
 
-    let header: ProfileHeader
+    let header: ProfilePreview
 
     let errorHandler: ErrorHandler
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileDuplicateButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileDuplicateButton.swift
@@ -25,13 +25,12 @@
 
 import CommonLibrary
 import CommonUtils
-import PassepartoutKit
 import SwiftUI
 
 struct ProfileDuplicateButton<Label>: View where Label: View {
     let profileManager: ProfileManager
 
-    let header: ProfilePreview
+    let preview: ProfilePreview
 
     let errorHandler: ErrorHandler
 
@@ -41,12 +40,12 @@ struct ProfileDuplicateButton<Label>: View where Label: View {
         Button {
             Task {
                 do {
-                    try await profileManager.duplicate(profileWithId: header.id)
+                    try await profileManager.duplicate(profileWithId: preview.id)
                 } catch {
                     errorHandler.handle(
                         error,
                         title: Strings.Global.duplicate,
-                        message: Strings.Views.Profiles.Errors.duplicate(header.name)
+                        message: Strings.Views.Profiles.Errors.duplicate(preview.name)
                     )
                 }
             }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -88,7 +88,7 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
 // MARK: - Subviews
 
 private extension ProfileGridView {
-    var allHeaders: [ProfileHeader] {
+    var allHeaders: [ProfilePreview] {
         profileManager.headers
     }
 
@@ -108,7 +108,7 @@ private extension ProfileGridView {
                 ProfileContextMenu(
                     profileManager: profileManager,
                     tunnel: tunnel,
-                    header: $0.header(),
+                    header: .init($0),
                     interactiveManager: interactiveManager,
                     errorHandler: errorHandler,
                     isInstalledProfile: true,
@@ -118,7 +118,7 @@ private extension ProfileGridView {
         }
     }
 
-    func profileView(for header: ProfileHeader) -> some View {
+    func profileView(for header: ProfilePreview) -> some View {
         ProfileRowView(
             style: .full,
             profileManager: profileManager,

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -108,7 +108,7 @@ private extension ProfileGridView {
                 ProfileContextMenu(
                     profileManager: profileManager,
                     tunnel: tunnel,
-                    header: .init($0),
+                    preview: .init($0),
                     interactiveManager: interactiveManager,
                     errorHandler: errorHandler,
                     isInstalledProfile: true,
@@ -118,31 +118,31 @@ private extension ProfileGridView {
         }
     }
 
-    func profileView(for header: ProfilePreview) -> some View {
+    func profileView(for preview: ProfilePreview) -> some View {
         ProfileRowView(
             style: .full,
             profileManager: profileManager,
             tunnel: tunnel,
-            header: header,
+            preview: preview,
             interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             nextProfileId: $nextProfileId,
             withMarker: true,
             flow: flow
         )
-        .themeGridCell(isSelected: header.id == nextProfileId ?? currentProfile?.id)
+        .themeGridCell(isSelected: preview.id == nextProfileId ?? currentProfile?.id)
         .contextMenu {
             ProfileContextMenu(
                 profileManager: profileManager,
                 tunnel: tunnel,
-                header: header,
+                preview: preview,
                 interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 isInstalledProfile: false,
                 flow: flow
             )
         }
-        .id(header.id)
+        .id(preview.id)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -64,7 +64,7 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
                             .unanimated()
                     }
                     LazyVGrid(columns: columns) {
-                        ForEach(allHeaders, content: profileView)
+                        ForEach(allPreviews, content: profileView)
                             .onDelete { offsets in
                                 Task {
                                     await profileManager.removeProfiles(at: offsets)
@@ -88,8 +88,8 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
 // MARK: - Subviews
 
 private extension ProfileGridView {
-    var allHeaders: [ProfilePreview] {
-        profileManager.headers
+    var allPreviews: [ProfilePreview] {
+        profileManager.previews
     }
 
     func headerView(scrollProxy: ScrollViewProxy) -> some View {

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileInfoButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileInfoButton.swift
@@ -23,13 +23,14 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import PassepartoutKit
 import SwiftUI
 
 struct ProfileInfoButton: View {
-    let header: ProfileHeader
+    let header: ProfilePreview
 
-    let onEdit: (ProfileHeader) -> Void
+    let onEdit: (ProfilePreview) -> Void
 
     var body: some View {
         Button {

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileInfoButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileInfoButton.swift
@@ -24,17 +24,16 @@
 //
 
 import CommonLibrary
-import PassepartoutKit
 import SwiftUI
 
 struct ProfileInfoButton: View {
-    let header: ProfilePreview
+    let preview: ProfilePreview
 
     let onEdit: (ProfilePreview) -> Void
 
     var body: some View {
         Button {
-            onEdit(header)
+            onEdit(preview)
         } label: {
             ThemeImage(.info)
         }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -78,7 +78,7 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
 }
 
 private extension ProfileListView {
-    var allHeaders: [ProfileHeader] {
+    var allHeaders: [ProfilePreview] {
         profileManager.headers
     }
 
@@ -98,7 +98,7 @@ private extension ProfileListView {
                 ProfileContextMenu(
                     profileManager: profileManager,
                     tunnel: tunnel,
-                    header: $0.header(),
+                    header: .init($0),
                     interactiveManager: interactiveManager,
                     errorHandler: errorHandler,
                     isInstalledProfile: true,
@@ -108,7 +108,7 @@ private extension ProfileListView {
         }
     }
 
-    func profileView(for header: ProfileHeader) -> some View {
+    func profileView(for header: ProfilePreview) -> some View {
         ProfileRowView(
             style: cardStyle,
             profileManager: profileManager,

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -63,7 +63,7 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
                         .unanimated()
                 }
                 Group {
-                    ForEach(allHeaders, content: profileView)
+                    ForEach(allPreviews, content: profileView)
                         .onDelete { offsets in
                             Task {
                                 await profileManager.removeProfiles(at: offsets)
@@ -78,8 +78,8 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
 }
 
 private extension ProfileListView {
-    var allHeaders: [ProfilePreview] {
-        profileManager.headers
+    var allPreviews: [ProfilePreview] {
+        profileManager.previews
     }
 
     func headerView(scrollProxy: ScrollViewProxy) -> some View {

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -98,7 +98,7 @@ private extension ProfileListView {
                 ProfileContextMenu(
                     profileManager: profileManager,
                     tunnel: tunnel,
-                    header: .init($0),
+                    preview: .init($0),
                     interactiveManager: interactiveManager,
                     errorHandler: errorHandler,
                     isInstalledProfile: true,
@@ -108,12 +108,12 @@ private extension ProfileListView {
         }
     }
 
-    func profileView(for header: ProfilePreview) -> some View {
+    func profileView(for preview: ProfilePreview) -> some View {
         ProfileRowView(
             style: cardStyle,
             profileManager: profileManager,
             tunnel: tunnel,
-            header: header,
+            preview: preview,
             interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             nextProfileId: $nextProfileId,
@@ -124,14 +124,14 @@ private extension ProfileListView {
             ProfileContextMenu(
                 profileManager: profileManager,
                 tunnel: tunnel,
-                header: header,
+                preview: preview,
                 interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 isInstalledProfile: false,
                 flow: flow
             )
         }
-        .id(header.id)
+        .id(preview.id)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRemoveButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRemoveButton.swift
@@ -24,20 +24,19 @@
 //
 
 import CommonLibrary
-import PassepartoutKit
 import SwiftUI
 
 struct ProfileRemoveButton<Label>: View where Label: View {
     let profileManager: ProfileManager
 
-    let header: ProfilePreview
+    let preview: ProfilePreview
 
     let label: () -> Label
 
     var body: some View {
         Button(role: .destructive) {
             Task {
-                await profileManager.remove(withId: header.id)
+                await profileManager.remove(withId: preview.id)
             }
         } label: {
             label()

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRemoveButton.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRemoveButton.swift
@@ -30,7 +30,7 @@ import SwiftUI
 struct ProfileRemoveButton<Label>: View where Label: View {
     let profileManager: ProfileManager
 
-    let header: ProfileHeader
+    let header: ProfilePreview
 
     let label: () -> Label
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -40,7 +40,7 @@ struct ProfileRowView: View, Routable {
 
     let tunnel: ExtendedTunnel
 
-    let header: ProfileHeader
+    let header: ProfilePreview
 
     let interactiveManager: InteractiveManager
 
@@ -102,6 +102,10 @@ private struct MarkerView: View {
 }
 
 private extension ProfileRowView {
+    var profile: Profile? {
+        profileManager.profile(withId: header.id)
+    }
+
     var markerView: some View {
         MarkerView(
             headerId: header.id,
@@ -114,7 +118,7 @@ private extension ProfileRowView {
     var cardView: some View {
         TunnelToggleButton(
             tunnel: tunnel,
-            profile: profileManager.profile(withId: header.id),
+            profile: profile,
             nextProfileId: $nextProfileId,
             interactiveManager: interactiveManager,
             errorHandler: errorHandler,
@@ -169,7 +173,7 @@ private extension ProfileRowView {
             style: .compact,
             profileManager: profileManager,
             tunnel: .mock,
-            header: profile.header(),
+            header: .init(profile),
             interactiveManager: InteractiveManager(),
             errorHandler: .default(),
             nextProfileId: .constant(nil),

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -40,7 +40,7 @@ struct ProfileRowView: View, Routable {
 
     let tunnel: ExtendedTunnel
 
-    let header: ProfilePreview
+    let preview: ProfilePreview
 
     let interactiveManager: InteractiveManager
 
@@ -67,7 +67,7 @@ struct ProfileRowView: View, Routable {
                     attributes: attributes,
                     isRemoteImportingEnabled: profileManager.isRemoteImportingEnabled
                 )
-                ProfileInfoButton(header: header) {
+                ProfileInfoButton(preview: preview) {
                     flow?.onEditProfile($0)
                 }
             }
@@ -79,7 +79,7 @@ struct ProfileRowView: View, Routable {
 // MARK: - Subviews (observing)
 
 private struct MarkerView: View {
-    let headerId: Profile.ID
+    let profileId: Profile.ID
 
     let nextProfileId: Profile.ID?
 
@@ -90,8 +90,8 @@ private struct MarkerView: View {
 
     var body: some View {
         ZStack {
-            ThemeImage(headerId == nextProfileId ? .pending : tunnel.statusImageName)
-                .opaque(requiredFeatures == nil && (headerId == nextProfileId || headerId == tunnel.currentProfile?.id))
+            ThemeImage(profileId == nextProfileId ? .pending : tunnel.statusImageName)
+                .opaque(requiredFeatures == nil && (profileId == nextProfileId || profileId == tunnel.currentProfile?.id))
 
             if let requiredFeatures {
                 PurchaseRequiredButton(features: requiredFeatures, paywallReason: .constant(nil))
@@ -103,12 +103,12 @@ private struct MarkerView: View {
 
 private extension ProfileRowView {
     var profile: Profile? {
-        profileManager.profile(withId: header.id)
+        profileManager.profile(withId: preview.id)
     }
 
     var markerView: some View {
         MarkerView(
-            headerId: header.id,
+            profileId: preview.id,
             nextProfileId: nextProfileId,
             tunnel: tunnel,
             requiredFeatures: requiredFeatures
@@ -131,7 +131,7 @@ private extension ProfileRowView {
             label: { _ in
                 ProfileCardView(
                     style: style,
-                    header: header
+                    preview: preview
                 )
                 .frame(maxWidth: .infinity)
                 .contentShape(.rect)
@@ -150,15 +150,15 @@ private extension ProfileRowView {
     }
 
     var requiredFeatures: Set<AppFeature>? {
-        profileManager.requiredFeatures(forProfileWithId: header.id)
+        profileManager.requiredFeatures(forProfileWithId: preview.id)
     }
 
     var isShared: Bool {
-        profileManager.isRemotelyShared(profileWithId: header.id)
+        profileManager.isRemotelyShared(profileWithId: preview.id)
     }
 
     var isTV: Bool {
-        isShared && profileManager.isAvailableForTV(profileWithId: header.id)
+        isShared && profileManager.isAvailableForTV(profileWithId: preview.id)
     }
 }
 
@@ -173,7 +173,7 @@ private extension ProfileRowView {
             style: .compact,
             profileManager: profileManager,
             tunnel: .mock,
-            header: .init(profile),
+            preview: .init(profile),
             interactiveManager: InteractiveManager(),
             errorHandler: .default(),
             nextProfileId: .constant(nil),

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
@@ -80,7 +80,7 @@ private extension AppMenu {
     }
 
     var profilesList: some View {
-        ForEach(profileManager.headers, id: \.id, content: profileToggle)
+        ForEach(profileManager.previews, id: \.id, content: profileToggle)
     }
 
     func profileToggle(for header: ProfilePreview) -> some View {

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
@@ -83,16 +83,16 @@ private extension AppMenu {
         ForEach(profileManager.previews, id: \.id, content: profileToggle)
     }
 
-    func profileToggle(for header: ProfilePreview) -> some View {
-        Toggle(header.name, isOn: profileToggleBinding(for: header))
+    func profileToggle(for preview: ProfilePreview) -> some View {
+        Toggle(preview.name, isOn: profileToggleBinding(for: preview))
     }
 
-    func profileToggleBinding(for header: ProfilePreview) -> Binding<Bool> {
+    func profileToggleBinding(for preview: ProfilePreview) -> Binding<Bool> {
         Binding {
-            header.id == tunnel.currentProfile?.id && tunnel.status != .inactive
+            preview.id == tunnel.currentProfile?.id && tunnel.status != .inactive
         } set: { isOn in
             Task {
-                guard let profile = profileManager.profile(withId: header.id) else {
+                guard let profile = profileManager.profile(withId: preview.id) else {
                     return
                 }
                 do {
@@ -102,7 +102,7 @@ private extension AppMenu {
                         try await tunnel.disconnect()
                     }
                 } catch {
-                    pp_log(.app, .error, "Unable to toggle profile \(header.id) from menu: \(error)")
+                    pp_log(.app, .error, "Unable to toggle profile \(preview.id) from menu: \(error)")
                 }
             }
         }

--- a/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
@@ -83,11 +83,11 @@ private extension AppMenu {
         ForEach(profileManager.headers, id: \.id, content: profileToggle)
     }
 
-    func profileToggle(for header: ProfileHeader) -> some View {
+    func profileToggle(for header: ProfilePreview) -> some View {
         Toggle(header.name, isOn: profileToggleBinding(for: header))
     }
 
-    func profileToggleBinding(for header: ProfileHeader) -> Binding<Bool> {
+    func profileToggleBinding(for header: ProfilePreview) -> Binding<Bool> {
         Binding {
             header.id == tunnel.currentProfile?.id && tunnel.status != .inactive
         } set: { isOn in

--- a/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Migration/MigrateView.swift
@@ -145,7 +145,7 @@ private extension MigrateView {
             model.step = .fetching
             pp_log(.App.migration, .notice, "Fetch migratable profiles...")
             let migratable = try await migrationManager.fetchMigratableProfiles()
-            let knownIDs = Set(profileManager.headers.map(\.id))
+            let knownIDs = Set(profileManager.previews.map(\.id))
             model.profiles = migratable.filter {
                 !knownIDs.contains($0.id)
             }

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
@@ -99,9 +99,9 @@ private extension ActiveProfileView {
 
     func detailView(for profile: Profile) -> some View {
         VStack(spacing: 10) {
-            if let connectionModule {
+            if let connectionType = profile.localizedDescription(optionalStyle: .connectionType) {
                 DetailRowView(title: Strings.Global.protocol) {
-                    Text(connectionModule.moduleHandler.id.name)
+                    Text(connectionType)
                 }
             }
             if let pair = profile.selectedProvider {
@@ -116,8 +116,8 @@ private extension ActiveProfileView {
                     }
                 }
             }
-            if let otherModulesList {
-                DetailRowView(title: otherModulesList) {
+            if let otherList = profile.localizedDescription(optionalStyle: .nonConnectionTypes) {
+                DetailRowView(title: otherList) {
                     EmptyView()
                 }
             }
@@ -164,28 +164,6 @@ private extension ActiveProfileView {
                 .padding(.vertical, 10)
         }
         .focused($focusedField, equals: .switchProfile)
-    }
-}
-
-private extension ActiveProfileView {
-    var connectionModule: ConnectionModule? {
-        profile?.firstConnectionModule(ifActive: true)
-    }
-
-    var otherModules: [Module]? {
-        profile?
-            .activeModules
-            .filter {
-                !($0 is ConnectionModule)
-            }
-            .nilIfEmpty
-    }
-
-    var otherModulesList: String? {
-        otherModules?
-            .map(\.moduleType.localizedDescription)
-            .sorted()
-            .joined(separator: ", ")
     }
 }
 

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -74,7 +74,7 @@ private extension ProfileListView {
             .font(.body)
     }
 
-    func toggleButton(for header: ProfilePreview) -> some View {
+    func toggleButton(for preview: ProfilePreview) -> some View {
         TunnelToggleButton(
             tunnel: tunnel,
             profile: profileManager.profile(withId: header.id),
@@ -90,7 +90,7 @@ private extension ProfileListView {
         .focused($focusedField, equals: .profile(header.id))
     }
 
-    func toggleView(for header: ProfilePreview) -> some View {
+    func toggleView(for preview: ProfilePreview) -> some View {
         HStack {
             Text(header.name)
             Spacer()

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -50,7 +50,7 @@ struct ProfileListView: View {
             headerView
                 .frame(maxWidth: .infinity, alignment: .leading)
             List {
-                ForEach(headers, id: \.id, content: toggleButton(for:))
+                ForEach(previews, id: \.id, content: toggleButton(for:))
             }
             .listStyle(.grouped)
             .scrollClipDisabled()
@@ -63,8 +63,8 @@ struct ProfileListView: View {
 }
 
 private extension ProfileListView {
-    var headers: [ProfilePreview] {
-        profileManager.headers
+    var previews: [ProfilePreview] {
+        profileManager.previews
     }
 
     var headerView: some View {
@@ -77,25 +77,25 @@ private extension ProfileListView {
     func toggleButton(for preview: ProfilePreview) -> some View {
         TunnelToggleButton(
             tunnel: tunnel,
-            profile: profileManager.profile(withId: header.id),
+            profile: profileManager.profile(withId: preview.id),
             nextProfileId: .constant(nil),
             interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             onProviderEntityRequired: onProviderEntityRequired,
             onPurchaseRequired: onPurchaseRequired,
             label: { _ in
-                toggleView(for: header)
+                toggleView(for: preview)
             }
         )
-        .focused($focusedField, equals: .profile(header.id))
+        .focused($focusedField, equals: .profile(preview.id))
     }
 
     func toggleView(for preview: ProfilePreview) -> some View {
         HStack {
-            Text(header.name)
+            Text(preview.name)
             Spacer()
             ThemeImage(tunnel.statusImageName)
-                .opaque(header.id == tunnel.currentProfile?.id)
+                .opaque(preview.id == tunnel.currentProfile?.id)
         }
         .font(.headline)
     }

--- a/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Passepartout/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -63,7 +63,7 @@ struct ProfileListView: View {
 }
 
 private extension ProfileListView {
-    var headers: [ProfileHeader] {
+    var headers: [ProfilePreview] {
         profileManager.headers
     }
 
@@ -74,7 +74,7 @@ private extension ProfileListView {
             .font(.body)
     }
 
-    func toggleButton(for header: ProfileHeader) -> some View {
+    func toggleButton(for header: ProfilePreview) -> some View {
         TunnelToggleButton(
             tunnel: tunnel,
             profile: profileManager.profile(withId: header.id),
@@ -90,7 +90,7 @@ private extension ProfileListView {
         .focused($focusedField, equals: .profile(header.id))
     }
 
-    func toggleView(for header: ProfileHeader) -> some View {
+    func toggleView(for header: ProfilePreview) -> some View {
         HStack {
             Text(header.name)
             Spacer()

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -147,7 +147,7 @@ extension ProfileManager {
         !filteredProfiles.isEmpty
     }
 
-    public var headers: [ProfilePreview] {
+    public var previews: [ProfilePreview] {
         filteredProfiles.map {
             processor?.preview(from: $0) ?? ProfilePreview($0)
         }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -147,9 +147,9 @@ extension ProfileManager {
         !filteredProfiles.isEmpty
     }
 
-    public var headers: [ProfileHeader] {
+    public var headers: [ProfilePreview] {
         filteredProfiles.map {
-            $0.header()
+            processor?.preview(from: $0) ?? ProfilePreview($0)
         }
     }
 

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/ProfilePreview.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/ProfilePreview.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileFlow.swift
+//  ProfilePreview.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 10/23/24.
+//  Created by Davide De Rosa on 11/22/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,16 +23,31 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonLibrary
 import Foundation
 import PassepartoutKit
 
-struct ProfileFlow {
-    let onEditProfile: (ProfilePreview) -> Void
+public struct ProfilePreview: Identifiable {
+    public let id: Profile.ID
 
-    let onEditProviderEntity: (Profile) -> Void
+    public let name: String
 
-    let onMigrateProfiles: () -> Void
+    public let subtitle: String?
 
-    let onPurchaseRequired: (Set<AppFeature>) -> Void
+    public init(id: Profile.ID, name: String, subtitle: String? = nil) {
+        self.id = id
+        self.name = name
+        self.subtitle = subtitle
+    }
+
+    public init(_ profile: Profile) {
+        id = profile.id
+        name = profile.name
+        subtitle = nil
+    }
+}
+
+extension ProfilePreview: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
 }

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/ProfilePreview.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/ProfilePreview.swift
@@ -26,7 +26,7 @@
 import Foundation
 import PassepartoutKit
 
-public struct ProfilePreview: Identifiable {
+public struct ProfilePreview: Identifiable, Hashable {
     public let id: Profile.ID
 
     public let name: String
@@ -43,11 +43,5 @@ public struct ProfilePreview: Identifiable {
         id = profile.id
         name = profile.name
         subtitle = nil
-    }
-}
-
-extension ProfilePreview: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id
     }
 }

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/TunnelInstallation.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/TunnelInstallation.swift
@@ -24,15 +24,14 @@
 //
 
 import Foundation
-import PassepartoutKit
 
 public struct TunnelInstallation {
-    public let header: ProfilePreview
+    public let preview: ProfilePreview
 
     public let onDemand: Bool
 
-    public init(header: ProfilePreview, onDemand: Bool) {
-        self.header = header
+    public init(preview: ProfilePreview, onDemand: Bool) {
+        self.preview = preview
         self.onDemand = onDemand
     }
 }

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/TunnelInstallation.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/TunnelInstallation.swift
@@ -27,11 +27,11 @@ import Foundation
 import PassepartoutKit
 
 public struct TunnelInstallation {
-    public let header: ProfileHeader
+    public let header: ProfilePreview
 
     public let onDemand: Bool
 
-    public init(header: ProfileHeader, onDemand: Bool) {
+    public init(header: ProfilePreview, onDemand: Bool) {
         self.header = header
         self.onDemand = onDemand
     }

--- a/Passepartout/Library/Sources/CommonLibrary/Strategy/InAppProcessor.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Strategy/InAppProcessor.swift
@@ -33,6 +33,8 @@ public final class InAppProcessor: ObservableObject, Sendable {
 
     private nonisolated let _isIncluded: (IAPManager, Profile) -> Bool
 
+    private nonisolated let _preview: (Profile) -> ProfilePreview
+
     private nonisolated let _willRebuild: (IAPManager, Profile.Builder) throws -> Profile.Builder
 
     private nonisolated let _willInstall: (IAPManager, Profile) throws -> Profile
@@ -43,6 +45,7 @@ public final class InAppProcessor: ObservableObject, Sendable {
         iapManager: IAPManager,
         title: @escaping (Profile) -> String,
         isIncluded: @escaping (IAPManager, Profile) -> Bool,
+        preview: @escaping (Profile) -> ProfilePreview,
         willRebuild: @escaping (IAPManager, Profile.Builder) throws -> Profile.Builder,
         willInstall: @escaping (IAPManager, Profile) throws -> Profile,
         verify: @escaping (IAPManager, Profile) -> Set<AppFeature>?
@@ -50,6 +53,7 @@ public final class InAppProcessor: ObservableObject, Sendable {
         self.iapManager = iapManager
         _title = title
         _isIncluded = isIncluded
+        _preview = preview
         _willRebuild = willRebuild
         _willInstall = willInstall
         _verify = verify
@@ -65,6 +69,10 @@ extension InAppProcessor: ProfileProcessor {
 
     public func isIncluded(_ profile: Profile) -> Bool {
         _isIncluded(iapManager, profile)
+    }
+
+    public func preview(from profile: Profile) -> ProfilePreview {
+        _preview(profile)
     }
 
     public func willRebuild(_ builder: Profile.Builder) throws -> Profile.Builder {

--- a/Passepartout/Library/Sources/CommonLibrary/Strategy/ProfileProcessor.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Strategy/ProfileProcessor.swift
@@ -29,6 +29,8 @@ import PassepartoutKit
 public protocol ProfileProcessor {
     func isIncluded(_ profile: Profile) -> Bool
 
+    func preview(from profile: Profile) -> ProfilePreview
+
     func willRebuild(_ builder: Profile.Builder) throws -> Profile.Builder
 
     func verify(_ profile: Profile) -> Set<AppFeature>?

--- a/Passepartout/Library/Sources/UILibrary/Extensions/ProfileManager+Editing.swift
+++ b/Passepartout/Library/Sources/UILibrary/Extensions/ProfileManager+Editing.swift
@@ -30,7 +30,7 @@ import PassepartoutKit
 @MainActor
 extension ProfileManager {
     public func removeProfiles(at offsets: IndexSet) async {
-        let idsToRemove = headers
+        let idsToRemove = previews
             .enumerated()
             .filter {
                 offsets.contains($0.offset)

--- a/Passepartout/Library/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
+++ b/Passepartout/Library/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
@@ -33,7 +33,7 @@ extension TunnelInstallationProviding {
         guard let currentProfile = tunnel.currentProfile else {
             return nil
         }
-        guard let header = profileManager.headers.first(where: {
+        guard let header = profileManager.previews.first(where: {
             $0.id == currentProfile.id
         }) else {
             return nil

--- a/Passepartout/Library/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
+++ b/Passepartout/Library/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
@@ -33,12 +33,12 @@ extension TunnelInstallationProviding {
         guard let currentProfile = tunnel.currentProfile else {
             return nil
         }
-        guard let header = profileManager.previews.first(where: {
+        guard let preview = profileManager.previews.first(where: {
             $0.id == currentProfile.id
         }) else {
             return nil
         }
-        return TunnelInstallation(header: header, onDemand: currentProfile.onDemand)
+        return TunnelInstallation(preview: preview, onDemand: currentProfile.onDemand)
     }
 
     public var currentProfile: Profile? {

--- a/Passepartout/Library/Sources/UILibrary/L10n/PassepartoutKit+L10n.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/PassepartoutKit+L10n.swift
@@ -27,6 +27,42 @@ import CommonUtils
 import Foundation
 import PassepartoutKit
 
+extension Profile: StyledOptionalLocalizableEntity {
+    public enum OptionalStyle {
+        case moduleTypes
+
+        case connectionType
+
+        case nonConnectionTypes
+    }
+
+    public func localizedDescription(optionalStyle: OptionalStyle) -> String? {
+        switch optionalStyle {
+        case .moduleTypes:
+            return activeModules
+                .nilIfEmpty?
+                .map(\.moduleType.localizedDescription)
+                .sorted()
+                .joined(separator: ", ")
+
+        case .connectionType:
+            return firstConnectionModule(ifActive: true)?
+                .moduleType
+                .localizedDescription
+
+        case .nonConnectionTypes:
+            return activeModules
+                .filter {
+                    !($0 is ConnectionModule)
+                }
+                .nilIfEmpty?
+                .map(\.moduleType.localizedDescription)
+                .sorted()
+                .joined(separator: ", ")
+        }
+    }
+}
+
 extension TunnelStatus: LocalizableEntity {
     public var localizedDescription: String {
         let V = Strings.Entities.TunnelStatus.self

--- a/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -809,10 +809,6 @@ public enum Strings {
         }
       }
       public enum Rows {
-        /// %d modules
-        public static func modules(_ p1: Int) -> String {
-          return Strings.tr("Localizable", "views.profiles.rows.modules", p1, fallback: "%d modules")
-        }
         /// Select a profile
         public static let notInstalled = Strings.tr("Localizable", "views.profiles.rows.not_installed", fallback: "Select a profile")
       }

--- a/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -809,6 +809,8 @@ public enum Strings {
         }
       }
       public enum Rows {
+        /// No active modules
+        public static let noModules = Strings.tr("Localizable", "views.profiles.rows.no_modules", fallback: "No active modules")
         /// Select a profile
         public static let notInstalled = Strings.tr("Localizable", "views.profiles.rows.not_installed", fallback: "Select a profile")
       }

--- a/Passepartout/Library/Sources/UILibrary/Mock/AppContext+Mock.swift
+++ b/Passepartout/Library/Sources/UILibrary/Mock/AppContext+Mock.swift
@@ -53,6 +53,9 @@ extension AppContext {
             isIncluded: { _, _ in
                 true
             },
+            preview: {
+                ProfilePreview($0)
+            },
             willRebuild: { _, builder in
                 builder
             },

--- a/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 // MARK: - Views
 
 "views.profiles.rows.not_installed" = "Select a profile";
+"views.profiles.rows.no_modules" = "No active modules";
 "views.profiles.folders.active_profile" = "Installed profile";
 "views.profiles.folders.default" = "My profiles";
 "views.profiles.folders.add_profile" = "Add profile";

--- a/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -117,7 +117,6 @@
 // MARK: - Views
 
 "views.profiles.rows.not_installed" = "Select a profile";
-"views.profiles.rows.modules" = "%d modules";
 "views.profiles.folders.active_profile" = "Installed profile";
 "views.profiles.folders.default" = "My profiles";
 "views.profiles.folders.add_profile" = "Add profile";

--- a/Passepartout/Library/Tests/AppUIMainTests/ProfileImporterTests.swift
+++ b/Passepartout/Library/Tests/AppUIMainTests/ProfileImporterTests.swift
@@ -47,7 +47,7 @@ extension ProfileImporterTests {
 
         try await sut.tryImport(urls: [], profileManager: profileManager, registry: registry)
         XCTAssertEqual(sut.nextURL, nil)
-        XCTAssertTrue(profileManager.headers.isEmpty)
+        XCTAssertTrue(profileManager.previews.isEmpty)
     }
 
     func test_givenURL_whenImport_thenOneProfileIsImported() async throws {

--- a/Passepartout/Library/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
+++ b/Passepartout/Library/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
@@ -47,6 +47,10 @@ final class MockProfileProcessor: ProfileProcessor {
         return isIncludedBlock(profile)
     }
 
+    func preview(from profile: Profile) -> ProfilePreview {
+        ProfilePreview(profile)
+    }
+
     func willRebuild(_ builder: Profile.Builder) throws -> Profile.Builder {
         willRebuildCount += 1
         return builder

--- a/Passepartout/Shared/Shared+App.swift
+++ b/Passepartout/Shared/Shared+App.swift
@@ -45,6 +45,13 @@ extension IAPManager {
         isIncluded: {
             Configuration.ProfileManager.isIncluded($0, $1)
         },
+        preview: {
+            ProfilePreview(
+                id: $0.id,
+                name: $0.name,
+                subtitle: $0.localizedDescription(optionalStyle: .moduleTypes)
+            )
+        },
         willRebuild: { _, builder in
             builder
         },


### PR DESCRIPTION
To get access to modules, try to avoid full Profile objects. Instead, replace the coupled ProfileHeader occurrences with a new intermediary ProfilePreview everywhere.

This way, a ProfileProcessor can inject the localized modules descriptions from above with the preview() method.