### PR TITLE
Fix missing beta check on tvOS

### DIFF
--- a/Passepartout/Library/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/IAPManager.swift
@@ -261,15 +261,15 @@ extension IAPManager {
 
 private extension IAPManager {
     func fetchLevelIfNeeded() async {
-        guard userLevel == .undefined else {
-            return
-        }
         if let customUserLevel {
             userLevel = customUserLevel
             pp_log(.App.iap, .info, "App level (custom): \(userLevel)")
             return
         }
         let isBeta = await betaChecker.isBeta()
+        guard userLevel == .undefined else {
+            return
+        }
         userLevel = isBeta ? .beta : .freemium
         pp_log(.App.iap, .info, "App level: \(userLevel)")
     }

--- a/Passepartout/Library/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/IAPManager.swift
@@ -261,6 +261,9 @@ extension IAPManager {
 
 private extension IAPManager {
     func fetchLevelIfNeeded() async {
+        guard userLevel == .undefined else {
+            return
+        }
         if let customUserLevel {
             userLevel = customUserLevel
             pp_log(.App.iap, .info, "App level (custom): \(userLevel)")

--- a/Passepartout/Library/Sources/CommonUtils/Business/TestFlightChecker.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Business/TestFlightChecker.swift
@@ -47,8 +47,8 @@ private extension TestFlightChecker {
     func verifyBetaBuild() -> Bool {
 #if os(macOS) || targetEnvironment(macCatalyst)
         isMacTestFlightBuild
-#elseif os(iOS)
-        isiOSSandboxBuild
+#elseif os(iOS) || os(tvOS)
+        isSandboxBuild
 #else
         false
 #endif
@@ -59,12 +59,17 @@ private extension TestFlightChecker {
     }
 }
 
-// MARK: iOS
+// MARK: iOS/tvOS
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 private extension TestFlightChecker {
-    var isiOSSandboxBuild: Bool {
-        bundle.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    var isSandboxBuild: Bool {
+        guard let url = bundle.appStoreReceiptURL else {
+            NSLog("No Bundle.main.appStoreReceiptURL")
+            return false
+        }
+        NSLog("Bundle.main.appStoreReceiptURL = \(url)")
+        return bundle.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
     }
 }
 #endif


### PR DESCRIPTION
Reuse the same receipt trick from iOS.

Also, fix a regression in IAPManager.fetchLevelIfNeeded() from #903, where a guard after an await was dropped leading to reentrancy issues.