### PR TITLE
Handle all connection attempts in AppCoordinator

### DIFF
--- a/Library/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
+++ b/Library/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
@@ -1,0 +1,96 @@
+//
+//  AppCoordinator+ModalRoute.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 11/29/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PassepartoutKit
+
+extension AppCoordinator {
+    enum ModalRoute: Identifiable, Equatable {
+        case about
+
+        case editProfile(UUID?)
+
+        case editProviderEntity(Profile, Bool, Module, SerializedProvider)
+
+        case interactiveLogin
+
+        case migrateProfiles
+
+        case preferences
+
+        var id: Int {
+            switch self {
+            case .about: return 1
+            case .editProfile: return 2
+            case .editProviderEntity: return 3
+            case .interactiveLogin: return 4
+            case .migrateProfiles: return 5
+            case .preferences: return 6
+            }
+        }
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.id == rhs.id
+        }
+
+        var size: ThemeModalSize {
+            switch self {
+            case .interactiveLogin:
+                return .custom(width: 500, height: 200)
+            case .migrateProfiles:
+                return .custom(width: 700, height: 400)
+            default:
+                return .large
+            }
+        }
+
+        var isFixedWidth: Bool {
+            switch self {
+            case .migrateProfiles:
+                return true
+            default:
+                return false
+            }
+        }
+
+        var isFixedHeight: Bool {
+            switch self {
+            case .migrateProfiles:
+                return true
+            default:
+                return false
+            }
+        }
+
+        var isInteractive: Bool {
+            switch self {
+            case .editProfile:
+                return false
+            default:
+                return true
+            }
+        }
+    }
+}

--- a/Library/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
+++ b/Library/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
@@ -27,7 +27,7 @@ import Foundation
 import PassepartoutKit
 
 extension AppCoordinator {
-    enum ModalRoute: Identifiable, Equatable {
+    enum ModalRoute: Identifiable {
         case about
 
         case editProfile(UUID?)
@@ -51,46 +51,59 @@ extension AppCoordinator {
             }
         }
 
-        static func == (lhs: Self, rhs: Self) -> Bool {
-            lhs.id == rhs.id
+        func options() -> ThemeModalOptions {
+            var options = ThemeModalOptions()
+            options.size = size
+            options.isFixedWidth = isFixedWidth
+            options.isFixedHeight = isFixedHeight
+            options.isInteractive = isInteractive
+            return options
         }
+    }
+}
 
-        var size: ThemeModalSize {
-            switch self {
-            case .interactiveLogin:
-                return .custom(width: 500, height: 200)
-            case .migrateProfiles:
-                return .custom(width: 700, height: 400)
-            default:
-                return .large
-            }
+extension AppCoordinator.ModalRoute: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+private extension AppCoordinator.ModalRoute {
+    var size: ThemeModalSize {
+        switch self {
+        case .interactiveLogin:
+            return .custom(width: 500, height: 200)
+        case .migrateProfiles:
+            return .custom(width: 700, height: 400)
+        default:
+            return .large
         }
+    }
 
-        var isFixedWidth: Bool {
-            switch self {
-            case .migrateProfiles:
-                return true
-            default:
-                return false
-            }
+    var isFixedWidth: Bool {
+        switch self {
+        case .migrateProfiles:
+            return true
+        default:
+            return false
         }
+    }
 
-        var isFixedHeight: Bool {
-            switch self {
-            case .migrateProfiles:
-                return true
-            default:
-                return false
-            }
+    var isFixedHeight: Bool {
+        switch self {
+        case .migrateProfiles:
+            return true
+        default:
+            return false
         }
+    }
 
-        var isInteractive: Bool {
-            switch self {
-            case .editProfile:
-                return false
-            default:
-                return true
-            }
+    var isInteractive: Bool {
+        switch self {
+        case .editProfile:
+            return false
+        default:
+            return true
         }
     }
 }

--- a/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -277,17 +277,7 @@ private extension AppCoordinator {
 
         pp_log(.app, .info, "Select new provider entity: \(entity)")
         do {
-            // FIXME: ###, move stuff like this to some ProfileFactory
-            guard var moduleBuilder = module.providerModuleBuilder() else {
-                assertionFailure("Module is not a ProviderModuleBuilder?")
-                return
-            }
-            try moduleBuilder.setProviderEntity(entity)
-            let newModule = try moduleBuilder.tryBuild()
-
-            var builder = profile.builder()
-            builder.saveModule(newModule)
-            let newProfile = try builder.tryBuild()
+            let newProfile = try profile.withEntity(entity, in: module)
 
             let wasConnected = newProfile.id == tunnel.currentProfile?.id && tunnel.status == .active
             try await profileManager.save(newProfile, isLocal: true)

--- a/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -95,14 +95,7 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
         .modifier(PaywallModifier(reason: $paywallReason))
         .themeModal(
             item: $modalRoute,
-            options: {
-                var options = ThemeModalOptions()
-                options.size = modalRoute?.size ?? .large
-                options.isFixedWidth = modalRoute?.isFixedWidth ?? false
-                options.isFixedHeight = modalRoute?.isFixedHeight ?? false
-                options.isInteractive = modalRoute?.isInteractive ?? true
-                return options
-            }(),
+            options: modalRoute?.options(),
             content: modalDestination
         )
         .onChange(of: interactiveManager.isPresented) {

--- a/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -236,7 +236,7 @@ extension AppCoordinator {
 
 extension AppCoordinator {
     public func onInteractiveLogin(_ profile: Profile, _ onComplete: @escaping InteractiveManager.CompletionBlock) {
-        pp_log(.app, .notice, "Present interactive login")
+        pp_log(.app, .info, "Present interactive login")
         interactiveManager.present(with: profile, onComplete: onComplete)
     }
 
@@ -244,10 +244,12 @@ extension AppCoordinator {
         guard let pair = profile.selectedProvider else {
             return
         }
+        pp_log(.app, .info, "Present provider entity selector")
         present(.editProviderEntity(profile, force, pair.module, pair.selection))
     }
 
     public func onPurchaseRequired(_ features: Set<AppFeature>) {
+        pp_log(.app, .info, "Present paywall for features: \(features)")
         setLater(.init(features, needsConfirmation: true)) {
             paywallReason = $0
         }

--- a/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Library/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -42,8 +42,6 @@ struct InstalledProfileView: View, Routable {
 
     let tunnel: ExtendedTunnel
 
-    let interactiveManager: InteractiveManager
-
     let errorHandler: ErrorHandler
 
     @Binding
@@ -111,7 +109,6 @@ private extension InstalledProfileView {
             tunnel: tunnel,
             profile: profile,
             nextProfileId: $nextProfileId,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             flow: flow
         )
@@ -124,7 +121,6 @@ private extension InstalledProfileView {
             profileManager: profileManager,
             tunnel: tunnel,
             preview: .init(profile ?? .forPreviews),
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             flow: flow
         )
@@ -135,7 +131,7 @@ private extension InstalledProfileView {
             .selectedProvider
             .map { _, selection in
                 Button {
-                    flow?.onProviderEntityRequired(profile!)
+                    flow?.connectionFlow?.onProviderEntityRequired(profile!)
                 } label: {
                     providerSelectorLabel(with: selection)
                 }
@@ -179,9 +175,6 @@ private struct ToggleButton: View {
     var nextProfileId: Profile.ID?
 
     @ObservedObject
-    var interactiveManager: InteractiveManager
-
-    @ObservedObject
     var errorHandler: ErrorHandler
 
     let flow: ProfileFlow?
@@ -191,14 +184,8 @@ private struct ToggleButton: View {
             tunnel: tunnel,
             profile: profile,
             nextProfileId: $nextProfileId,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
-            onProviderEntityRequired: {
-                flow?.onProviderEntityRequired($0)
-            },
-            onPurchaseRequired: {
-                flow?.onPurchaseRequired($0)
-            },
+            flow: flow?.connectionFlow,
             label: { _ in
                 ThemeImage(.tunnelToggle)
                     .scaleEffect(1.5, anchor: .trailing)
@@ -301,7 +288,6 @@ private struct HeaderView: View {
             profileManager: .forPreviews,
             profile: .forPreviews,
             tunnel: .forPreviews,
-            interactiveManager: InteractiveManager(),
             errorHandler: .default(),
             nextProfileId: .constant(nil)
         )
@@ -316,7 +302,6 @@ private struct ContentView: View {
                 profileManager: .forPreviews,
                 tunnel: .forPreviews,
                 preview: .init(.forPreviews),
-                interactiveManager: InteractiveManager(),
                 errorHandler: .default(),
                 nextProfileId: .constant(nil),
                 withMarker: true

--- a/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -103,16 +103,7 @@ private struct ContainerModifier: ViewModifier {
             .themeProgress(
                 if: !profileManager.isReady,
                 isEmpty: !profileManager.hasProfiles,
-                emptyContent: {
-                    VStack(spacing: 16) {
-                        Text(Strings.Views.App.Folders.noProfiles)
-                            .themeEmptyMessage(fullScreen: false)
-
-                        Button(Strings.Views.App.Folders.NoProfiles.migrate) {
-                            flow?.onMigrateProfiles()
-                        }
-                    }
-                }
+                emptyContent: emptyView
             )
             .searchable(text: $search)
             .onChange(of: search) {
@@ -120,6 +111,17 @@ private struct ContainerModifier: ViewModifier {
             }
             .themeAnimation(on: profileManager.isReady, category: .profiles)
             .themeAnimation(on: profileManager.previews, category: .profiles)
+    }
+
+    private func emptyView() -> some View {
+        VStack(spacing: 16) {
+            Text(Strings.Views.App.Folders.noProfiles)
+                .themeEmptyMessage(fullScreen: false)
+
+            Button(Strings.Views.App.Folders.NoProfiles.migrate) {
+                flow?.onMigrateProfiles()
+            }
+        }
     }
 }
 

--- a/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -45,9 +45,6 @@ struct ProfileContainerView: View, Routable {
 
     var flow: ProfileFlow?
 
-    @StateObject
-    private var interactiveManager = InteractiveManager()
-
     var body: some View {
         debugChanges()
         return innerView
@@ -62,7 +59,6 @@ struct ProfileContainerView: View, Routable {
                 errorHandler: errorHandler
             ))
             .navigationTitle(Strings.Unlocalized.appName)
-            .themeModal(isPresented: $interactiveManager.isPresented, content: interactiveDestination)
             .withErrorHandler(errorHandler)
     }
 }
@@ -76,7 +72,6 @@ private extension ProfileContainerView {
             ProfileListView(
                 profileManager: profileManager,
                 tunnel: tunnel,
-                interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 flow: flow
             )
@@ -85,22 +80,10 @@ private extension ProfileContainerView {
             ProfileGridView(
                 profileManager: profileManager,
                 tunnel: tunnel,
-                interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 flow: flow
             )
         }
-    }
-
-    func interactiveDestination() -> some View {
-        InteractiveCoordinator(style: .modal, manager: interactiveManager) {
-            errorHandler.handle(
-                $0,
-                title: interactiveManager.editor.profile.name,
-                message: Strings.Errors.App.tunnel
-            )
-        }
-        .presentationDetents([.medium])
     }
 }
 

--- a/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
@@ -46,8 +46,6 @@ struct ProfileContextMenu: View, Routable {
 
     let preview: ProfilePreview
 
-    let interactiveManager: InteractiveManager
-
     let errorHandler: ErrorHandler
 
     var flow: ProfileFlow?
@@ -78,14 +76,8 @@ private extension ProfileContextMenu {
             tunnel: tunnel,
             profile: profile,
             nextProfileId: .constant(nil),
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
-            onProviderEntityRequired: {
-                flow?.onProviderEntityRequired($0)
-            },
-            onPurchaseRequired: {
-                flow?.onPurchaseRequired($0)
-            },
+            flow: flow?.connectionFlow,
             label: {
                 ThemeImageLabel(
                     $0 ? Strings.Global.Actions.enable : Strings.Global.Actions.disable,
@@ -100,7 +92,7 @@ private extension ProfileContextMenu {
             ProviderConnectToButton(
                 profile: $0,
                 onTap: {
-                    flow?.onProviderEntityRequired($0)
+                    flow?.connectionFlow?.onProviderEntityRequired($0)
                 },
                 label: {
                     ThemeImageLabel(Strings.Views.App.ProfileContext.connectTo.withTrailingDots, .profileProvider)
@@ -115,9 +107,7 @@ private extension ProfileContextMenu {
             tunnel: tunnel,
             profile: profile,
             errorHandler: errorHandler,
-            onPurchaseRequired: {
-                flow?.onPurchaseRequired($0)
-            },
+            flow: flow?.connectionFlow,
             label: {
                 ThemeImageLabel(Strings.Global.Actions.restart, .tunnelRestart)
             }
@@ -161,7 +151,6 @@ private extension ProfileContextMenu {
                 profileManager: .forPreviews,
                 tunnel: .forPreviews,
                 preview: .init(.forPreviews),
-                interactiveManager: InteractiveManager(),
                 errorHandler: .default()
             )
         }

--- a/Library/Sources/AppUIMain/Views/App/ProfileFlow.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileFlow.swift
@@ -26,13 +26,12 @@
 import CommonLibrary
 import Foundation
 import PassepartoutKit
+import UILibrary
 
 struct ProfileFlow {
     let onEditProfile: (ProfilePreview) -> Void
 
     let onMigrateProfiles: () -> Void
 
-    let onProviderEntityRequired: (Profile) -> Void
-
-    let onPurchaseRequired: (Set<AppFeature>) -> Void
+    let connectionFlow: ConnectionFlow?
 }

--- a/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -39,8 +39,6 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
     @ObservedObject
     var tunnel: ExtendedTunnel
 
-    let interactiveManager: InteractiveManager
-
     let errorHandler: ErrorHandler
 
     var flow: ProfileFlow?
@@ -98,7 +96,6 @@ private extension ProfileGridView {
             profileManager: profileManager,
             profile: currentProfile,
             tunnel: tunnel,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             nextProfileId: $nextProfileId,
             flow: flow
@@ -110,7 +107,6 @@ private extension ProfileGridView {
                     profileManager: profileManager,
                     tunnel: tunnel,
                     preview: .init($0),
-                    interactiveManager: interactiveManager,
                     errorHandler: errorHandler,
                     flow: flow
                 )
@@ -124,7 +120,6 @@ private extension ProfileGridView {
             profileManager: profileManager,
             tunnel: tunnel,
             preview: preview,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             nextProfileId: $nextProfileId,
             withMarker: true,
@@ -137,7 +132,6 @@ private extension ProfileGridView {
                 profileManager: profileManager,
                 tunnel: tunnel,
                 preview: preview,
-                interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 flow: flow
             )
@@ -152,7 +146,6 @@ private extension ProfileGridView {
     ProfileGridView(
         profileManager: .forPreviews,
         tunnel: .forPreviews,
-        interactiveManager: InteractiveManager(),
         errorHandler: .default()
     )
     .themeWindow(width: 600, height: 300)

--- a/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -45,8 +45,6 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
     @ObservedObject
     var tunnel: ExtendedTunnel
 
-    let interactiveManager: InteractiveManager
-
     let errorHandler: ErrorHandler
 
     var flow: ProfileFlow?
@@ -88,7 +86,6 @@ private extension ProfileListView {
             profileManager: profileManager,
             profile: currentProfile,
             tunnel: tunnel,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             nextProfileId: $nextProfileId,
             flow: flow
@@ -100,7 +97,6 @@ private extension ProfileListView {
                     profileManager: profileManager,
                     tunnel: tunnel,
                     preview: .init($0),
-                    interactiveManager: interactiveManager,
                     errorHandler: errorHandler,
                     flow: flow
                 )
@@ -114,7 +110,6 @@ private extension ProfileListView {
             profileManager: profileManager,
             tunnel: tunnel,
             preview: preview,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             nextProfileId: $nextProfileId,
             withMarker: true,
@@ -126,7 +121,6 @@ private extension ProfileListView {
                 profileManager: profileManager,
                 tunnel: tunnel,
                 preview: preview,
-                interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 flow: flow
             )
@@ -151,7 +145,6 @@ private extension ProfileListView {
     ProfileListView(
         profileManager: .forPreviews,
         tunnel: .forPreviews,
-        interactiveManager: InteractiveManager(),
         errorHandler: .default()
     )
     .withMockEnvironment()

--- a/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -48,8 +48,6 @@ struct ProfileRowView: View, Routable, SizeClassProviding {
 
     let preview: ProfilePreview
 
-    let interactiveManager: InteractiveManager
-
     let errorHandler: ErrorHandler
 
     @Binding
@@ -147,14 +145,8 @@ private extension ProfileRowView {
             tunnel: tunnel,
             profile: profile,
             nextProfileId: $nextProfileId,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
-            onProviderEntityRequired: {
-                flow?.onProviderEntityRequired($0)
-            },
-            onPurchaseRequired: {
-                flow?.onPurchaseRequired($0)
-            },
+            flow: flow?.connectionFlow,
             label: { _ in
                 ProfileCardView(
                     style: style,
@@ -183,7 +175,6 @@ private extension ProfileRowView {
                 profileManager: profileManager,
                 tunnel: tunnel,
                 preview: preview,
-                interactiveManager: interactiveManager,
                 errorHandler: errorHandler,
                 flow: flow
             )
@@ -214,7 +205,6 @@ private extension ProfileRowView {
             profileManager: profileManager,
             tunnel: .forPreviews,
             preview: .init(profile),
-            interactiveManager: InteractiveManager(),
             errorHandler: .default(),
             nextProfileId: .constant(nil),
             withMarker: true

--- a/Library/Sources/AppUIMain/Views/App/TunnelRestartButton.swift
+++ b/Library/Sources/AppUIMain/Views/App/TunnelRestartButton.swift
@@ -37,7 +37,7 @@ struct TunnelRestartButton<Label>: View where Label: View {
 
     let errorHandler: ErrorHandler
 
-    let onPurchaseRequired: (Set<AppFeature>) -> Void
+    var flow: ConnectionFlow?
 
     let label: () -> Label
 
@@ -50,19 +50,7 @@ struct TunnelRestartButton<Label>: View where Label: View {
                 return
             }
             Task {
-                do {
-                    try await tunnel.connect(with: profile)
-                } catch AppError.ineligibleProfile(let requiredFeatures) {
-                    onPurchaseRequired(requiredFeatures)
-                } catch is CancellationError {
-                    //
-                } catch {
-                    errorHandler.handle(
-                        error,
-                        title: profile.name,
-                        message: Strings.Errors.App.tunnel
-                    )
-                }
+                await flow?.onConnect(profile)
             }
         } label: {
             label()

--- a/Library/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Library/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -131,7 +131,7 @@ private extension AppCoordinator {
 
 // MARK: - Handlers
 
-// FIXME: ### mostly duplicated from AppUIMain.AppCordinator
+// FIXME: ### duplicated from AppUIMain.AppCordinator
 private extension AppCoordinator {
     func onConnect(_ profile: Profile, force: Bool) async {
         do {
@@ -160,13 +160,6 @@ private extension AppCoordinator {
         interactiveManager.present(with: profile, onComplete: onComplete)
     }
 
-    func onProviderEntityRequired(_ profile: Profile) {
-        errorHandler.handle(
-            title: profile.name,
-            message: Strings.Alerts.Providers.MissingServer.message
-        )
-    }
-
     func onPurchaseRequired(_ features: Set<AppFeature>) {
         setLater(.init(features, needsConfirmation: true)) {
             paywallReason = $0
@@ -182,7 +175,16 @@ private extension AppCoordinator {
     }
 }
 
-// MARK: -
+private extension AppCoordinator {
+    func onProviderEntityRequired(_ profile: Profile) {
+        errorHandler.handle(
+            title: profile.name,
+            message: Strings.Alerts.Providers.MissingServer.message
+        )
+    }
+}
+
+// MARK: - Previews
 
 #Preview {
     AppCoordinator(

--- a/Library/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Library/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -135,7 +135,7 @@ private extension AppCoordinator {
 
 extension AppCoordinator {
     public func onInteractiveLogin(_ profile: Profile, _ onComplete: @escaping InteractiveManager.CompletionBlock) {
-        pp_log(.app, .notice, "Present interactive login")
+        pp_log(.app, .info, "Present interactive login")
         interactiveManager.present(with: profile, onComplete: onComplete)
     }
 
@@ -147,6 +147,7 @@ extension AppCoordinator {
     }
 
     public func onPurchaseRequired(_ features: Set<AppFeature>) {
+        pp_log(.app, .info, "Present paywall for features: \(features)")
         setLater(.init(features, needsConfirmation: true)) {
             paywallReason = $0
         }

--- a/Library/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
+++ b/Library/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
@@ -48,12 +48,9 @@ struct ActiveProfileView: View {
     var focusedField: ProfileView.Field?
 
     @ObservedObject
-    var interactiveManager: InteractiveManager
-
-    @ObservedObject
     var errorHandler: ErrorHandler
 
-    var flow: AppFlow?
+    var flow: ConnectionFlow?
 
     var body: some View {
         VStack(spacing: .zero) {
@@ -132,10 +129,8 @@ private extension ActiveProfileView {
             tunnel: tunnel,
             profile: profile,
             nextProfileId: .constant(nil),
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
-            onProviderEntityRequired: onProviderEntityRequired,
-            onPurchaseRequired: onPurchaseRequired,
+            flow: flow,
             label: {
                 Text($0 ? Strings.Global.Actions.connect : Strings.Global.Actions.disconnect)
                     .frame(maxWidth: .infinity)
@@ -166,16 +161,6 @@ private extension ActiveProfileView {
                 .padding(.vertical, 10)
         }
         .focused($focusedField, equals: .switchProfile)
-    }
-}
-
-private extension ActiveProfileView {
-    func onProviderEntityRequired(_ profile: Profile) {
-        flow?.onProviderEntityRequired(profile)
-    }
-
-    func onPurchaseRequired(_ features: Set<AppFeature>) {
-        flow?.onPurchaseRequired(features)
     }
 }
 
@@ -250,7 +235,6 @@ private struct ContentPreview: View {
             tunnel: .forPreviews,
             isSwitching: $isSwitching,
             focusedField: $focusedField,
-            interactiveManager: InteractiveManager(),
             errorHandler: .default()
         )
         .withMockEnvironment()

--- a/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Library/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -40,12 +40,9 @@ struct ProfileListView: View {
     var focusedField: ProfileView.Field?
 
     @ObservedObject
-    var interactiveManager: InteractiveManager
-
-    @ObservedObject
     var errorHandler: ErrorHandler
 
-    var flow: AppFlow?
+    var flow: ConnectionFlow?
 
     var body: some View {
         VStack {
@@ -80,10 +77,8 @@ private extension ProfileListView {
             tunnel: tunnel,
             profile: profileManager.profile(withId: preview.id),
             nextProfileId: .constant(nil),
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
-            onProviderEntityRequired: onProviderEntityRequired,
-            onPurchaseRequired: onPurchaseRequired,
+            flow: flow,
             label: { _ in
                 toggleView(for: preview)
             }
@@ -99,16 +94,6 @@ private extension ProfileListView {
                 .opaque(preview.id == tunnel.currentProfile?.id)
         }
         .font(.headline)
-    }
-}
-
-private extension ProfileListView {
-    func onProviderEntityRequired(_ profile: Profile) {
-        flow?.onProviderEntityRequired(profile)
-    }
-
-    func onPurchaseRequired(_ features: Set<AppFeature>) {
-        flow?.onPurchaseRequired(features)
     }
 }
 
@@ -133,7 +118,6 @@ private struct ContentPreview: View {
             profileManager: profileManager,
             tunnel: .forPreviews,
             focusedField: $focusedField,
-            interactiveManager: InteractiveManager(),
             errorHandler: .default()
         )
         .withMockEnvironment()

--- a/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Library/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -48,18 +48,18 @@ struct ProfileView: View, Routable, TunnelInstallationProviding {
     var tunnel: ExtendedTunnel
 
     @ObservedObject
+    var interactiveManager: InteractiveManager
+
+    @ObservedObject
     var errorHandler: ErrorHandler
 
-    var flow: AppFlow?
+    var flow: ConnectionFlow?
 
     @State
     var showsSidePanel = false
 
     @FocusState
     private var focusedField: Field?
-
-    @StateObject
-    private var interactiveManager = InteractiveManager()
 
     var body: some View {
         GeometryReader { geo in
@@ -104,7 +104,6 @@ private extension ProfileView {
             tunnel: tunnel,
             isSwitching: $showsSidePanel,
             focusedField: $focusedField,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             flow: flow
         )
@@ -145,7 +144,6 @@ private extension ProfileView {
             profileManager: profileManager,
             tunnel: tunnel,
             focusedField: $focusedField,
-            interactiveManager: interactiveManager,
             errorHandler: errorHandler,
             flow: flow
         )
@@ -192,6 +190,7 @@ private extension ProfileView {
     ProfileView(
         profileManager: .forPreviews,
         tunnel: .forPreviews,
+        interactiveManager: InteractiveManager(),
         errorHandler: .default(),
         showsSidePanel: true
     )
@@ -202,6 +201,7 @@ private extension ProfileView {
     ProfileView(
         profileManager: ProfileManager(profiles: []),
         tunnel: .forPreviews,
+        interactiveManager: InteractiveManager(),
         errorHandler: .default(),
         showsSidePanel: true
     )

--- a/Library/Sources/CommonLibrary/Business/ExtendedTunnel.swift
+++ b/Library/Sources/CommonLibrary/Business/ExtendedTunnel.swift
@@ -98,9 +98,12 @@ extension ExtendedTunnel {
         try await tunnel.install(newProfile, connect: false, title: processedTitle)
     }
 
-    public func connect(with profile: Profile) async throws {
+    public func connect(with profile: Profile, force: Bool = false) async throws {
         pp_log(.app, .notice, "Connect to profile \(profile.id)...")
         let newProfile = try processedProfile(profile)
+        if !force && newProfile.isInteractive {
+            throw AppError.interactiveLogin
+        }
         try await tunnel.install(newProfile, connect: true, title: processedTitle)
     }
 

--- a/Library/Sources/CommonLibrary/Domain/AppError.swift
+++ b/Library/Sources/CommonLibrary/Domain/AppError.swift
@@ -35,6 +35,8 @@ public enum AppError: Error {
 
     case ineligibleProfile(Set<AppFeature>)
 
+    case interactiveLogin
+
     case malformedModule(any ModuleBuilder, error: Error)
 
     case permissionDenied

--- a/Library/Sources/CommonLibrary/Extensions/Profile+Providers.swift
+++ b/Library/Sources/CommonLibrary/Extensions/Profile+Providers.swift
@@ -1,0 +1,42 @@
+//
+//  Profile+Providers.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 12/1/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PassepartoutKit
+
+extension Profile {
+    public func withEntity(_ entity: any ProviderEntity & Encodable, in module: Module) throws -> Profile {
+        guard var moduleBuilder = module.providerModuleBuilder() else {
+            assertionFailure("Module is not a ProviderModuleBuilder?")
+            return self
+        }
+        try moduleBuilder.setProviderEntity(entity)
+        let newModule = try moduleBuilder.tryBuild()
+
+        var builder = builder()
+        builder.saveModule(newModule)
+        return try builder.tryBuild()
+    }
+}

--- a/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Library/Sources/UILibrary/Business/AppContext.swift
@@ -199,14 +199,12 @@ private extension AppContext {
         }
         pendingTask = Task {
             do {
-                if profile.isInteractive {
-                    pp_log(.app, .info, "\tProfile \(profile.id) is interactive, disconnect")
-                    try await tunnel.disconnect()
-                    return
-                }
                 do {
                     pp_log(.app, .info, "\tReconnect profile \(profile.id)")
                     try await tunnel.connect(with: profile)
+                } catch AppError.interactiveLogin {
+                    pp_log(.app, .info, "\tProfile \(profile.id) is interactive, disconnect")
+                    try await tunnel.disconnect()
                 } catch {
                     pp_log(.app, .error, "\tUnable to reconnect profile \(profile.id), disconnect: \(error)")
                     try await tunnel.disconnect()

--- a/Library/Sources/UILibrary/Extensions/AppCoordinatorConforming+Extensions.swift
+++ b/Library/Sources/UILibrary/Extensions/AppCoordinatorConforming+Extensions.swift
@@ -1,0 +1,52 @@
+//
+//  AppCoordinatorConforming+Extensions.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 12/1/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import Foundation
+import PassepartoutKit
+
+extension AppCoordinatorConforming {
+    public func onConnect(_ profile: Profile, force: Bool) async {
+        do {
+            try iapManager.verify(profile)
+            try await tunnel.connect(with: profile, force: force)
+        } catch AppError.ineligibleProfile(let requiredFeatures) {
+            onPurchaseRequired(requiredFeatures)
+        } catch AppError.interactiveLogin {
+            onInteractiveLogin(profile) {
+                await onConnect($0, force: true)
+            }
+        } catch let ppError as PassepartoutError {
+            switch ppError.code {
+            case .missingProviderEntity:
+                onProviderEntityRequired(profile, force: force)
+            default:
+                onError(ppError, profile: profile)
+            }
+        } catch {
+            onError(error, profile: profile)
+        }
+    }
+}

--- a/Library/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Library/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -44,6 +44,9 @@ extension AppError: LocalizedError {
         case .ineligibleProfile:
             return nil
 
+        case .interactiveLogin:
+            return nil
+
         case .malformedModule(let module, let error):
             return V.malformedModule(module.moduleType.localizedDescription, error.localizedDescription)
 

--- a/Library/Sources/UILibrary/Strategy/AppCoordinatorConforming.swift
+++ b/Library/Sources/UILibrary/Strategy/AppCoordinatorConforming.swift
@@ -27,10 +27,17 @@ import CommonLibrary
 import Foundation
 import PassepartoutKit
 
+@MainActor
 public protocol AppCoordinatorConforming {
-    init(
-        profileManager: ProfileManager,
-        tunnel: ExtendedTunnel,
-        registry: Registry
-    )
+    var iapManager: IAPManager { get }
+
+    var tunnel: ExtendedTunnel { get }
+
+    func onInteractiveLogin(_ profile: Profile, _ onComplete: @escaping InteractiveManager.CompletionBlock)
+
+    func onProviderEntityRequired(_ profile: Profile, force: Bool)
+
+    func onPurchaseRequired(_ features: Set<AppFeature>)
+
+    func onError(_ error: Error, profile: Profile)
 }

--- a/Library/Sources/UILibrary/Views/UI/ConnectionFlow.swift
+++ b/Library/Sources/UILibrary/Views/UI/ConnectionFlow.swift
@@ -1,8 +1,8 @@
 //
-//  AppFlow.swift
+//  ConnectionFlow.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 11/23/24.
+//  Created by Davide De Rosa on 11/29/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,12 +23,19 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonLibrary
 import Foundation
 import PassepartoutKit
 
-struct AppFlow {
-    let onProviderEntityRequired: (Profile) -> Void
+public struct ConnectionFlow {
+    public let onConnect: (Profile) async -> Void
 
-    let onPurchaseRequired: (Set<AppFeature>) -> Void
+    public let onProviderEntityRequired: (Profile) -> Void
+
+    public init(
+        onConnect: @escaping (Profile) async -> Void,
+        onProviderEntityRequired: @escaping (Profile) -> Void
+    ) {
+        self.onConnect = onConnect
+        self.onProviderEntityRequired = onProviderEntityRequired
+    }
 }

--- a/Passepartout/Shared/Testing/ProfileManager+Testing.swift
+++ b/Passepartout/Shared/Testing/ProfileManager+Testing.swift
@@ -51,6 +51,12 @@ extension ProfileManager {
                            var providerBuilder = moduleBuilder as? any ProviderModuleBuilder {
                             providerBuilder.providerId = providerId
                             moduleBuilder = providerBuilder
+
+                            if parameters.name == "Hide.me" {
+                                var ovpnBuilder = moduleBuilder as! OpenVPNModule.Builder
+                                ovpnBuilder.isInteractive = true
+                                moduleBuilder = ovpnBuilder
+                            }
                         }
                         builder.modules.append(try moduleBuilder.tryBuild())
                     }


### PR DESCRIPTION
Let the AppCoordinator take care of the connection requirements via modals:

- onInteractiveLogin() - now presented on AppError
- onProviderEntityRequired()
- onPurchaseRequired()
- Any other connection error

Subviews must not use tunnel.connect(), rather they route connection requests via the ConnectionFlow callbacks. In particular, migrate to the AppCoordinator the connection logic from:

- TunnelToggleButton.perform()
- ProviderEntitySelector.onSelect()

onInteractiveLogin() and onPurchaseRequired() are now handled internally, while onProviderEntityRequired() is kept public because it's how subviews may present the entity selector.

Extras:

- Avoid modals overlap with a 500ms delay
- Shrink interactive login size on macOS