### PR TITLE
Retain on-demand flag on save profile

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "7b43f2a7f4d1955b0e7a2a029cce629264ee2a69"
+        "revision" : "e47fc3eb375d2fceb1597fee81b85460f6b0f0b3"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.11.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "7b43f2a7f4d1955b0e7a2a029cce629264ee2a69"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "e47fc3eb375d2fceb1597fee81b85460f6b0f0b3"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),


### PR DESCRIPTION
Regressed recently in library. When a profile was "Inactive (on-demand)", saving it would revert to "Inactive" because the underlying manager was being disabled.