### PR TITLE
Extend ProfileManager events

### DIFF
--- a/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -356,6 +356,7 @@ private extension ProfileManager {
 
 private extension ProfileManager {
     func reloadLocalProfiles(_ result: [Profile]) {
+        objectWillChange.send()
         pp_log(.App.profiles, .info, "Reload local profiles: \(result.map(\.id))")
 
         let excludedIds = Set(result
@@ -378,8 +379,6 @@ private extension ProfileManager {
             waitingObservers.remove(.local)
         }
 
-        objectWillChange.send()
-
         if !excludedIds.isEmpty {
             pp_log(.App.profiles, .info, "Delete excluded profiles from repository: \(excludedIds)")
             Task {
@@ -390,7 +389,9 @@ private extension ProfileManager {
     }
 
     func reloadRemoteProfiles(_ result: [Profile]) {
+        objectWillChange.send()
         pp_log(.App.profiles, .info, "Reload remote profiles: \(result.map(\.id))")
+
         allRemoteProfiles = result.reduce(into: [:]) {
             $0[$1.id] = $1
         }
@@ -402,8 +403,6 @@ private extension ProfileManager {
             await self?.importRemoteProfiles(result)
             self?.didChange.send(.stopRemoteImport)
         }
-
-        objectWillChange.send()
     }
 
     func importRemoteProfiles(_ profiles: [Profile]) async {
@@ -485,6 +484,7 @@ private extension ProfileManager {
     }
 
     func reloadFilteredProfiles(with search: String) {
+        objectWillChange.send()
         filteredProfiles = allProfiles
             .values
             .filter {
@@ -498,7 +498,5 @@ private extension ProfileManager {
             }
 
         pp_log(.App.profiles, .notice, "Filter profiles with '\(search)' (\(filteredProfiles.count) results)")
-
-        objectWillChange.send()
     }
 }

--- a/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -35,7 +35,7 @@ public final class ProfileManager: ObservableObject {
         case remote
     }
 
-    public enum Event {
+    public enum Event: Equatable {
         case ready
 
         case save(Profile)
@@ -437,7 +437,7 @@ private extension ProfileManager {
             remoteImportTask = nil
         }
 
-        pp_log(.App.profiles, .info, "Start importing remote profiles: \(profiles.map(\.id)))")
+        pp_log(.App.profiles, .info, "Start importing remote profiles: \(profiles.map(\.id))")
         assert(profiles.count == Set(profiles.map(\.id)).count, "Remote repository must not have duplicates")
 
         pp_log(.App.profiles, .debug, "Local attributes:")

--- a/Library/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Library/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -36,9 +36,17 @@ public final class ProfileManager: ObservableObject {
     }
 
     public enum Event {
+        case ready
+
         case save(Profile)
 
         case remove([Profile.ID])
+
+        case localProfiles
+
+        case filteredProfiles
+
+        case remoteProfiles
 
         case startRemoteImport
 
@@ -63,14 +71,24 @@ public final class ProfileManager: ObservableObject {
 
     private var allProfiles: [Profile.ID: Profile] {
         didSet {
+            didChange.send(.localProfiles)
+
             reloadFilteredProfiles(with: searchSubject.value)
             reloadRequiredFeatures()
         }
     }
 
-    private var allRemoteProfiles: [Profile.ID: Profile]
+    private var allRemoteProfiles: [Profile.ID: Profile] {
+        didSet {
+            didChange.send(.remoteProfiles)
+        }
+    }
 
-    private var filteredProfiles: [Profile]
+    private var filteredProfiles: [Profile] {
+        didSet {
+            didChange.send(.filteredProfiles)
+        }
+    }
 
     @Published
     private var requiredFeatures: [Profile.ID: Set<AppFeature>]
@@ -78,7 +96,13 @@ public final class ProfileManager: ObservableObject {
     @Published
     public private(set) var isRemoteImportingEnabled: Bool
 
-    private var waitingObservers: Set<Observer>
+    private var waitingObservers: Set<Observer> {
+        didSet {
+            if isReady {
+                didChange.send(.ready)
+            }
+        }
+    }
 
     // MARK: Publishers
 

--- a/Library/Tests/AppUIMainTests/ProfileImporterTests.swift
+++ b/Library/Tests/AppUIMainTests/ProfileImporterTests.swift
@@ -58,7 +58,6 @@ extension ProfileImporterTests {
         let exp = expectation(description: "Save")
         profileManager
             .didChange
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 switch $0 {
                 case .save(let profile):
@@ -91,7 +90,6 @@ extension ProfileImporterTests {
         let exp = expectation(description: "Save")
         profileManager
             .didChange
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 switch $0 {
                 case .save(let profile):

--- a/Library/Tests/CommonLibraryTests/ExtendedTunnelTests.swift
+++ b/Library/Tests/CommonLibraryTests/ExtendedTunnelTests.swift
@@ -49,7 +49,6 @@ extension ExtendedTunnelTests {
         var didCall = false
         sut
             .$lastErrorCode
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 if !didCall, $0 != nil {
                     didCall = true
@@ -80,7 +79,6 @@ extension ExtendedTunnelTests {
         var didCall = false
         sut
             .$dataCount
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 if !didCall, $0 != nil {
                     didCall = true

--- a/Library/Tests/CommonLibraryTests/IAPManagerTests.swift
+++ b/Library/Tests/CommonLibraryTests/IAPManagerTests.swift
@@ -375,7 +375,6 @@ extension IAPManagerTests {
         sut
             .$eligibleFeatures
             .dropFirst()
-            .receive(on: ImmediateScheduler.shared)
             .sink { _ in
                 exp.fulfill()
             }
@@ -428,7 +427,6 @@ extension IAPManagerTests {
         sut
             .$eligibleFeatures
             .dropFirst()
-            .receive(on: ImmediateScheduler.shared)
             .sink { _ in
                 exp.fulfill()
             }

--- a/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
+++ b/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
@@ -235,7 +235,6 @@ extension ProfileManagerTests {
         let exp = expectation(description: "Backup")
         backupRepository
             .profilesPublisher
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 guard !$0.isEmpty else {
                     return
@@ -283,7 +282,6 @@ extension ProfileManagerTests {
         let exp = expectation(description: "Remote")
         remoteRepository
             .profilesPublisher
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 guard !$0.isEmpty else {
                     return
@@ -312,7 +310,6 @@ extension ProfileManagerTests {
         let exp = expectation(description: "Remote")
         remoteRepository
             .profilesPublisher
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 guard $0.isEmpty else {
                     return
@@ -696,7 +693,6 @@ private extension ProfileManagerTests {
     func observeRemoteImport(_ sut: ProfileManager, block: @escaping () -> Void) {
         sut
             .didChange
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 if case .stopRemoteImport = $0 {
                     block()

--- a/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
+++ b/Library/Tests/CommonLibraryTests/ProfileManagerTests.swift
@@ -79,12 +79,11 @@ extension ProfileManagerTests {
         XCTAssertTrue(sut.hasProfiles)
         XCTAssertEqual(sut.previews.count, 2)
 
-        try await wait(sut, "Search") {
+        try await wait(sut, "Search", until: .filteredProfiles) {
             $0.search(byName: "ar")
-        } until: {
-            $0.previews.count == 1
         }
         XCTAssertTrue(sut.isSearching)
+        XCTAssertEqual(sut.previews.count, 1)
         let found = try XCTUnwrap(sut.previews.last)
         XCTAssertEqual(found.id, profile2.id)
     }
@@ -163,10 +162,8 @@ extension ProfileManagerTests {
         XCTAssertFalse(sut.hasProfiles)
 
         let profile = newProfile()
-        try await wait(sut, "Save") {
+        try await wait(sut, "Save", until: .save(profile)) {
             try await $0.save(profile)
-        } until: {
-            $0.hasProfiles
         }
         XCTAssertEqual(sut.previews.count, 1)
         XCTAssertEqual(sut.profile(withId: profile.id), profile)
@@ -185,11 +182,10 @@ extension ProfileManagerTests {
         builder.name = "newName"
         let renamedProfile = try builder.tryBuild()
 
-        try await wait(sut, "Save") {
+        try await wait(sut, "Save", until: .save(renamedProfile)) {
             try await $0.save(renamedProfile)
-        } until: {
-            $0.previews.first?.name == renamedProfile.name
         }
+        XCTAssertEqual(sut.previews.first?.name, renamedProfile.name)
     }
 
     func test_givenRepositoryAndProcessor_whenSave_thenProcessorIsNotInvoked() async throws {
@@ -257,10 +253,8 @@ extension ProfileManagerTests {
         XCTAssertTrue(sut.isReady)
         XCTAssertTrue(sut.hasProfiles)
 
-        try await wait(sut, "Remove") {
+        try await wait(sut, "Remove", until: .remove([profile.id])) {
             await $0.remove(withId: profile.id)
-        } until: {
-            !$0.hasProfiles
         }
         XCTAssertTrue(sut.previews.isEmpty)
     }
@@ -347,23 +341,20 @@ extension ProfileManagerTests {
 
         try await waitForReady(sut)
 
-        try await wait(sut, "Duplicate 1") {
+        try await wait(sut, "Duplicate 1", until: .localProfiles) {
             try await $0.duplicate(profileWithId: profile.id)
-        } until: {
-            $0.previews.count == 2
         }
+        XCTAssertEqual(sut.previews.count, 2)
 
-        try await wait(sut, "Duplicate 2") {
+        try await wait(sut, "Duplicate 2", until: .localProfiles) {
             try await $0.duplicate(profileWithId: profile.id)
-        } until: {
-            $0.previews.count == 3
         }
+        XCTAssertEqual(sut.previews.count, 3)
 
-        try await wait(sut, "Duplicate 3") {
+        try await wait(sut, "Duplicate 3", until: .localProfiles) {
             try await $0.duplicate(profileWithId: profile.id)
-        } until: {
-            $0.previews.count == 4
         }
+        XCTAssertEqual(sut.previews.count, 4)
 
         XCTAssertEqual(sut.previews.map(\.name), [
             "example",
@@ -394,12 +385,11 @@ extension ProfileManagerTests {
             remoteRepository
         })
 
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: {
-            $0.previews.count == allProfiles.count
         }
+        XCTAssertEqual(sut.previews.count, allProfiles.count)
 
         XCTAssertEqual(Set(sut.previews), Set(allProfiles.map { ProfilePreview($0) }))
         localProfiles.forEach {
@@ -431,12 +421,11 @@ extension ProfileManagerTests {
             remoteRepository
         })
 
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: {
-            $0.previews.count == 4 // unique IDs
         }
+        XCTAssertEqual(sut.previews.count, 4) // unique IDs
 
         sut.previews.forEach {
             switch $0.id {
@@ -479,15 +468,9 @@ extension ProfileManagerTests {
             remoteRepository
         }, processor: processor)
 
-        var didImport = false
-        observeRemoteImport(sut) {
-            didImport = true
-        }
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: { _ in
-            didImport
         }
 
         XCTAssertEqual(processor.isIncludedCount, allProfiles.count)
@@ -520,15 +503,9 @@ extension ProfileManagerTests {
             remoteRepository
         }, processor: processor)
 
-        var didImport = false
-        observeRemoteImport(sut) {
-            didImport = true
-        }
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: { _ in
-            didImport
         }
 
         try sut.previews.forEach {
@@ -558,12 +535,11 @@ extension ProfileManagerTests {
             remoteRepository
         })
 
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: {
-            $0.previews.count == localProfiles.count
         }
+        XCTAssertEqual(sut.previews.count, localProfiles.count)
 
         let r1 = UUID()
         let r2 = UUID()
@@ -572,7 +548,9 @@ extension ProfileManagerTests {
         let fp2 = UUID()
         let fp3 = UUID()
 
-        try await wait(sut, "Multiple imports") { _ in
+        try await wait(sut, "Multiple imports", until: .stopRemoteImport) {
+            $0.previews.count == 5
+        } after: { _ in
             remoteRepository.profiles = [
                 newProfile("remote1", id: r1)
             ]
@@ -585,8 +563,6 @@ extension ProfileManagerTests {
                 newProfile("remote2", id: r2, fingerprint: fp2),
                 newProfile("remote3", id: r3, fingerprint: fp3)
             ]
-        } until: {
-            $0.previews.count == 5
         }
 
         localProfiles.forEach {
@@ -617,22 +593,15 @@ extension ProfileManagerTests {
             remoteRepository
         })
 
-        var didImport = false
-        observeRemoteImport(sut) {
-            didImport = true
-        }
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: {
-            $0.previews.count == 1
         }
-        try await wait(sut, "Remote reset") { _ in
-            remoteRepository.profiles = []
-        } until: { _ in
-            didImport
-        }
+        XCTAssertEqual(sut.previews.count, 1)
 
+        try await wait(sut, "Remote reset", until: .stopRemoteImport) { _ in
+            remoteRepository.profiles = []
+        }
         XCTAssertEqual(sut.previews.count, 1)
         XCTAssertEqual(sut.previews.first, ProfilePreview(profile))
     }
@@ -641,25 +610,19 @@ extension ProfileManagerTests {
         let profile = newProfile()
         let localProfiles = [profile]
         let repository = InMemoryProfileRepository(profiles: localProfiles)
-        let remoteRepository = InMemoryProfileRepository()
+        let remoteRepository = InMemoryProfileRepository(profiles: localProfiles)
         let sut = ProfileManager(repository: repository, remoteRepositoryBlock: { _ in
             remoteRepository
         }, mirrorsRemoteRepository: true)
 
-        var didImport = false
-        observeRemoteImport(sut) {
-            didImport = true
-        }
-        try await wait(sut, "Remote import") {
+        try await wait(sut, "Remote import", until: .stopRemoteImport) {
             try await $0.observeLocal()
             try await $0.observeRemote(true)
-        } until: {
-            $0.previews.count == 1
         }
-        try await wait(sut, "Remote reset") { _ in
+        XCTAssertEqual(sut.previews.count, 1)
+
+        try await wait(sut, "Remote reset", until: .stopRemoteImport) { _ in
             remoteRepository.profiles = []
-        } until: { _ in
-            didImport
         }
         XCTAssertFalse(sut.hasProfiles)
     }
@@ -682,52 +645,33 @@ private extension ProfileManagerTests {
     }
 
     func waitForReady(_ sut: ProfileManager, importingRemote: Bool = true) async throws {
-        try await wait(sut, "Ready") {
+        try await wait(sut, "Ready", until: .ready) {
             try await $0.observeLocal()
             try await $0.observeRemote(importingRemote)
-        } until: {
-            $0.isReady
         }
-    }
-
-    func observeRemoteImport(_ sut: ProfileManager, block: @escaping () -> Void) {
-        sut
-            .didChange
-            .sink {
-                if case .stopRemoteImport = $0 {
-                    block()
-                }
-            }
-            .store(in: &subscriptions)
     }
 
     func wait(
         _ sut: ProfileManager,
         _ description: String,
-        after action: (ProfileManager) async throws -> Void,
-        until condition: @escaping (ProfileManager) -> Bool
+        until event: ProfileManager.Event,
+        condition: @escaping (ProfileManager) -> Bool = { _ in true },
+        after action: (ProfileManager) async throws -> Void
     ) async throws {
-        guard !condition(sut) else {
-            return
-        }
         let exp = expectation(description: description)
         var wasMet = false
 
-        Publishers.Merge(
-            sut.objectWillChange,
-            sut.didChange.map { _ in }
-        )
-        .receive(on: ImmediateScheduler.shared)
-        .sink {
-            guard !wasMet else {
-                return
+        sut.didChange
+            .sink {
+                guard !wasMet else {
+                    return
+                }
+                if $0 == event, condition(sut) {
+                    wasMet = true
+                    exp.fulfill()
+                }
             }
-            if condition(sut) {
-                wasMet = true
-                exp.fulfill()
-            }
-        }
-        .store(in: &subscriptions)
+            .store(in: &subscriptions)
 
         try await action(sut)
         await fulfillment(of: [exp], timeout: CommonLibraryTests.timeout)

--- a/Library/Tests/UILibraryTests/ProfileEditorTests.swift
+++ b/Library/Tests/UILibraryTests/ProfileEditorTests.swift
@@ -233,7 +233,6 @@ extension ProfileEditorTests {
         let exp = expectation(description: "Save")
         manager
             .didChange
-            .receive(on: ImmediateScheduler.shared)
             .sink {
                 switch $0 {
                 case .save(let savedProfile):


### PR DESCRIPTION
Especially for flaky tests:

- Do objectWillChange.send() _before_ performing the change
- Send more events to .didChange to be more deterministic about test expectations