### PR TITLE
Fix missing animations in profiles list

### DIFF
--- a/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -108,8 +108,6 @@ private struct ContainerModifier: ViewModifier {
             .onChange(of: search) {
                 profileManager.search(byName: $0)
             }
-            .themeAnimation(on: profileManager.isReady, category: .profiles)
-            .themeAnimation(on: profileManager.previews, category: .profiles)
     }
 
     private func emptyView() -> some View {

--- a/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -73,6 +73,8 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
                 }
                 .padding(.horizontal)
             }
+            .themeAnimation(on: profileManager.isReady, category: .profiles)
+            .themeAnimation(on: profileManager.previews, category: .profiles)
         }
         .onReceive(tunnel.currentProfilePublisher) {
             currentProfile = $0

--- a/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -71,6 +71,8 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
                 .themeSection(header: Strings.Views.App.Folders.default)
             }
             .themeForm()
+            .themeAnimation(on: profileManager.isReady, category: .profiles)
+            .themeAnimation(on: profileManager.previews, category: .profiles)
         }
     }
 }


### PR DESCRIPTION
The list was not animating e.g. on iCloud updates. Move .themeAnimation() from ProfileContainerView (ContainerModifier) to ProfileListView/ProfileGridView.