### PR TITLE
Select preset matching current filter

### DIFF
--- a/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
@@ -147,6 +147,11 @@ private extension VPNProviderServerView {
     func compatiblePreset(with server: VPNServer) -> VPNPreset<Configuration>? {
         vpnManager
             .presets
+            .filter { preset in
+                filtersViewModel.presets.contains {
+                    preset.presetId == $0.presetId
+                }
+            }
             .first {
                 if let supportedIds = server.provider.supportedPresetIds {
                     return supportedIds.contains($0.presetId)


### PR DESCRIPTION
E.g. Mullvad was not selecting "Custom DNS".