### PR TITLE
Fix layout of multiline modules

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileCardView.swift
@@ -51,6 +51,7 @@ struct ProfileCardView: View {
                     .themeTruncating()
 
                 Text(preview.subtitle ?? Strings.Views.Profiles.Rows.noModules)
+                    .multilineTextAlignment(.leading)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -54,24 +54,28 @@ struct ProfileRowView: View, Routable {
     var flow: ProfileFlow?
 
     var body: some View {
-        HStack {
-            Group {
-                if withMarker {
-                    markerView
+        VStack(spacing: .zero) {
+            Spacer(minLength: .zero)
+            HStack {
+                Group {
+                    if withMarker {
+                        markerView
+                    }
+                    cardView
                 }
-                cardView
-            }
-            Spacer()
-            HStack(spacing: 10.0) {
-                ProfileAttributesView(
-                    attributes: attributes,
-                    isRemoteImportingEnabled: profileManager.isRemoteImportingEnabled
-                )
-                ProfileInfoButton(preview: preview) {
-                    flow?.onEditProfile($0)
+                Spacer()
+                HStack(spacing: 10.0) {
+                    ProfileAttributesView(
+                        attributes: attributes,
+                        isRemoteImportingEnabled: profileManager.isRemoteImportingEnabled
+                    )
+                    ProfileInfoButton(preview: preview) {
+                        flow?.onEditProfile($0)
+                    }
                 }
+                .imageScale(.large)
             }
-            .imageScale(.large)
+            Spacer(minLength: .zero)
         }
     }
 }


### PR DESCRIPTION
- Align to .leading in multi-line
- Wrap profile rows into top/bottom spacers to adjust to tallest cell in grid

See #915 