### PR TITLE
Fix regressions in L&F

### DIFF
--- a/Passepartout/Library/Sources/CommonUtils/Views/View+Extensions.swift
+++ b/Passepartout/Library/Sources/CommonUtils/Views/View+Extensions.swift
@@ -69,12 +69,16 @@ extension View {
     }
 
     public func scrollableOnTV() -> some View {
+#if os(tvOS)
 //        focusable()
         Button {
             //
         } label: {
             self
         }
+#else
+        self
+#endif
     }
 }
 

--- a/Passepartout/Library/Sources/UILibrary/Views/About/PurchasedView.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/About/PurchasedView.swift
@@ -111,8 +111,7 @@ private extension PurchasedView {
                 HStack {
                     Text(feature.localizedDescription)
                     Spacer()
-                    ThemeImage(.marked)
-                        .opaque(iapManager.isEligible(for: feature))
+                    ThemeImage(iapManager.isEligible(for: feature) ? .marked : .close)
                 }
                 .scrollableOnTV()
             }

--- a/Passepartout/Library/Sources/UILibrary/Views/About/PurchasedView.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/About/PurchasedView.swift
@@ -39,7 +39,7 @@ public struct PurchasedView: View {
     }
 
     public var body: some View {
-        listView
+        contentView
             .themeEmpty(if: isEmpty, message: Strings.Views.Purchased.noPurchases)
             .onLoad {
                 Task {
@@ -64,8 +64,17 @@ private extension PurchasedView {
 }
 
 private extension PurchasedView {
-    var listView: some View {
-        List {
+    var contentView: some View {
+#if os(macOS)
+        Form(content: sectionsGroup)
+            .themeForm()
+#else
+        List(content: sectionsGroup)
+#endif
+    }
+
+    func sectionsGroup() -> some View {
+        Group {
             downloadSection
             productsSection
             featuresSection


### PR DESCRIPTION
- Text appearance on iOS/macOS (broken by #943)
- Visual ambiguity in "Purchased" when no feature is eligible
- "Purchased" must be a form on macOS