### PR TITLE
Exclude OpenVPN endpoints

### DIFF
--- a/Library/Sources/AppDataPreferences/Domain/CDExcludedEndpoint.swift
+++ b/Library/Sources/AppDataPreferences/Domain/CDExcludedEndpoint.swift
@@ -1,8 +1,8 @@
 //
-//  CDModulePreferencesV3.swift
+//  CDExcludedEndpoint.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 12/5/24.
+//  Created by Davide De Rosa on 12/8/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -26,12 +26,13 @@
 import CoreData
 import Foundation
 
-@objc(CDModulePreferencesV3)
-final class CDModulePreferencesV3: NSManagedObject {
-    @nonobjc static func fetchRequest() -> NSFetchRequest<CDModulePreferencesV3> {
-        NSFetchRequest<CDModulePreferencesV3>(entityName: "CDModulePreferencesV3")
+@objc(CDExcludedEndpoint)
+final class CDExcludedEndpoint: NSManagedObject {
+    @nonobjc static func fetchRequest() -> NSFetchRequest<CDExcludedEndpoint> {
+        NSFetchRequest<CDExcludedEndpoint>(entityName: "CDExcludedEndpoint")
     }
 
-    @NSManaged var uuid: UUID?
-    @NSManaged var excludedEndpoints: Set<CDExcludedEndpoint>?
+    @NSManaged var endpoint: String?
+    @NSManaged var modulePreferences: CDModulePreferencesV3?
+    @NSManaged var providerPreferences: CDProviderPreferencesV3?
 }

--- a/Library/Sources/AppDataPreferences/Domain/CDProviderPreferencesV3.swift
+++ b/Library/Sources/AppDataPreferences/Domain/CDProviderPreferencesV3.swift
@@ -34,4 +34,5 @@ final class CDProviderPreferencesV3: NSManagedObject {
 
     @NSManaged var providerId: String?
     @NSManaged var favoriteServerIds: Data?
+    @NSManaged var excludedEndpoints: Set<CDExcludedEndpoint>?
 }

--- a/Library/Sources/AppDataPreferences/Domain/Mapper.swift
+++ b/Library/Sources/AppDataPreferences/Domain/Mapper.swift
@@ -29,12 +29,27 @@ import Foundation
 import PassepartoutKit
 
 struct DomainMapper {
-    func preferences(from entity: CDModulePreferencesV3) throws -> ModulePreferences {
-        ModulePreferences()
+    func excludedEndpoints(from entities: Set<CDExcludedEndpoint>?) -> Set<ExtendedEndpoint> {
+        entities.map {
+            Set($0.compactMap {
+                $0.endpoint.map {
+                    ExtendedEndpoint(rawValue: $0)
+                } ?? nil
+            })
+        } ?? []
     }
 }
 
 struct CoreDataMapper {
-    func set(_ entity: CDModulePreferencesV3, from preferences: ModulePreferences) throws {
+    let context: NSManagedObjectContext
+
+    func cdExcludedEndpoint(from endpoint: ExtendedEndpoint) -> CDExcludedEndpoint {
+        let cdEndpoint = CDExcludedEndpoint(context: context)
+        cdEndpoint.endpoint = endpoint.rawValue
+        return cdEndpoint
+    }
+
+    func cdExcludedEndpoints(from endpoints: Set<ExtendedEndpoint>) -> Set<CDExcludedEndpoint> {
+        Set(endpoints.map(cdExcludedEndpoint(from:)))
     }
 }

--- a/Library/Sources/AppDataPreferences/Preferences.xcdatamodeld/Preferences.xcdatamodel/contents
+++ b/Library/Sources/AppDataPreferences/Preferences.xcdatamodeld/Preferences.xcdatamodel/contents
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="CDExcludedEndpoint" representedClassName="CDExcludedEndpoint" syncable="YES">
+        <attribute name="endpoint" optional="YES" attributeType="String"/>
+        <relationship name="modulePreferences" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDModulePreferencesV3" inverseName="excludedEndpoints" inverseEntity="CDModulePreferencesV3"/>
+        <relationship name="providerPreferences" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDProviderPreferencesV3" inverseName="excludedEndpoints" inverseEntity="CDProviderPreferencesV3"/>
+    </entity>
     <entity name="CDModulePreferencesV3" representedClassName="CDModulePreferencesV3" syncable="YES">
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="excludedEndpoints" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDExcludedEndpoint" inverseName="modulePreferences" inverseEntity="CDExcludedEndpoint"/>
     </entity>
     <entity name="CDProviderPreferencesV3" representedClassName="CDProviderPreferencesV3" syncable="YES">
         <attribute name="favoriteServerIds" optional="YES" attributeType="Binary"/>
         <attribute name="providerId" optional="YES" attributeType="String"/>
+        <relationship name="excludedEndpoints" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDExcludedEndpoint" inverseName="providerPreferences" inverseEntity="CDExcludedEndpoint"/>
     </entity>
 </model>

--- a/Library/Sources/AppDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
+++ b/Library/Sources/AppDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
@@ -82,6 +82,35 @@ private final class CDProviderPreferencesRepositoryV3: ProviderPreferencesReposi
         }
     }
 
+    func isExcludedEndpoint(_ endpoint: ExtendedEndpoint) -> Bool {
+        context.performAndWait {
+            entity.excludedEndpoints?.contains {
+                $0.endpoint == endpoint.rawValue
+            } ?? false
+        }
+    }
+
+    func addExcludedEndpoint(_ endpoint: ExtendedEndpoint) {
+        context.performAndWait {
+            let mapper = CoreDataMapper(context: context)
+            let cdEndpoint = mapper.cdExcludedEndpoint(from: endpoint)
+            cdEndpoint.providerPreferences = entity
+            entity.excludedEndpoints?.insert(cdEndpoint)
+        }
+    }
+
+    func removeExcludedEndpoint(_ endpoint: ExtendedEndpoint) {
+        context.performAndWait {
+            guard let found = entity.excludedEndpoints?.first(where: {
+                $0.endpoint == endpoint.rawValue
+            }) else {
+                return
+            }
+            entity.excludedEndpoints?.remove(found)
+            context.delete(found)
+        }
+    }
+
     func save() throws {
         guard context.hasChanges else {
             return

--- a/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Library/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -229,11 +229,7 @@ extension AppCoordinator {
 extension AppCoordinator {
     public func onInteractiveLogin(_ profile: Profile, _ onComplete: @escaping InteractiveManager.CompletionBlock) {
         pp_log(.app, .info, "Present interactive login")
-        interactiveManager.present(
-            with: profile,
-            preferencesManager: preferencesManager,
-            onComplete: onComplete
-        )
+        interactiveManager.present(with: profile, onComplete: onComplete)
     }
 
     public func onProviderEntityRequired(_ profile: Profile, force: Bool) {
@@ -302,7 +298,7 @@ private extension AppCoordinator {
     func editProfile(_ profile: EditableProfile, initialModuleId: UUID?) {
         profilePath = NavigationPath()
         let isShared = profileManager.isRemotelyShared(profileWithId: profile.id)
-        profileEditor.load(profile, isShared: isShared, preferencesManager: preferencesManager)
+        profileEditor.load(profile, isShared: isShared)
         present(.editProfile(initialModuleId))
     }
 }

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView+Configuration.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView+Configuration.swift
@@ -85,10 +85,13 @@ private extension OpenVPNView.ConfigurationView {
     }
 
     var pullRows: [ModuleRow]? {
-        configuration.pullMask?.map {
-            .text(caption: $0.localizedDescription, value: nil)
-        }
-        .nilIfEmpty
+        configuration.pullMask?
+            .map(\.localizedDescription)
+            .sorted()
+            .map {
+                .text(caption: $0, value: nil)
+            }
+            .nilIfEmpty
     }
 
     func ipRows(for ip: IPSettings?, routes: [Route]?) -> [ModuleRow]? {
@@ -130,15 +133,14 @@ private extension OpenVPNView.ConfigurationView {
         configuration.routingPolicies?
             .compactMap {
                 switch $0 {
-                case .IPv4:
-                    return .text(caption: Strings.Unlocalized.ipv4)
-
-                case .IPv6:
-                    return .text(caption: Strings.Unlocalized.ipv6)
-
-                default:
-                    return nil
+                case .IPv4: return Strings.Unlocalized.ipv4
+                case .IPv6: return Strings.Unlocalized.ipv6
+                default: return nil
                 }
+            }
+            .sorted()
+            .map {
+                .text(caption: $0)
             }
             .nilIfEmpty
     }
@@ -272,4 +274,23 @@ private extension OpenVPNView.ConfigurationView {
         }
         return rows.nilIfEmpty
     }
+}
+
+// MARK: - Previews
+
+#Preview {
+    struct Preview: View {
+        var body: some View {
+            Form {
+                OpenVPNView.ConfigurationView(
+                    isServerPushed: false,
+                    configuration: .forPreviews,
+                    credentialsRoute: nil
+                )
+            }
+            .withMockEnvironment()
+        }
+    }
+
+    return Preview()
 }

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView+Extensions.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView+Extensions.swift
@@ -1,0 +1,89 @@
+//
+//  OpenVPNView+Extensions.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 12/8/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PassepartoutKit
+
+// swiftlint: disable force_try
+extension OpenVPN.Configuration.Builder {
+    static var forPreviews: Self {
+        var builder = OpenVPN.Configuration.Builder(withFallbacks: true)
+        builder.noPullMask = [.proxy]
+        builder.authUserPass = true
+        builder.remotes = [
+            .init(rawValue: "2.2.2.2:UDP:2222")!,
+            .init(rawValue: "6.6.6.6:UDP:6666")!,
+            .init(rawValue: "12.12.12.12:TCP:21212")!,
+            .init(rawValue: "12:12:12:12:20:20:20:20:TCP6:21212")!
+        ]
+        builder.ipv4 = IPSettings(subnet: try! .init("5.5.5.5", 24))
+            .including(routes: [
+                .init(defaultWithGateway: .ip("120.1.1.1", .v4)),
+                .init(.init(rawValue: "55.10.20.30/32"), nil)
+            ])
+            .excluding(routes: [
+                .init(.init(rawValue: "88.40.30.30/32"), nil),
+                .init(.init(rawValue: "60.60.60.60/32"), .ip("127.0.0.1", .v4))
+            ])
+        builder.ipv6 = IPSettings(subnet: try! .init("::5", 24))
+            .including(routes: [
+                .init(defaultWithGateway: .ip("120::1:1:1", .v6)),
+                .init(.init(rawValue: "55:10:20::30/128"), nil),
+                .init(.init(rawValue: "60:60:60::60/128"), .ip("::2", .v6))
+            ])
+            .excluding(routes: [
+                .init(.init(rawValue: "88:40:30::30/32"), nil)
+            ])
+        builder.routingPolicies = [.IPv4, .IPv6]
+        builder.dnsServers = ["1.2.3.4", "4.5.6.7"]
+        builder.dnsDomain = "domain.com"
+        builder.searchDomains = ["search1.com", "search2.com"]
+        builder.httpProxy = try! .init("10.10.10.10", 1080)
+        builder.httpsProxy = try! .init("10.10.10.10", 8080)
+        builder.proxyAutoConfigurationURL = URL(string: "https://hello.pac")!
+        builder.proxyBypassDomains = ["bypass1.com", "bypass2.com"]
+        builder.xorMethod = .xormask(mask: .init(Data(hex: "1234")))
+        builder.ca = .init(mockPem: "ca-certificate")
+        builder.clientCertificate = .init(mockPem: "client-certificate")
+        builder.clientKey = .init(mockPem: "client-key")
+        builder.tlsWrap = .init(strategy: .auth, key: .init(biData: Data(count: 256)))
+        builder.keepAliveInterval = 10.0
+        builder.renegotiatesAfter = 60.0
+        builder.randomizeEndpoint = true
+        builder.randomizeHostnames = true
+        return builder
+    }
+}
+// swiftlint: enable force_try
+
+private extension OpenVPN.CryptoContainer {
+    init(mockPem: String) {
+        self.init(pem: """
+-----BEGIN CERTIFICATE-----
+\(mockPem)
+-----END CERTIFICATE-----
+""")
+    }
+}

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView+Import.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView+Import.swift
@@ -1,0 +1,122 @@
+//
+//  OpenVPNView+Import.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 12/8/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import CommonUtils
+import PassepartoutKit
+import SwiftUI
+
+extension OpenVPNView {
+    struct ImportModifier: ViewModifier {
+
+        @Binding
+        var draft: OpenVPNModule.Builder
+
+        let impl: OpenVPNModule.Implementation?
+
+        @Binding
+        var isImporting: Bool
+
+        @ObservedObject
+        var errorHandler: ErrorHandler
+
+        @State
+        private var importURL: URL?
+
+        @State
+        private var importPassphrase: String?
+
+        @State
+        private var requiresPassphrase = false
+
+        func body(content: Content) -> some View {
+            content
+                .fileImporter(
+                    isPresented: $isImporting,
+                    allowedContentTypes: [.item],
+                    onCompletion: importConfiguration
+                )
+                .alert(
+                    draft.moduleType.localizedDescription,
+                    isPresented: $requiresPassphrase,
+                    presenting: importURL,
+                    actions: { url in
+                        SecureField(
+                            Strings.Placeholders.secret,
+                            text: $importPassphrase ?? ""
+                        )
+                        Button(Strings.Alerts.Import.Passphrase.ok) {
+                            importConfiguration(from: .success(url))
+                        }
+                        Button(Strings.Global.Actions.cancel, role: .cancel) {
+                            isImporting = false
+                        }
+                    },
+                    message: {
+                        Text(Strings.Alerts.Import.Passphrase.message($0.lastPathComponent))
+                    }
+                )
+        }
+    }
+}
+
+private extension OpenVPNView.ImportModifier {
+    func importConfiguration(from result: Result<URL, Error>) {
+        do {
+            let url = try result.get()
+            guard url.startAccessingSecurityScopedResource() else {
+                throw AppError.permissionDenied
+            }
+            defer {
+                url.stopAccessingSecurityScopedResource()
+            }
+            importURL = url
+
+            guard let impl else {
+                fatalError("Requires OpenVPNModule implementation")
+            }
+            guard let parser = impl.importer as? StandardOpenVPNParser else {
+                fatalError("OpenVPNModule importer should be StandardOpenVPNParser")
+            }
+            let parsed = try parser.parsed(fromURL: url, passphrase: importPassphrase)
+
+            draft.configurationBuilder = parsed.configuration.builder()
+        } catch StandardOpenVPNParserError.encryptionPassphrase,
+                StandardOpenVPNParserError.unableToDecrypt {
+            Task {
+                // XXX: re-present same alert after artificial delay
+                try? await Task.sleep(for: .milliseconds(500))
+                importPassphrase = nil
+                requiresPassphrase = true
+            }
+        } catch {
+            pp_log(.app, .error, "Unable to import OpenVPN configuration: \(error)")
+            errorHandler.handle(
+                (error as? StandardOpenVPNParserError)?.asPassepartoutError ?? error,
+                title: draft.moduleType.localizedDescription
+            )
+        }
+    }
+}

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -85,7 +85,6 @@ struct OpenVPNView: View, ModuleDraftEditing {
             .navigationDestination(for: Subroute.self, destination: destination)
             .themeAnimation(on: draft.wrappedValue.providerId, category: .modules)
             .withErrorHandler(errorHandler)
-            .onDisappear(perform: onDisappear)
     }
 }
 
@@ -130,6 +129,7 @@ private extension OpenVPNView {
     var providerModifier: some ViewModifier {
         VPNProviderContentModifier(
             providerId: providerId,
+            providerPreferences: providerPreferences,
             selectedEntity: providerEntity,
             paywallReason: $paywallReason,
             entityDestination: Subroute.providerServer,
@@ -204,13 +204,7 @@ private extension OpenVPNView {
     }
 
     var allowedEndpoints: Blacklist<ExtendedEndpoint> {
-        if let providerId = draft.wrappedValue.providerId {
-            do {
-                pp_log(.app, .debug, "Load preferences for provider \(providerId)")
-                providerPreferences.repository = try preferencesManager.preferencesRepository(forProviderWithId: providerId)
-            } catch {
-                pp_log(.app, .error, "Unable to load preferences for provider \(providerId): \(error)")
-            }
+        if draft.wrappedValue.providerSelection != nil {
             return providerPreferences.allowedEndpoints()
         } else {
             return preferences.allowedEndpoints()
@@ -220,15 +214,6 @@ private extension OpenVPNView {
     func onSelectServer(server: VPNServer, preset: VPNPreset<OpenVPN.Configuration>) {
         draft.wrappedValue.providerEntity = VPNEntity(server: server, preset: preset)
         path.wrappedValue.removeLast()
-    }
-
-    func onDisappear() {
-        do {
-            pp_log(.app, .debug, "Save preferences for provider \(providerId.wrappedValue.debugDescription)")
-            try providerPreferences.save()
-        } catch {
-            pp_log(.app, .error, "Unable to save preferences for provider \(providerId.wrappedValue.debugDescription): \(error)")
-        }
     }
 }
 

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -46,15 +46,6 @@ struct OpenVPNView: View, ModuleDraftEditing {
     private var isImporting = false
 
     @State
-    private var importURL: URL?
-
-    @State
-    private var importPassphrase: String?
-
-    @State
-    private var requiresPassphrase = false
-
-    @State
     private var paywallReason: PaywallReason?
 
     @StateObject
@@ -64,7 +55,6 @@ struct OpenVPNView: View, ModuleDraftEditing {
         module = OpenVPNModule.Builder(configurationBuilder: serverConfiguration.builder())
         editor = ProfileEditor(modules: [module])
         assert(module.configurationBuilder != nil, "isServerPushed must imply module.configurationBuilder != nil")
-
         impl = nil
         isServerPushed = true
     }
@@ -79,11 +69,12 @@ struct OpenVPNView: View, ModuleDraftEditing {
     var body: some View {
         contentView
             .moduleView(editor: editor, draft: draft.wrappedValue)
-            .fileImporter(
-                isPresented: $isImporting,
-                allowedContentTypes: [.item],
-                onCompletion: importConfiguration
-            )
+            .modifier(ImportModifier(
+                draft: draft,
+                impl: impl,
+                isImporting: $isImporting,
+                errorHandler: errorHandler
+            ))
             .modifier(PaywallModifier(reason: $paywallReason))
             .navigationDestination(for: Subroute.self, destination: destination)
             .themeAnimation(on: draft.wrappedValue.providerId, category: .modules)
@@ -126,26 +117,6 @@ private extension OpenVPNView {
         Button(Strings.Modules.General.Rows.importFromFile.withTrailingDots) {
             isImporting = true
         }
-        .alert(
-            module.moduleType.localizedDescription,
-            isPresented: $requiresPassphrase,
-            presenting: importURL,
-            actions: { url in
-                SecureField(
-                    Strings.Placeholders.secret,
-                    text: $importPassphrase ?? ""
-                )
-                Button(Strings.Alerts.Import.Passphrase.ok) {
-                    importConfiguration(from: .success(url))
-                }
-                Button(Strings.Global.Actions.cancel, role: .cancel) {
-                    isImporting = false
-                }
-            },
-            message: {
-                Text(Strings.Alerts.Import.Passphrase.message($0.lastPathComponent))
-            }
-        )
     }
 
     var providerModifier: some ViewModifier {
@@ -162,50 +133,6 @@ private extension OpenVPNView {
 
     var providerAccountRows: [ModuleRow]? {
         [.push(caption: Strings.Modules.Openvpn.credentials, route: HashableRoute(Subroute.credentials))]
-    }
-}
-
-private extension OpenVPNView {
-    func onSelectServer(server: VPNServer, preset: VPNPreset<OpenVPN.Configuration>) {
-        draft.wrappedValue.providerEntity = VPNEntity(server: server, preset: preset)
-        path.wrappedValue.removeLast()
-    }
-
-    func importConfiguration(from result: Result<URL, Error>) {
-        do {
-            let url = try result.get()
-            guard url.startAccessingSecurityScopedResource() else {
-                throw AppError.permissionDenied
-            }
-            defer {
-                url.stopAccessingSecurityScopedResource()
-            }
-            importURL = url
-
-            guard let impl else {
-                fatalError("Requires OpenVPNModule implementation")
-            }
-            guard let parser = impl.importer as? StandardOpenVPNParser else {
-                fatalError("OpenVPNModule importer should be StandardOpenVPNParser")
-            }
-            let parsed = try parser.parsed(fromURL: url, passphrase: importPassphrase)
-
-            draft.wrappedValue.configurationBuilder = parsed.configuration.builder()
-        } catch StandardOpenVPNParserError.encryptionPassphrase,
-                StandardOpenVPNParserError.unableToDecrypt {
-            Task {
-                // XXX: re-present same alert after artificial delay
-                try? await Task.sleep(for: .milliseconds(500))
-                importPassphrase = nil
-                requiresPassphrase = true
-            }
-        } catch {
-            pp_log(.app, .error, "Unable to import OpenVPN configuration: \(error)")
-            errorHandler.handle(
-                (error as? StandardOpenVPNParserError)?.asPassepartoutError ?? error,
-                title: module.moduleType.localizedDescription
-            )
-        }
     }
 }
 
@@ -260,66 +187,18 @@ private extension OpenVPNView {
     }
 }
 
+// MARK: - Logic
+
+private extension OpenVPNView {
+    func onSelectServer(server: VPNServer, preset: VPNPreset<OpenVPN.Configuration>) {
+        draft.wrappedValue.providerEntity = VPNEntity(server: server, preset: preset)
+        path.wrappedValue.removeLast()
+    }
+}
+
 // MARK: - Previews
 
-// swiftlint: disable force_try
 #Preview {
-    var builder = OpenVPN.Configuration.Builder(withFallbacks: true)
-    builder.noPullMask = [.proxy]
-    builder.authUserPass = true
-    builder.remotes = [
-        .init(rawValue: "2.2.2.2:UDP:2222")!,
-        .init(rawValue: "6.6.6.6:UDP:6666")!,
-        .init(rawValue: "12.12.12.12:TCP:21212")!,
-        .init(rawValue: "12:12:12:12:20:20:20:20:TCP6:21212")!
-    ]
-    builder.ipv4 = IPSettings(subnet: try! .init("5.5.5.5", 24))
-        .including(routes: [
-            .init(defaultWithGateway: .ip("120.1.1.1", .v4)),
-            .init(.init(rawValue: "55.10.20.30/32"), nil)
-        ])
-        .excluding(routes: [
-            .init(.init(rawValue: "88.40.30.30/32"), nil),
-            .init(.init(rawValue: "60.60.60.60/32"), .ip("127.0.0.1", .v4))
-        ])
-    builder.ipv6 = IPSettings(subnet: try! .init("::5", 24))
-        .including(routes: [
-            .init(defaultWithGateway: .ip("120::1:1:1", .v6)),
-            .init(.init(rawValue: "55:10:20::30/128"), nil),
-            .init(.init(rawValue: "60:60:60::60/128"), .ip("::2", .v6))
-        ])
-        .excluding(routes: [
-            .init(.init(rawValue: "88:40:30::30/32"), nil)
-        ])
-    builder.routingPolicies = [.IPv4, .IPv6]
-    builder.dnsServers = ["1.2.3.4", "4.5.6.7"]
-    builder.dnsDomain = "domain.com"
-    builder.searchDomains = ["search1.com", "search2.com"]
-    builder.httpProxy = try! .init("10.10.10.10", 1080)
-    builder.httpsProxy = try! .init("10.10.10.10", 8080)
-    builder.proxyAutoConfigurationURL = URL(string: "https://hello.pac")!
-    builder.proxyBypassDomains = ["bypass1.com", "bypass2.com"]
-    builder.xorMethod = .xormask(mask: .init(Data(hex: "1234")))
-    builder.ca = .init(mockPem: "ca-certificate")
-    builder.clientCertificate = .init(mockPem: "client-certificate")
-    builder.clientKey = .init(mockPem: "client-key")
-    builder.tlsWrap = .init(strategy: .auth, key: .init(biData: Data(count: 256)))
-    builder.keepAliveInterval = 10.0
-    builder.renegotiatesAfter = 60.0
-    builder.randomizeEndpoint = true
-    builder.randomizeHostnames = true
-
-    let module = OpenVPNModule.Builder(configurationBuilder: builder)
+    let module = OpenVPNModule.Builder(configurationBuilder: .forPreviews)
     return module.preview(title: "OpenVPN")
-}
-// swiftlint: enable force_try
-
-private extension OpenVPN.CryptoContainer {
-    init(mockPem: String) {
-        self.init(pem: """
------BEGIN CERTIFICATE-----
-\(mockPem)
------END CERTIFICATE-----
-""")
-    }
 }

--- a/Library/Sources/AppUIMain/Views/Modules/WireGuardView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/WireGuardView.swift
@@ -79,6 +79,7 @@ private extension WireGuardView {
     var providerModifier: some ViewModifier {
         VPNProviderContentModifier(
             providerId: providerId,
+            providerPreferences: nil,
             selectedEntity: providerEntity,
             paywallReason: $paywallReason,
             entityDestination: Subroute.providerServer,

--- a/Library/Sources/AppUIMain/Views/VPN/VPNProviderContentModifier.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNProviderContentModifier.swift
@@ -34,6 +34,8 @@ struct VPNProviderContentModifier<Configuration, ProviderRows>: ViewModifier whe
     @Binding
     var providerId: ProviderID?
 
+    let providerPreferences: ProviderPreferences?
+
     @Binding
     var selectedEntity: VPNEntity<Configuration>?
 
@@ -51,6 +53,7 @@ struct VPNProviderContentModifier<Configuration, ProviderRows>: ViewModifier whe
             .modifier(ProviderContentModifier(
                 apis: apis,
                 providerId: $providerId,
+                providerPreferences: providerPreferences,
                 entityType: VPNEntity<Configuration>.self,
                 paywallReason: $paywallReason,
                 providerRows: {
@@ -94,6 +97,7 @@ private extension VPNProviderContentModifier {
                 .modifier(VPNProviderContentModifier(
                     apis: [API.bundled],
                     providerId: .constant(.hideme),
+                    providerPreferences: nil,
                     selectedEntity: .constant(nil as VPNEntity<OpenVPN.Configuration>?),
                     paywallReason: .constant(nil),
                     entityDestination: "Destination",

--- a/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
@@ -23,10 +23,28 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonUtils
 import Foundation
 import PassepartoutKit
 
-public struct ModulePreferences: Sendable {
+@MainActor
+public final class ModulePreferences: ObservableObject {
+    public var repository: ModulePreferencesRepository?
+
     public init() {
+    }
+
+    public func allowedEndpoints() -> Blacklist<ExtendedEndpoint> {
+        Blacklist { [weak self] in
+            self?.repository?.isExcludedEndpoint($0) != true
+        } allow: { [weak self] in
+            self?.repository?.removeExcludedEndpoint($0)
+        } deny: { [weak self] in
+            self?.repository?.addExcludedEndpoint($0)
+        }
+    }
+
+    public func save() throws {
+        try repository?.save()
     }
 }

--- a/Library/Sources/CommonLibrary/Domain/ProviderPreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ProviderPreferences.swift
@@ -54,10 +54,6 @@ public final class ProviderPreferences: ObservableObject {
         }
     }
 
-    public func refresh() {
-        objectWillChange.send()
-    }
-
     public func save() throws {
         try repository?.save()
     }

--- a/Library/Sources/CommonLibrary/Domain/ProviderPreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ProviderPreferences.swift
@@ -23,16 +23,13 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonUtils
 import Foundation
 import PassepartoutKit
 
 @MainActor
-public final class ProviderPreferences: ObservableObject, ProviderPreferencesRepository {
-    public var repository: ProviderPreferencesRepository? {
-        didSet {
-            objectWillChange.send()
-        }
-    }
+public final class ProviderPreferences: ObservableObject {
+    public var repository: ProviderPreferencesRepository?
 
     public init() {
     }
@@ -45,6 +42,20 @@ public final class ProviderPreferences: ObservableObject, ProviderPreferencesRep
             objectWillChange.send()
             repository?.favoriteServers = newValue
         }
+    }
+
+    public func allowedEndpoints() -> Blacklist<ExtendedEndpoint> {
+        Blacklist { [weak self] in
+            self?.repository?.isExcludedEndpoint($0) != true
+        } allow: { [weak self] in
+            self?.repository?.removeExcludedEndpoint($0)
+        } deny: { [weak self] in
+            self?.repository?.addExcludedEndpoint($0)
+        }
+    }
+
+    public func refresh() {
+        objectWillChange.send()
     }
 
     public func save() throws {

--- a/Library/Sources/CommonLibrary/Strategy/ModulePreferencesRepository.swift
+++ b/Library/Sources/CommonLibrary/Strategy/ModulePreferencesRepository.swift
@@ -26,8 +26,12 @@
 import Foundation
 import PassepartoutKit
 
-public protocol ModulePreferencesRepository: Sendable {
-    func preferences(for moduleIds: [UUID]) throws -> [UUID: ModulePreferences]
+public protocol ModulePreferencesRepository {
+    func isExcludedEndpoint(_ endpoint: ExtendedEndpoint) -> Bool
 
-    func set(_ preferences: [UUID: ModulePreferences]) throws
+    func addExcludedEndpoint(_ endpoint: ExtendedEndpoint)
+
+    func removeExcludedEndpoint(_ endpoint: ExtendedEndpoint)
+
+    func save() throws
 }

--- a/Library/Sources/CommonLibrary/Strategy/ProviderPreferencesRepository.swift
+++ b/Library/Sources/CommonLibrary/Strategy/ProviderPreferencesRepository.swift
@@ -29,5 +29,11 @@ import PassepartoutKit
 public protocol ProviderPreferencesRepository {
     var favoriteServers: Set<String> { get set }
 
+    func isExcludedEndpoint(_ endpoint: ExtendedEndpoint) -> Bool
+
+    func addExcludedEndpoint(_ endpoint: ExtendedEndpoint)
+
+    func removeExcludedEndpoint(_ endpoint: ExtendedEndpoint)
+
     func save() throws
 }

--- a/Library/Sources/CommonUtils/Business/Blacklist.swift
+++ b/Library/Sources/CommonUtils/Business/Blacklist.swift
@@ -1,8 +1,8 @@
 //
-//  UUID+RawRepresentable.swift
+//  Blacklist.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 12/4/24.
+//  Created by Davide De Rosa on 12/8/24.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -25,12 +25,35 @@
 
 import Foundation
 
-extension UUID: @retroactive RawRepresentable {
-    public init?(rawValue: String) {
-        self.init(uuidString: rawValue)
+@MainActor
+public final class Blacklist<T>: ObservableObject where T: Equatable {
+    private let isAllowed: (T) -> Bool
+
+    private let allow: (T) -> Void
+
+    private let deny: (T) -> Void
+
+    public init(
+        isAllowed: @escaping (T) -> Bool,
+        allow: @escaping (T) -> Void,
+        deny: @escaping (T) -> Void
+    ) {
+        self.isAllowed = isAllowed
+        self.allow = allow
+        self.deny = deny
     }
 
-    public var rawValue: String {
-        uuidString
+    public func isAllowed(_ value: T) -> Bool {
+        isAllowed(value)
+    }
+
+    public func allow(_ value: T) {
+        objectWillChange.send()
+        allow(value)
+    }
+
+    public func deny(_ value: T) {
+        objectWillChange.send()
+        deny(value)
     }
 }

--- a/Library/Sources/UILibrary/Business/InteractiveManager.swift
+++ b/Library/Sources/UILibrary/Business/InteractiveManager.swift
@@ -41,9 +41,9 @@ public final class InteractiveManager: ObservableObject {
     public init() {
     }
 
-    public func present(with profile: Profile, preferencesManager: PreferencesManager, onComplete: CompletionBlock?) {
+    public func present(with profile: Profile, onComplete: CompletionBlock?) {
         editor = ProfileEditor()
-        editor.load(profile.editable(), isShared: false, preferencesManager: preferencesManager)
+        editor.load(profile.editable(), isShared: false)
         self.onComplete = onComplete
         isPresented = true
     }

--- a/Library/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
+++ b/Library/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
@@ -41,12 +41,4 @@ extension ProfileEditor {
             self?.saveModule($0, activating: false)
         }
     }
-
-    public func binding(forPreferencesOf moduleId: UUID) -> Binding<ModulePreferences> {
-        Binding { [weak self] in
-            self?.preferences[moduleId] ?? ModulePreferences()
-        } set: { [weak self] in
-            self?.preferences[moduleId] = $0
-        }
-    }
 }

--- a/Passepartout/Shared/Dependencies+PreferencesManager.swift
+++ b/Passepartout/Shared/Dependencies+PreferencesManager.swift
@@ -41,7 +41,9 @@ extension Dependencies {
             author: nil
         )
         return PreferencesManager(
-            modulesRepository: AppData.cdModulePreferencesRepositoryV3(context: preferencesStore.context),
+            modulesFactory: {
+                try AppData.cdModulePreferencesRepositoryV3(context: preferencesStore.context, moduleId: $0)
+            },
             providersFactory: {
                 try AppData.cdProviderPreferencesRepositoryV3(context: preferencesStore.context, providerId: $0)
             }

--- a/Passepartout/Tunnel/Context/DefaultTunnelProcessor.swift
+++ b/Passepartout/Tunnel/Context/DefaultTunnelProcessor.swift
@@ -37,27 +37,32 @@ final class DefaultTunnelProcessor: Sendable {
 
 extension DefaultTunnelProcessor: PacketTunnelProcessor {
     func willStart(_ profile: Profile) throws -> Profile {
-        var builder = profile.builder()
-        try builder.modules.forEach {
-            guard var moduleBuilder = $0.moduleBuilder() as? OpenVPNModule.Builder else {
-                return
-            }
-
-            let modulesPreferences = try preferencesManager.preferencesRepository(forModuleWithId: moduleBuilder.id)
-            moduleBuilder.configurationBuilder?.remotes?.removeAll {
-                modulesPreferences.isExcludedEndpoint($0)
-            }
-
-            if let providerId = moduleBuilder.providerId {
-                let providerPreferences = try preferencesManager.preferencesRepository(forProviderWithId: providerId)
-                moduleBuilder.configurationBuilder?.remotes?.removeAll {
-                    providerPreferences.isExcludedEndpoint($0)
+        do {
+            var builder = profile.builder()
+            try builder.modules.forEach {
+                guard var moduleBuilder = $0.moduleBuilder() as? OpenVPNModule.Builder else {
+                    return
                 }
-            }
 
-            let module = try moduleBuilder.tryBuild()
-            builder.saveModule(module)
+                let modulesPreferences = try preferencesManager.preferencesRepository(forModuleWithId: moduleBuilder.id)
+                moduleBuilder.configurationBuilder?.remotes?.removeAll {
+                    modulesPreferences.isExcludedEndpoint($0)
+                }
+
+                if let providerId = moduleBuilder.providerId {
+                    let providerPreferences = try preferencesManager.preferencesRepository(forProviderWithId: providerId)
+                    moduleBuilder.configurationBuilder?.remotes?.removeAll {
+                        providerPreferences.isExcludedEndpoint($0)
+                    }
+                }
+
+                let module = try moduleBuilder.tryBuild()
+                builder.saveModule(module)
+            }
+            return try builder.tryBuild()
+        } catch {
+            pp_log(.app, .error, "Unable to process profile, revert to original: \(error)")
+            return profile
         }
-        return try builder.tryBuild()
     }
 }

--- a/Passepartout/Tunnel/Context/DefaultTunnelProcessor.swift
+++ b/Passepartout/Tunnel/Context/DefaultTunnelProcessor.swift
@@ -42,10 +42,19 @@ extension DefaultTunnelProcessor: PacketTunnelProcessor {
             guard var moduleBuilder = $0.moduleBuilder() as? OpenVPNModule.Builder else {
                 return
             }
+
             let modulesPreferences = try preferencesManager.preferencesRepository(forModuleWithId: moduleBuilder.id)
             moduleBuilder.configurationBuilder?.remotes?.removeAll {
                 modulesPreferences.isExcludedEndpoint($0)
             }
+
+            if let providerId = moduleBuilder.providerId {
+                let providerPreferences = try preferencesManager.preferencesRepository(forProviderWithId: providerId)
+                moduleBuilder.configurationBuilder?.remotes?.removeAll {
+                    providerPreferences.isExcludedEndpoint($0)
+                }
+            }
+
             let module = try moduleBuilder.tryBuild()
             builder.saveModule(module)
         }


### PR DESCRIPTION
Exclude endpoints from OpenVPN modules and providers with the generic Blacklist<T> observable. Eventually, rebuild the Profile in PacketTunnelProvider (via DefaultTunnelProcessor) with the applied exclusions from preferences.

Revisit approach to preferences:

- Module preferences
  - Tied to the module and therefore to the parent profile
  - Load/save in ProfileEditor on request (rather than on ProfileEditor.load)
- Provider preferences
  - Shared globally across profiles
  - Load/save in module view if needed

For more consistency with Core Data:

- Revert to observables for both module and provider preferences
- Treat excluded endpoints as relationships rather than a serialized Array
- Add/remove single relationships over bulk delete + re-add
- Do not map the relationships, Blacklist only needs exists/add/remove:
  - isExcludedEndpoint
  - addExcludedEndpoint
  - removeExcludedEndpoint

Some clean-up:

- Move the importer logic to OpenVPNView.ImportModifier
- Move the preview data to OpenVPN.Configuration.Builder.forPreviews
- Drop objectWillChange.send() on .repository didSet to avoid potential recursion during SwiftUI updates

Closes #971 