### PR TITLE
Add provider profile from toolbar

### DIFF
--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "e47fc3eb375d2fceb1597fee81b85460f6b0f0b3"
+        "revision" : "dd4d614e9334b0a788cf8216793471074d1ec5dd"
       }
     },
     {

--- a/Passepartout/Library/Package.swift
+++ b/Passepartout/Library/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.11.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "e47fc3eb375d2fceb1597fee81b85460f6b0f0b3"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "dd4d614e9334b0a788cf8216793471074d1ec5dd"),
 //        .package(path: "../../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Passepartout/Library/Sources/AppUIMain/Business/ProfileImporter.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Business/ProfileImporter.swift
@@ -123,10 +123,7 @@ private extension ProfileImporter {
         }
 
         let module = try registry.module(fromURL: url, object: passphrase)
-        var onDemandModuleBuilder = OnDemandModule.Builder()
-        onDemandModuleBuilder.isEnabled = false
-        onDemandModuleBuilder.policy = .any
-        let onDemandModule = onDemandModuleBuilder.tryBuild()
+        let onDemandModule = OnDemandModule.Builder().tryBuild()
 
         var builder = Profile.Builder()
         builder.name = url.lastPathComponent

--- a/Passepartout/Library/Sources/AppUIMain/Business/ProfileImporter.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Business/ProfileImporter.swift
@@ -125,6 +125,7 @@ private extension ProfileImporter {
         let module = try registry.module(fromURL: url, object: passphrase)
         var onDemandModuleBuilder = OnDemandModule.Builder()
         onDemandModuleBuilder.isEnabled = false
+        onDemandModuleBuilder.policy = .any
         let onDemandModule = onDemandModuleBuilder.tryBuild()
 
         var builder = Profile.Builder()

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -85,7 +85,7 @@ private extension AddProfileMenu {
             onSelect: {
                 var copy = $0
                 copy.name = newName
-                onNewProfile(copy, nil)
+                onNewProfile(copy, copy.modules.first?.id)
             }
         )
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -133,7 +133,7 @@ private struct ProvidersSubmenu: View {
         Button(provider.description) {
             var editable = EditableProfile()
             if var newModule = moduleType.newModule(with: registry) as? any ProviderModuleBuilder {
-                newModule.providerId = .protonvpn
+                newModule.providerId = provider.id
                 editable.modules.append(newModule)
             }
             editable.modules.append(OnDemandModule.Builder())

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -55,7 +55,7 @@ private extension AddProfileMenu {
             let profile = profileManager.new(withName: Strings.Placeholders.Profile.name)
             onNewProfile(profile)
         } label: {
-            ThemeImageLabel(Strings.Views.App.Toolbar.newProfile, .profileEdit)
+            ThemeImageLabel(Strings.Views.App.Toolbar.newProfile.withTrailingDots, .profileEdit)
         }
     }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -43,6 +43,7 @@ struct AddProfileMenu: View {
         Menu {
             emptyProfileButton
             importProfileButton
+            providerProfileMenu
             Divider()
             migrateProfilesButton
         } label: {
@@ -69,6 +70,25 @@ private extension AddProfileMenu {
         }
     }
 
+    var providerProfileMenu: some View {
+        Menu {
+            ForEach(supportedProviders, content: providerProfileButton(for:))
+        } label: {
+            ThemeImageLabel(Strings.Views.App.Toolbar.NewProfile.provider, .profileProvider)
+        }
+    }
+
+    func providerProfileButton(for moduleType: ModuleType) -> some View {
+        Button(ModuleType.openVPN.localizedDescription) {
+            var editable = EditableProfile(name: newName)
+            let newModule = moduleType.newModule(with: registry)
+            editable.modules.append(newModule)
+            editable.modules.append(OnDemandModule.Builder())
+            editable.activeModulesIds = Set(editable.modules.map(\.id))
+            onNewProfile(editable)
+        }
+    }
+
     var migrateProfilesButton: some View {
         Button(action: onMigrateProfiles) {
             ThemeImageLabel(Strings.Views.App.Toolbar.migrateProfiles.withTrailingDots, .profileMigrate)
@@ -79,5 +99,9 @@ private extension AddProfileMenu {
 private extension AddProfileMenu {
     var newName: String {
         profileManager.firstUniqueName(from: Strings.Placeholders.Profile.name)
+    }
+
+    var supportedProviders: [ModuleType] {
+        [.openVPN]
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -102,7 +102,7 @@ private extension AddProfileMenu {
         profileManager.firstUniqueName(from: Strings.Placeholders.Profile.name)
     }
 
-    // FIXME: #899, this should be global and reused by #657
+    // TODO: #657, define this list in a single global place
     var supportedModuleTypes: [ModuleType] {
         [.openVPN]
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -30,16 +30,18 @@ import SwiftUI
 struct AddProfileMenu: View {
     let profileManager: ProfileManager
 
+    let registry: Registry
+
     @Binding
     var isImporting: Bool
 
     let onMigrateProfiles: () -> Void
 
-    let onNewProfile: (Profile) -> Void
+    let onNewProfile: (EditableProfile) -> Void
 
     var body: some View {
         Menu {
-            newProfileButton
+            emptyProfileButton
             importProfileButton
             Divider()
             migrateProfilesButton
@@ -50,12 +52,12 @@ struct AddProfileMenu: View {
 }
 
 private extension AddProfileMenu {
-    var newProfileButton: some View {
+    var emptyProfileButton: some View {
         Button {
-            let profile = profileManager.new(withName: Strings.Placeholders.Profile.name)
-            onNewProfile(profile)
+            let editable = EditableProfile(name: newName)
+            onNewProfile(editable)
         } label: {
-            ThemeImageLabel(Strings.Views.App.Toolbar.newProfile.withTrailingDots, .profileEdit)
+            ThemeImageLabel(Strings.Views.App.Toolbar.NewProfile.empty.withTrailingDots, .profileEdit)
         }
     }
 
@@ -71,5 +73,11 @@ private extension AddProfileMenu {
         Button(action: onMigrateProfiles) {
             ThemeImageLabel(Strings.Views.App.Toolbar.migrateProfiles.withTrailingDots, .profileMigrate)
         }
+    }
+}
+
+private extension AddProfileMenu {
+    var newName: String {
+        profileManager.firstUniqueName(from: Strings.Placeholders.Profile.name)
     }
 }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -37,7 +37,7 @@ struct AddProfileMenu: View {
 
     let onMigrateProfiles: () -> Void
 
-    let onNewProfile: (EditableProfile) -> Void
+    let onNewProfile: (EditableProfile, UUID?) -> Void
 
     var body: some View {
         Menu {
@@ -56,7 +56,7 @@ private extension AddProfileMenu {
     var emptyProfileButton: some View {
         Button {
             let editable = EditableProfile(name: newName)
-            onNewProfile(editable)
+            onNewProfile(editable, nil)
         } label: {
             ThemeImageLabel(Strings.Views.App.Toolbar.NewProfile.empty.withTrailingDots, .profileEdit)
         }
@@ -85,7 +85,7 @@ private extension AddProfileMenu {
             onSelect: {
                 var copy = $0
                 copy.name = newName
-                onNewProfile(copy)
+                onNewProfile(copy, nil)
             }
         )
     }

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -175,7 +175,7 @@ extension AppCoordinator {
                     guard let profile = profileManager.profile(withId: $0.id) else {
                         return
                     }
-                    enterDetail(of: profile)
+                    enterDetail(of: profile.editable())
                 },
                 onMigrateProfiles: {
                     modalRoute = .migrateProfiles
@@ -196,6 +196,7 @@ extension AppCoordinator {
     func toolbarContent() -> some ToolbarContent {
         AppToolbar(
             profileManager: profileManager,
+            registry: registry,
             layout: $layout,
             isImporting: $isImporting,
             onPreferences: {
@@ -264,7 +265,7 @@ extension AppCoordinator {
 #endif
     }
 
-    func enterDetail(of profile: Profile) {
+    func enterDetail(of profile: EditableProfile) {
         profilePath = NavigationPath()
         let isShared = profileManager.isRemotelyShared(profileWithId: profile.id)
         profileEditor.editProfile(profile, isShared: isShared)

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -99,7 +99,7 @@ extension AppCoordinator {
     enum ModalRoute: Identifiable, Equatable {
         case about
 
-        case editProfile
+        case editProfile(UUID?)
 
         case editProviderEntity(Profile, Module, SerializedProvider)
 
@@ -175,7 +175,7 @@ extension AppCoordinator {
                     guard let profile = profileManager.profile(withId: $0.id) else {
                         return
                     }
-                    enterDetail(of: profile.editable())
+                    enterDetail(of: profile.editable(), initialModuleId: nil)
                 },
                 onMigrateProfiles: {
                     modalRoute = .migrateProfiles
@@ -221,10 +221,11 @@ extension AppCoordinator {
                 tunnel: tunnel
             )
 
-        case .editProfile:
+        case .editProfile(let initialModuleId):
             ProfileCoordinator(
                 profileManager: profileManager,
                 profileEditor: profileEditor,
+                initialModuleId: initialModuleId,
                 registry: registry,
                 moduleViewFactory: DefaultModuleViewFactory(registry: registry),
                 modally: true,
@@ -265,11 +266,11 @@ extension AppCoordinator {
 #endif
     }
 
-    func enterDetail(of profile: EditableProfile) {
+    func enterDetail(of profile: EditableProfile, initialModuleId: UUID?) {
         profilePath = NavigationPath()
         let isShared = profileManager.isRemotelyShared(profileWithId: profile.id)
         profileEditor.editProfile(profile, isShared: isShared)
-        present(.editProfile)
+        present(.editProfile(initialModuleId))
     }
 
     func onDismiss() {

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppToolbar.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppToolbar.swift
@@ -38,6 +38,8 @@ struct AppToolbar: ToolbarContent, SizeClassProviding {
 
     let profileManager: ProfileManager
 
+    let registry: Registry
+
     @Binding
     var layout: ProfilesLayout
 
@@ -50,7 +52,7 @@ struct AppToolbar: ToolbarContent, SizeClassProviding {
 
     let onMigrateProfiles: () -> Void
 
-    let onNewProfile: (Profile) -> Void
+    let onNewProfile: (EditableProfile) -> Void
 
     var body: some ToolbarContent {
         if isBigDevice {
@@ -75,6 +77,7 @@ private extension AppToolbar {
     var addProfileMenu: some View {
         AddProfileMenu(
             profileManager: profileManager,
+            registry: registry,
             isImporting: $isImporting,
             onMigrateProfiles: onMigrateProfiles,
             onNewProfile: onNewProfile
@@ -108,6 +111,7 @@ private extension AppToolbar {
             .toolbar {
                 AppToolbar(
                     profileManager: .mock,
+                    registry: Registry(),
                     layout: .constant(.list),
                     isImporting: .constant(false),
                     onPreferences: {},

--- a/Passepartout/Library/Sources/AppUIMain/Views/App/AppToolbar.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/App/AppToolbar.swift
@@ -52,7 +52,7 @@ struct AppToolbar: ToolbarContent, SizeClassProviding {
 
     let onMigrateProfiles: () -> Void
 
-    let onNewProfile: (EditableProfile) -> Void
+    let onNewProfile: (EditableProfile, UUID?) -> Void
 
     var body: some ToolbarContent {
         if isBigDevice {
@@ -117,7 +117,7 @@ private extension AppToolbar {
                     onPreferences: {},
                     onAbout: {},
                     onMigrateProfiles: {},
-                    onNewProfile: { _ in }
+                    onNewProfile: { _, _ in }
                 )
             }
             .frame(width: 600, height: 400)

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -47,6 +47,8 @@ struct ProfileCoordinator: View {
 
     let profileEditor: ProfileEditor
 
+    let initialModuleId: UUID?
+
     let registry: Registry
 
     let moduleViewFactory: any ModuleViewFactory
@@ -82,6 +84,7 @@ private extension ProfileCoordinator {
 #if os(iOS)
         ProfileEditView(
             profileEditor: profileEditor,
+            initialModuleId: initialModuleId,
             moduleViewFactory: moduleViewFactory,
             path: $path,
             paywallReason: $paywallReason,
@@ -96,6 +99,7 @@ private extension ProfileCoordinator {
 #else
         ProfileSplitView(
             profileEditor: profileEditor,
+            initialModuleId: initialModuleId,
             moduleViewFactory: moduleViewFactory,
             paywallReason: $paywallReason,
             flow: .init(
@@ -164,6 +168,7 @@ private extension ProfileCoordinator {
     ProfileCoordinator(
         profileManager: .mock,
         profileEditor: ProfileEditor(profile: .newMockProfile()),
+        initialModuleId: nil,
         registry: Registry(),
         moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
         modally: false,

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -35,6 +35,8 @@ struct ProfileEditView: View, Routable {
     @ObservedObject
     var profileEditor: ProfileEditor
 
+    let initialModuleId: UUID?
+
     let moduleViewFactory: any ModuleViewFactory
 
     @Binding
@@ -66,6 +68,11 @@ struct ProfileEditView: View, Routable {
         .navigationTitle(Strings.Global.Nouns.profile)
         .navigationBarBackButtonHidden(true)
         .navigationDestination(for: NavigationRoute.self, destination: pushDestination)
+        .onLoad {
+            if let initialModuleId {
+                push(.moduleDetail(moduleId: initialModuleId))
+            }
+        }
     }
 }
 
@@ -183,6 +190,7 @@ private extension ProfileEditView {
     NavigationStack {
         ProfileEditView(
             profileEditor: ProfileEditor(profile: .newMockProfile()),
+            initialModuleId: nil,
             moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
             path: .constant(NavigationPath()),
             paywallReason: .constant(nil)

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
@@ -33,6 +33,8 @@ import SwiftUI
 struct ProfileSplitView: View, Routable {
     let profileEditor: ProfileEditor
 
+    let initialModuleId: UUID?
+
     let moduleViewFactory: any ModuleViewFactory
 
     @Binding
@@ -73,6 +75,11 @@ struct ProfileSplitView: View, Routable {
             .themeNavigationStack(path: $detailPath)
             .toolbar(content: toolbarContent)
             .environment(\.navigationPath, $detailPath)
+        }
+        .onLoad {
+            if let initialModuleId {
+                selectedModuleId = initialModuleId
+            }
         }
     }
 }
@@ -133,6 +140,7 @@ private extension ProfileSplitView {
 #Preview {
     ProfileSplitView(
         profileEditor: ProfileEditor(profile: .newMockProfile()),
+        initialModuleId: nil,
         moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
         paywallReason: .constant(nil)
     )

--- a/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -273,13 +273,16 @@ extension ProfileManager {
 // MARK: - Shortcuts
 
 extension ProfileManager {
-    public func new(withName name: String) -> Profile {
-        var builder = Profile.Builder()
-        builder.name = firstUniqueName(from: name)
-        do {
-            return try builder.tryBuild()
-        } catch {
-            fatalError("Unable to build new empty profile: \(error)")
+    public func firstUniqueName(from name: String) -> String {
+        let allNames = Set(allProfiles.values.map(\.name))
+        var newName = name
+        var index = 1
+        while true {
+            if !allNames.contains(newName) {
+                return newName
+            }
+            newName = [name, index.description].joined(separator: ".")
+            index += 1
         }
     }
 
@@ -294,21 +297,6 @@ extension ProfileManager {
         let copy = try builder.tryBuild()
 
         try await save(copy)
-    }
-}
-
-private extension ProfileManager {
-    func firstUniqueName(from name: String) -> String {
-        let allNames = Set(allProfiles.values.map(\.name))
-        var newName = name
-        var index = 1
-        while true {
-            if !allNames.contains(newName) {
-                return newName
-            }
-            newName = [name, index.description].joined(separator: ".")
-            index += 1
-        }
     }
 }
 

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/EditableProfile.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/EditableProfile.swift
@@ -43,7 +43,7 @@ public struct EditableProfile: MutableProfileType {
         id: UUID = UUID(),
         name: String = "",
         modules: [any ModuleBuilder] = [],
-        activeModulesIds: Set<UUID>,
+        activeModulesIds: Set<UUID> = [],
         modulesMetadata: [UUID: ModuleMetadata]? = nil,
         userInfo: [String: AnyHashable]? = nil
     ) {

--- a/Passepartout/Library/Sources/CommonLibrary/Domain/ModuleType+New.swift
+++ b/Passepartout/Library/Sources/CommonLibrary/Domain/ModuleType+New.swift
@@ -45,9 +45,7 @@ extension ModuleType {
             return IPModule.Builder()
 
         case .onDemand:
-            var builder = OnDemandModule.Builder()
-            builder.policy = .any
-            return builder
+            return OnDemandModule.Builder()
 
         default:
             fatalError("Unknown module type: \(rawValue)")

--- a/Passepartout/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Passepartout/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -58,8 +58,8 @@ public final class ProfileEditor: ObservableObject {
         removedModules = [:]
     }
 
-    public func editProfile(_ profile: Profile, isShared: Bool) {
-        editableProfile = profile.editable()
+    public func editProfile(_ profile: EditableProfile, isShared: Bool) {
+        editableProfile = profile
         self.isShared = isShared
         removedModules = [:]
     }

--- a/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -613,8 +613,12 @@ public enum Strings {
         public static let importProfile = Strings.tr("Localizable", "views.app.toolbar.import_profile", fallback: "Import profile")
         /// Migrate profiles
         public static let migrateProfiles = Strings.tr("Localizable", "views.app.toolbar.migrate_profiles", fallback: "Migrate profiles")
-        /// New profile
-        public static let newProfile = Strings.tr("Localizable", "views.app.toolbar.new_profile", fallback: "New profile")
+        public enum NewProfile {
+          /// Empty profile
+          public static let empty = Strings.tr("Localizable", "views.app.toolbar.new_profile.empty", fallback: "Empty profile")
+          /// Provider
+          public static let provider = Strings.tr("Localizable", "views.app.toolbar.new_profile.provider", fallback: "Provider")
+        }
       }
       public enum Tv {
         /// Open %@ on your iOS or macOS device and enable the "%@" toggle of a profile to make it appear here.

--- a/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -47,7 +47,8 @@
 "views.app.folders.add_profile" = "Add profile";
 "views.app.folders.no_profiles" = "No profiles";
 "views.app.folders.no_profiles.migrate" = "Migrate old profiles...";
-"views.app.toolbar.new_profile" = "New profile";
+"views.app.toolbar.new_profile.empty" = "Empty profile";
+"views.app.toolbar.new_profile.provider" = "Provider";
 "views.app.toolbar.import_profile" = "Import profile";
 "views.app.toolbar.migrate_profiles" = "Migrate profiles";
 "views.app.tv.header" = "Open %@ on your iOS or macOS device and enable the \"%@\" toggle of a profile to make it appear here.";

--- a/Passepartout/Library/Sources/UILibrary/Theme/Theme+ImageName.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Theme+ImageName.swift
@@ -50,6 +50,7 @@ extension Theme {
         case profileEdit
         case profileImport
         case profileMigrate
+        case profileProvider
         case profilesGrid
         case profilesList
         case progress
@@ -101,6 +102,7 @@ extension Theme.ImageName {
             case .profileEdit: return "square.and.pencil"
             case .profileImport: return "square.and.arrow.down"
             case .profileMigrate: return "arrow.up.square"
+            case .profileProvider: return "network"
             case .profilesGrid: return "square.grid.2x2"
             case .profilesList: return "rectangle.grid.1x2"
             case .progress: return "clock"

--- a/Passepartout/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
+++ b/Passepartout/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
@@ -339,8 +339,8 @@ extension ProfileManagerTests {
         try await waitForReady(sut)
         XCTAssertEqual(sut.previews.count, 1)
 
-        let newProfile = sut.new(withName: profile.name)
-        XCTAssertEqual(newProfile.name, "example.1")
+        let newName = sut.firstUniqueName(from: profile.name)
+        XCTAssertEqual(newName, "example.1")
     }
 
     func test_givenRepository_whenDuplicate_thenSavesProfileWithNewName() async throws {


### PR DESCRIPTION
Create profile with a provider module and an on-demand module (disabled) to speed up initial provider selection and configuration. Supports OpenVPN for now.

Fixes #899 