### PR TITLE
Add guidance for OpenVPN provider credentials

### DIFF
--- a/Library/Package.resolved
+++ b/Library/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "dd4d614e9334b0a788cf8216793471074d1ec5dd"
+        "revision" : "5211efce28b6d96a38747a6004a4bf03e169b27c"
       }
     },
     {

--- a/Library/Package.swift
+++ b/Library/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.11.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "dd4d614e9334b0a788cf8216793471074d1ec5dd"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "5211efce28b6d96a38747a6004a4bf03e169b27c"),
 //        .package(path: "../../passepartoutkit-source"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "0.9.1"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "031863a1cd683962a7dfe68e20b91fa820a1ecce"),

--- a/Library/Sources/AppDataProviders/Domain/CDProviderV3.swift
+++ b/Library/Sources/AppDataProviders/Domain/CDProviderV3.swift
@@ -35,5 +35,6 @@ final class CDProviderV3: NSManagedObject {
     @NSManaged var providerId: String?
     @NSManaged var fullName: String?
     @NSManaged var supportedConfigurationIds: String?
+    @NSManaged var encodedConfigurations: Data? // [String: ProviderMetadata.Configuration]
     @NSManaged var lastUpdate: Date?
 }

--- a/Library/Sources/AppDataProviders/Domain/CoreDataMapper.swift
+++ b/Library/Sources/AppDataProviders/Domain/CoreDataMapper.swift
@@ -1,0 +1,76 @@
+//
+//  CoreDataMapper.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 10/28/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CoreData
+import Foundation
+import PassepartoutKit
+
+struct CoreDataMapper {
+    let context: NSManagedObjectContext
+
+    @discardableResult
+    func cdProvider(from metadata: ProviderMetadata, lastUpdate: Date?) throws -> CDProviderV3 {
+        let entity = CDProviderV3(context: context)
+        entity.providerId = metadata.id.rawValue
+        entity.fullName = metadata.description
+        entity.lastUpdate = lastUpdate
+        entity.supportedConfigurationIds = metadata.configurations.map(\.key).joined(separator: ",")
+        entity.encodedConfigurations = try JSONEncoder().encode(metadata.configurations)
+        return entity
+    }
+
+    @discardableResult
+    func cdServer(from server: VPNServer) throws -> CDVPNServerV3 {
+        let entity = CDVPNServerV3(context: context)
+        let encoder = JSONEncoder()
+        entity.serverId = server.serverId
+        entity.hostname = server.hostname
+        entity.ipAddresses = try server.ipAddresses.map {
+            try encoder.encode($0)
+        }
+        entity.providerId = server.provider.id.rawValue
+        entity.countryCode = server.provider.countryCode
+        entity.categoryName = server.provider.categoryName
+        entity.localizedCountry = server.provider.countryCode.localizedAsRegionCode
+        entity.otherCountryCodes = server.provider.otherCountryCodes?.joined(separator: ",")
+        entity.area = server.provider.area
+        entity.supportedConfigurationIds = server.provider.supportedConfigurationIdentifiers?.joined(separator: ",")
+        entity.supportedPresetIds = server.provider.supportedPresetIds?.joined(separator: ",")
+        return entity
+    }
+
+    @discardableResult
+    func cdPreset(from preset: AnyVPNPreset) throws -> CDVPNPresetV3 {
+        let entity = CDVPNPresetV3(context: self.context)
+        let encoder = JSONEncoder()
+        entity.presetId = preset.presetId
+        entity.providerId = preset.providerId.rawValue
+        entity.presetDescription = preset.description
+        entity.endpoints = try encoder.encode(preset.endpoints)
+        entity.configurationId = preset.configurationIdentifier
+        entity.configuration = preset.configuration
+        return entity
+    }
+}

--- a/Library/Sources/AppDataProviders/Providers.xcdatamodeld/Providers.xcdatamodel/contents
+++ b/Library/Sources/AppDataProviders/Providers.xcdatamodeld/Providers.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23H124" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="CDProviderV3" representedClassName="CDProviderV3" syncable="YES">
+        <attribute name="encodedConfigurations" optional="YES" attributeType="Binary"/>
         <attribute name="fullName" optional="YES" attributeType="String"/>
         <attribute name="lastUpdate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="providerId" optional="YES" attributeType="String"/>

--- a/Library/Sources/AppDataProviders/Strategy/CDProviderRepositoryV3.swift
+++ b/Library/Sources/AppDataProviders/Strategy/CDProviderRepositoryV3.swift
@@ -99,9 +99,9 @@ actor CDProviderRepositoryV3: NSObject, ProviderRepository {
 
                 // replace but retain last update
                 let mapper = CoreDataMapper(context: context)
-                index.forEach {
+                try index.forEach {
                     let lastUpdate = lastUpdatesByProvider[$0.id.rawValue]
-                    mapper.cdProvider(from: $0, lastUpdate: lastUpdate)
+                    try mapper.cdProvider(from: $0, lastUpdate: lastUpdate)
                 }
 
                 try context.save()

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -236,6 +236,7 @@ private extension OpenVPNView {
         case .credentials:
             Form {
                 OpenVPNCredentialsView(
+                    providerId: draft.providerId.wrappedValue,
                     isInteractive: draft.isInteractive,
                     credentials: draft.credentials
                 )

--- a/Library/Sources/CommonAPI/API/v5/providers/index.json
+++ b/Library/Sources/CommonAPI/API/v5/providers/index.json
@@ -2,50 +2,111 @@
     "metadata": [{
         "name": "hideme",
         "fullName": "Hide.me",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "ivpn",
         "fullName": "IVPN",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "mullvad",
         "fullName": "Mullvad",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "nordvpn",
         "fullName": "NordVPN",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {
+                "credentials": {
+                    "purpose": "specific",
+                    "url": "https://my.nordaccount.com/dashboard/nordvpn/manual-configuration/service-credentials/"
+                }
+            }
+        }
     }, {
         "name": "oeck",
         "fullName": "Oeck",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "pia",
         "fullName": "PIA",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "protonvpn",
         "fullName": "ProtonVPN",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {
+                "credentials": {
+                    "purpose": "specific",
+                    "url": "https://account.protonvpn.com/account-password"
+                }
+            }
+        }
     }, {
         "name": "surfshark",
         "fullName": "SurfShark",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {
+                "credentials": {
+                    "purpose": "specific",
+                    "url": "https://my.surfshark.com/vpn/manual-setup/main"
+                }
+            }
+        }
     }, {
         "name": "torguard",
         "fullName": "TorGuard",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {
+                "credentials": {
+                    "purpose": "specific",
+                    "url": "https://torguard.net/clientarea.php?action=changepw"
+                }
+            }
+        }
     }, {
         "name": "tunnelbear",
         "fullName": "TunnelBear",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "vyprvpn",
         "fullName": "VyprVPN",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {}
+        }
     }, {
         "name": "windscribe",
         "fullName": "Windscribe",
-        "vpn": ["ovpn"]
+        "vpn": ["ovpn"],
+        "configurations": {
+            "OpenVPN": {
+                "credentials": {
+                    "purpose": "specific",
+                    "url": "https://windscribe.com/getconfig/openvpn"
+                }
+            }
+        }
     }]
 }

--- a/Library/Sources/CommonLibrary/Domain/ProfileAttributes.swift
+++ b/Library/Sources/CommonLibrary/Domain/ProfileAttributes.swift
@@ -66,9 +66,9 @@ extension ProfileAttributes: CustomDebugStringConvertible {
     }
 }
 
-// MARK: - ProfileUserInfoTransformable
+// MARK: - UserInfoTransformable
 
-extension ProfileAttributes: ProfileUserInfoTransformable {
+extension ProfileAttributes: UserInfoTransformable {
     public var userInfo: [String: AnyHashable]? {
         do {
             let data = try JSONEncoder().encode(self)

--- a/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -478,12 +478,12 @@ public enum Strings {
         /// Interactive
         public static let interactive = Strings.tr("Localizable", "modules.openvpn.credentials.interactive", fallback: "Interactive")
         public enum Guidance {
-          /// See your credentials
-          public static let link = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.link", fallback: "See your credentials")
-          /// Use your service credentials, which may differ from website credentials.
-          public static let specific = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.specific", fallback: "Use your service credentials, which may differ from website credentials.")
-          /// Use your website credentials.
-          public static let web = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.web", fallback: "Use your website credentials.")
+          /// See your OpenVPN credentials
+          public static let link = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.link", fallback: "See your OpenVPN credentials")
+          /// Use your specific OpenVPN credentials, which differ from your account.
+          public static let specific = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.specific", fallback: "Use your specific OpenVPN credentials, which differ from your account.")
+          /// Use your account credentials.
+          public static let web = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.web", fallback: "Use your account credentials.")
         }
         public enum Interactive {
           /// On-demand will be disabled.

--- a/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -477,6 +477,14 @@ public enum Strings {
       public enum Credentials {
         /// Interactive
         public static let interactive = Strings.tr("Localizable", "modules.openvpn.credentials.interactive", fallback: "Interactive")
+        public enum Guidance {
+          /// See your credentials
+          public static let link = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.link", fallback: "See your credentials")
+          /// Use your service credentials, which may differ from website credentials.
+          public static let specific = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.specific", fallback: "Use your service credentials, which may differ from website credentials.")
+          /// Use your website credentials.
+          public static let web = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.web", fallback: "Use your website credentials.")
+        }
         public enum Interactive {
           /// On-demand will be disabled.
           public static let footer = Strings.tr("Localizable", "modules.openvpn.credentials.interactive.footer", fallback: "On-demand will be disabled.")

--- a/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -480,8 +480,8 @@ public enum Strings {
         public enum Guidance {
           /// See your OpenVPN credentials
           public static let link = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.link", fallback: "See your OpenVPN credentials")
-          /// Use your specific OpenVPN credentials, which differ from your account.
-          public static let specific = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.specific", fallback: "Use your specific OpenVPN credentials, which differ from your account.")
+          /// Use your specific OpenVPN credentials, which are not the same credentials you log in with.
+          public static let specific = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.specific", fallback: "Use your specific OpenVPN credentials, which are not the same credentials you log in with.")
           /// Use your account credentials.
           public static let web = Strings.tr("Localizable", "modules.openvpn.credentials.guidance.web", fallback: "Use your account credentials.")
         }

--- a/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -165,6 +165,9 @@
 "modules.openvpn.pull" = "Pull";
 "modules.openvpn.redirect_gateway" = "Redirect gateway";
 "modules.openvpn.credentials" = "Credentials";
+"modules.openvpn.credentials.guidance.web" = "Use your website credentials.";
+"modules.openvpn.credentials.guidance.specific" = "Use your service credentials, which may differ from website credentials.";
+"modules.openvpn.credentials.guidance.link" = "See your credentials";
 "modules.openvpn.remotes" = "Remotes";
 "modules.openvpn.communication" = "Communication";
 "modules.openvpn.cipher" = "Cipher";

--- a/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "modules.openvpn.redirect_gateway" = "Redirect gateway";
 "modules.openvpn.credentials" = "Credentials";
 "modules.openvpn.credentials.guidance.web" = "Use your account credentials.";
-"modules.openvpn.credentials.guidance.specific" = "Use your specific OpenVPN credentials, which differ from your account.";
+"modules.openvpn.credentials.guidance.specific" = "Use your specific OpenVPN credentials, which are not the same credentials you log in with.";
 "modules.openvpn.credentials.guidance.link" = "See your OpenVPN credentials";
 "modules.openvpn.remotes" = "Remotes";
 "modules.openvpn.communication" = "Communication";

--- a/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -165,9 +165,9 @@
 "modules.openvpn.pull" = "Pull";
 "modules.openvpn.redirect_gateway" = "Redirect gateway";
 "modules.openvpn.credentials" = "Credentials";
-"modules.openvpn.credentials.guidance.web" = "Use your website credentials.";
-"modules.openvpn.credentials.guidance.specific" = "Use your service credentials, which may differ from website credentials.";
-"modules.openvpn.credentials.guidance.link" = "See your credentials";
+"modules.openvpn.credentials.guidance.web" = "Use your account credentials.";
+"modules.openvpn.credentials.guidance.specific" = "Use your specific OpenVPN credentials, which differ from your account.";
+"modules.openvpn.credentials.guidance.link" = "See your OpenVPN credentials";
 "modules.openvpn.remotes" = "Remotes";
 "modules.openvpn.communication" = "Communication";
 "modules.openvpn.cipher" = "Cipher";

--- a/Library/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
+++ b/Library/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
@@ -31,6 +31,7 @@ extension OpenVPNModule.Builder: InteractiveViewProviding {
         let draft = editor[self]
 
         return OpenVPNCredentialsView(
+            providerId: draft.wrappedValue.providerId,
             isInteractive: draft.isInteractive,
             credentials: draft.credentials,
             isAuthenticating: true,

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/Passepartout.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/Passepartout.xcscheme
@@ -85,7 +85,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-pp_ui_testing"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-pp_fake_migration"


### PR DESCRIPTION
Some providers require specific credentials for OpenVPN, different from account credentials. Update the API index with this information to show an information footer and possibly a link to the OpenVPN credentials.

Also, fix the OTP footer not appearing on macOS.