### PR TITLE
Inform about use of profile name in Shortcuts

### DIFF
--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/NameSection.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/NameSection.swift
@@ -32,14 +32,23 @@ struct NameSection: View {
 
     let placeholder: String
 
+    var footer: String?
+
     var body: some View {
         debugChanges()
         return Group {
             ThemeTextField(Strings.Global.Nouns.name, text: $name, placeholder: placeholder)
                 .labelsHidden()
                 .themeManualInput()
+
+#if os(macOS)
+            footer.map {
+                Text($0)
+                    .themeFooter()
+            }
+#endif
         }
-        .themeSection(header: Strings.Global.Nouns.name)
+        .themeSection(header: Strings.Global.Nouns.name, footer: footer)
     }
 }
 

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileNameSection.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/ProfileNameSection.swift
@@ -1,8 +1,8 @@
 //
-//  ProfileGeneralView.swift
+//  ProfileNameSection.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 6/25/24.
+//  Created by Davide De Rosa on 11/27/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,40 +23,19 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#if os(macOS)
-
-import CommonLibrary
 import SwiftUI
+import UILibrary
 
-struct ProfileGeneralView: View {
-
-    @ObservedObject
-    var profileEditor: ProfileEditor
+struct ProfileNameSection: View {
 
     @Binding
-    var paywallReason: PaywallReason?
+    var name: String
 
     var body: some View {
-        Form {
-            ProfileNameSection(
-                name: $profileEditor.profile.name
-            )
-            StorageSection(
-                profileEditor: profileEditor,
-                paywallReason: $paywallReason
-            )
-            UUIDSection(uuid: profileEditor.profile.id)
-        }
-        .themeForm()
+        NameSection(
+            name: $name,
+            placeholder: Strings.Placeholders.Profile.name,
+            footer: Strings.Views.Profile.Sections.Name.footer
+        )
     }
 }
-
-#Preview {
-    ProfileGeneralView(
-        profileEditor: ProfileEditor(),
-        paywallReason: .constant(nil)
-    )
-    .withMockEnvironment()
-}
-
-#endif

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -55,7 +55,8 @@ struct ProfileEditView: View, Routable {
         return List {
             NameSection(
                 name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
+                placeholder: Strings.Placeholders.Profile.name,
+                footer: Strings.Views.Profile.Sections.Name.footer
             )
             modulesSection
             StorageSection(

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -53,10 +53,8 @@ struct ProfileEditView: View, Routable {
     var body: some View {
         debugChanges()
         return List {
-            NameSection(
-                name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name,
-                footer: Strings.Views.Profile.Sections.Name.footer
+            ProfileNameSection(
+                name: $profileEditor.profile.name
             )
             modulesSection
             StorageSection(

--- a/Passepartout/Library/Sources/AppUIMain/Views/Profile/macOS/ProfileGeneralView+macOS.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Profile/macOS/ProfileGeneralView+macOS.swift
@@ -40,7 +40,8 @@ struct ProfileGeneralView: View {
         Form {
             NameSection(
                 name: $profileEditor.profile.name,
-                placeholder: Strings.Placeholders.Profile.name
+                placeholder: Strings.Placeholders.Profile.name,
+                footer: Strings.Views.Profile.Sections.Name.footer
             )
             StorageSection(
                 profileEditor: profileEditor,

--- a/Passepartout/Library/Sources/AppUIMain/Views/Providers/ProviderContentModifier.swift
+++ b/Passepartout/Library/Sources/AppUIMain/Views/Providers/ProviderContentModifier.swift
@@ -98,7 +98,7 @@ private extension ProviderContentModifier {
                 HStack {
                     lastUpdatedString.map {
                         Text($0)
-                            .foregroundStyle(.secondary)
+                            .themeFooter()
                     }
                     Spacer()
                     RefreshInfrastructureButton(apis: apis, providerId: providerId)

--- a/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Passepartout/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -804,6 +804,12 @@ public enum Strings {
         /// Add module
         public static let addModule = Strings.tr("Localizable", "views.profile.rows.add_module", fallback: "Add module")
       }
+      public enum Sections {
+        public enum Name {
+          /// Use this name to create your VPN automations from the Shortcuts app.
+          public static let footer = Strings.tr("Localizable", "views.profile.sections.name.footer", fallback: "Use this name to create your VPN automations from the Shortcuts app.")
+        }
+      }
     }
     public enum Providers {
       /// Clear filters

--- a/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -99,6 +99,7 @@
 "views.preferences.erase_icloud" = "Erase iCloud store";
 "views.preferences.erase_icloud.footer" = "To erase the iCloud store securely, do so on all your synced devices. This will not affect local profiles.";
 
+"views.profile.sections.name.footer" = "Use this name to create your VPN automations from the Shortcuts app.";
 "views.profile.rows.add_module" = "Add module";
 "views.profile.module_list.section.footer" = "Drag modules to rearrange them, as their order determines priority.";
 "views.profile.alerts.purchase.buttons.ok" = "Save anyway";

--- a/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+macOS.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/Platforms/Theme+macOS.swift
@@ -91,8 +91,7 @@ extension ThemeRowWithFooterModifier {
 
             footer.map {
                 Text($0)
-                    .foregroundStyle(.secondary)
-                    .font(.subheadline)
+                    .themeFooter()
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }

--- a/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
+++ b/Passepartout/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
@@ -143,6 +143,11 @@ extension View {
         modifier(ThemeRowWithFooterModifier(footer: footer))
     }
 
+    public func themeFooter() -> some View {
+        foregroundStyle(.secondary)
+            .font(.subheadline)
+    }
+
     public func themeSectionWithSingleRow(header: String? = nil, footer: String, above: Bool = false) -> some View {
         Group {
             if above {

--- a/Passepartout/Library/Sources/UILibrary/Views/UI/NameSection.swift
+++ b/Passepartout/Library/Sources/UILibrary/Views/UI/NameSection.swift
@@ -25,16 +25,22 @@
 
 import SwiftUI
 
-struct NameSection: View {
+public struct NameSection: View {
 
     @Binding
-    var name: String
+    private var name: String
 
-    let placeholder: String
+    private let placeholder: String
 
-    var footer: String?
+    private let footer: String?
 
-    var body: some View {
+    public init(name: Binding<String>, placeholder: String, footer: String? = nil) {
+        _name = name
+        self.placeholder = placeholder
+        self.footer = footer
+    }
+
+    public var body: some View {
         debugChanges()
         return Group {
             ThemeTextField(Strings.Global.Nouns.name, text: $name, placeholder: placeholder)


### PR DESCRIPTION
Now that Siri is superseded by the more general Shortcuts automations, add an informational footer below the "Name" field of the profile editor.