### PR TITLE
Improve confusing footer modifiers

### DIFF
--- a/Library/Sources/AppUIMain/Views/Profile/StorageSection.swift
+++ b/Library/Sources/AppUIMain/Views/Profile/StorageSection.swift
@@ -41,9 +41,9 @@ struct StorageSection: View {
         debugChanges()
         return Group {
             sharingToggle
-                .themeRow(footer: sharingDescription)
+                .themeRowWithSubtitle(sharingDescription)
             tvToggle
-                .themeRow(footer: tvDescription)
+                .themeRowWithSubtitle(tvDescription)
             purchaseButton
         }
         .themeSection(

--- a/Library/Sources/AppUIMain/Views/Profile/StorageSection.swift
+++ b/Library/Sources/AppUIMain/Views/Profile/StorageSection.swift
@@ -46,10 +46,7 @@ struct StorageSection: View {
                 .themeRowWithSubtitle(tvDescription)
             purchaseButton
         }
-        .themeSection(
-            header: header,
-            footer: footer
-        )
+        .themeSection(header: header, footer: footer)
     }
 }
 

--- a/Library/Sources/AppUIMain/Views/Providers/ProviderContentModifier.swift
+++ b/Library/Sources/AppUIMain/Views/Providers/ProviderContentModifier.swift
@@ -98,7 +98,7 @@ private extension ProviderContentModifier {
                 HStack {
                     lastUpdatedString.map {
                         Text($0)
-                            .themeFooter()
+                            .themeSubtitle()
                     }
                     Spacer()
                     RefreshInfrastructureButton(apis: apis, providerId: providerId)

--- a/Library/Sources/UILibrary/Theme/Platforms/Theme+iOS.swift
+++ b/Library/Sources/UILibrary/Theme/Platforms/Theme+iOS.swift
@@ -141,7 +141,7 @@ extension ThemeSectionWithHeaderFooterModifier {
 extension ThemeRowWithSubtitleModifier {
     func body(content: Content) -> some View {
         content
-        // omit footer on iOS/tvOS, use ThemeSectionWithHeaderFooterModifier
+        // omit subtitle on iOS/tvOS, use ThemeSectionWithHeaderFooterModifier
     }
 }
 

--- a/Library/Sources/UILibrary/Theme/Platforms/Theme+iOS.swift
+++ b/Library/Sources/UILibrary/Theme/Platforms/Theme+iOS.swift
@@ -138,7 +138,7 @@ extension ThemeSectionWithHeaderFooterModifier {
     }
 }
 
-extension ThemeRowWithFooterModifier {
+extension ThemeRowWithSubtitleModifier {
     func body(content: Content) -> some View {
         content
         // omit footer on iOS/tvOS, use ThemeSectionWithHeaderFooterModifier

--- a/Library/Sources/UILibrary/Theme/Platforms/Theme+macOS.swift
+++ b/Library/Sources/UILibrary/Theme/Platforms/Theme+macOS.swift
@@ -71,15 +71,18 @@ extension ThemeManualInputModifier {
 }
 
 extension ThemeSectionWithHeaderFooterModifier {
-
-    @ViewBuilder
     func body(content: Content) -> some View {
         Section {
             content
+            if forcesFooter {
+                footer.map {
+                    Text($0)
+                        .themeSubtitle()
+                }
+            }
         } header: {
             header.map(Text.init)
         }
-        // omit footer on macOS, use ThemeRowWithFooterModifier
     }
 }
 

--- a/Library/Sources/UILibrary/Theme/Platforms/Theme+macOS.swift
+++ b/Library/Sources/UILibrary/Theme/Platforms/Theme+macOS.swift
@@ -83,15 +83,15 @@ extension ThemeSectionWithHeaderFooterModifier {
     }
 }
 
-extension ThemeRowWithFooterModifier {
+extension ThemeRowWithSubtitleModifier {
     func body(content: Content) -> some View {
         VStack {
             content
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            footer.map {
+            subtitle.map {
                 Text($0)
-                    .themeFooter()
+                    .themeSubtitle()
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }

--- a/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
+++ b/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
@@ -135,6 +135,7 @@ extension View {
         modifier(ThemeManualInputModifier())
     }
 
+    // footer is hidden on macOS
     public func themeSection(header: String? = nil, footer: String? = nil) -> some View {
         modifier(ThemeSectionWithHeaderFooterModifier(header: header, footer: footer))
     }
@@ -148,12 +149,13 @@ extension View {
 
                 self
             } else {
-                themeRowWithSubtitle(footer) // macOS footer
+                themeRowWithSubtitle(footer) // macOS
             }
         }
-        .themeSection(header: header, footer: footer) // iOS/tvOS footer
+        .themeSection(header: header, footer: footer) // iOS/tvOS
     }
 
+    // subtitle is hidden on iOS/tvOS
     public func themeRowWithSubtitle(_ subtitle: String?) -> some View {
         modifier(ThemeRowWithSubtitleModifier(subtitle: subtitle))
     }

--- a/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
+++ b/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
@@ -139,27 +139,28 @@ extension View {
         modifier(ThemeSectionWithHeaderFooterModifier(header: header, footer: footer))
     }
 
-    public func themeRow(footer: String? = nil) -> some View {
-        modifier(ThemeRowWithFooterModifier(footer: footer))
-    }
-
-    public func themeFooter() -> some View {
-        foregroundStyle(.secondary)
-            .font(.subheadline)
-    }
-
+    // shortcut
     public func themeSectionWithSingleRow(header: String? = nil, footer: String, above: Bool = false) -> some View {
         Group {
             if above {
                 EmptyView()
-                    .themeRow(footer: footer)
+                    .themeRowWithSubtitle(footer) // macOS
 
                 self
             } else {
-                themeRow(footer: footer)
+                themeRowWithSubtitle(footer) // macOS footer
             }
         }
-        .themeSection(header: header, footer: footer)
+        .themeSection(header: header, footer: footer) // iOS/tvOS footer
+    }
+
+    public func themeRowWithSubtitle(_ subtitle: String?) -> some View {
+        modifier(ThemeRowWithSubtitleModifier(subtitle: subtitle))
+    }
+
+    public func themeSubtitle() -> some View {
+        foregroundStyle(.secondary)
+            .font(.subheadline)
     }
 
     public func themeNavigationDetail() -> some View {
@@ -415,8 +416,8 @@ struct ThemeSectionWithHeaderFooterModifier: ViewModifier {
     let footer: String?
 }
 
-struct ThemeRowWithFooterModifier: ViewModifier {
-    let footer: String?
+struct ThemeRowWithSubtitleModifier: ViewModifier {
+    let subtitle: String?
 }
 
 struct ThemeEmptyMessageModifier: ViewModifier {

--- a/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
+++ b/Library/Sources/UILibrary/Theme/UI/Theme+Modifiers.swift
@@ -135,12 +135,10 @@ extension View {
         modifier(ThemeManualInputModifier())
     }
 
-    // footer is hidden on macOS
-    public func themeSection(header: String? = nil, footer: String? = nil) -> some View {
-        modifier(ThemeSectionWithHeaderFooterModifier(header: header, footer: footer))
+    public func themeSection(header: String? = nil, footer: String? = nil, forcesFooter: Bool = false) -> some View {
+        modifier(ThemeSectionWithHeaderFooterModifier(header: header, footer: footer, forcesFooter: forcesFooter))
     }
 
-    // shortcut
     public func themeSectionWithSingleRow(header: String? = nil, footer: String, above: Bool = false) -> some View {
         Group {
             if above {
@@ -416,6 +414,8 @@ struct ThemeSectionWithHeaderFooterModifier: ViewModifier {
     let header: String?
 
     let footer: String?
+
+    let forcesFooter: Bool
 }
 
 struct ThemeRowWithSubtitleModifier: ViewModifier {

--- a/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -124,7 +124,7 @@ private extension OpenVPNCredentialsView {
                     PurchaseRequiredButton(features: requiredFeatures, paywallReason: $paywallReason)
                 }
             }
-            .themeRow(footer: interactiveFooter)
+            .themeRowWithSubtitle(interactiveFooter)
 
             if isInteractive {
                 Picker(Strings.Unlocalized.otp, selection: $builder.otpMethod) {
@@ -159,7 +159,7 @@ private extension OpenVPNCredentialsView {
 #if os(macOS)
             inputFooter.map {
                 Text($0)
-                    .themeFooter()
+                    .themeSubtitle()
             }
 #endif
         }

--- a/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Library/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -156,14 +156,8 @@ private extension OpenVPNCredentialsView {
             if isEligibleForInteractiveLogin, isAuthenticating, builder.otpMethod != .none {
                 otpField
             }
-#if os(macOS)
-            inputFooter.map {
-                Text($0)
-                    .themeSubtitle()
-            }
-#endif
         }
-        .themeSection(footer: inputFooter)
+        .themeSection(footer: inputFooter, forcesFooter: true)
     }
 
     @ViewBuilder

--- a/Library/Sources/UILibrary/Views/UI/NameSection.swift
+++ b/Library/Sources/UILibrary/Views/UI/NameSection.swift
@@ -46,15 +46,8 @@ public struct NameSection: View {
             ThemeTextField(Strings.Global.Nouns.name, text: $name, placeholder: placeholder)
                 .labelsHidden()
                 .themeManualInput()
-
-#if os(macOS)
-            footer.map {
-                Text($0)
-                    .themeSubtitle()
-            }
-#endif
         }
-        .themeSection(header: Strings.Global.Nouns.name, footer: footer)
+        .themeSection(header: Strings.Global.Nouns.name, footer: footer, forcesFooter: true)
     }
 }
 

--- a/Library/Sources/UILibrary/Views/UI/NameSection.swift
+++ b/Library/Sources/UILibrary/Views/UI/NameSection.swift
@@ -50,7 +50,7 @@ public struct NameSection: View {
 #if os(macOS)
             footer.map {
                 Text($0)
-                    .themeFooter()
+                    .themeSubtitle()
             }
 #endif
         }


### PR DESCRIPTION
There was duplication and a ugly `#if os(macOS)` with some footers explicitly rendered on macOS with .themeFooter() (now .themeSubtitle()).

Move this logic to the .themeSection() modifiers by adding a `forcesFooter` parameter. When true, a fake footer is added on macOS as the last row of a section.