### PR TITLE
Review incorrect behavior in preferences

### DIFF
--- a/Library/Sources/AppDataPreferences/Strategy/CDModulePreferencesRepositoryV3.swift
+++ b/Library/Sources/AppDataPreferences/Strategy/CDModulePreferencesRepositoryV3.swift
@@ -97,4 +97,8 @@ private final class CDModulePreferencesRepositoryV3: ModulePreferencesRepository
             throw error
         }
     }
+
+    func discard() {
+        context.rollback()
+    }
 }

--- a/Library/Sources/AppDataPreferences/Strategy/CDModulePreferencesRepositoryV3.swift
+++ b/Library/Sources/AppDataPreferences/Strategy/CDModulePreferencesRepositoryV3.swift
@@ -87,18 +87,22 @@ private final class CDModulePreferencesRepositoryV3: ModulePreferencesRepository
     }
 
     func save() throws {
-        guard context.hasChanges else {
-            return
-        }
-        do {
-            try context.save()
-        } catch {
-            context.rollback()
-            throw error
+        try context.performAndWait {
+            guard context.hasChanges else {
+                return
+            }
+            do {
+                try context.save()
+            } catch {
+                context.rollback()
+                throw error
+            }
         }
     }
 
     func discard() {
-        context.rollback()
+        context.performAndWait {
+            context.rollback()
+        }
     }
 }

--- a/Library/Sources/AppDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
+++ b/Library/Sources/AppDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
@@ -112,14 +112,16 @@ private final class CDProviderPreferencesRepositoryV3: ProviderPreferencesReposi
     }
 
     func save() throws {
-        guard context.hasChanges else {
-            return
-        }
-        do {
-            try context.save()
-        } catch {
-            context.rollback()
-            throw error
+        try context.performAndWait {
+            guard context.hasChanges else {
+                return
+            }
+            do {
+                try context.save()
+            } catch {
+                context.rollback()
+                throw error
+            }
         }
     }
 }

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -89,7 +89,11 @@ struct OpenVPNView: View, ModuleDraftEditing {
             .themeAnimation(on: draft.wrappedValue.providerId, category: .modules)
             .withErrorHandler(errorHandler)
             .onLoad {
-                editor.loadPreferences(preferences, forModuleWithId: module.id, manager: preferencesManager)
+                editor.loadPreferences(
+                    preferences,
+                    from: preferencesManager,
+                    forModuleWithId: module.id
+                )
             }
     }
 }

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -99,7 +99,7 @@ private extension OpenVPNView {
                 isServerPushed: isServerPushed,
                 configuration: configuration,
                 credentialsRoute: Subroute.credentials,
-                allowedEndpoints: allowedEndpoints
+                excludedEndpoints: excludedEndpoints
             )
         } else {
             emptyConfigurationView
@@ -175,7 +175,7 @@ private extension OpenVPNView {
                     isServerPushed: false,
                     configuration: configuration.builder(),
                     credentialsRoute: nil,
-                    allowedEndpoints: allowedEndpoints
+                    excludedEndpoints: excludedEndpoints
                 )
             }
             .themeForm()
@@ -203,11 +203,11 @@ private extension OpenVPNView {
         editor.preferences(forModuleWithId: module.id, manager: preferencesManager)
     }
 
-    var allowedEndpoints: Blacklist<ExtendedEndpoint> {
+    var excludedEndpoints: ObservableList<ExtendedEndpoint> {
         if draft.wrappedValue.providerSelection != nil {
-            return providerPreferences.allowedEndpoints()
+            return providerPreferences.excludedEndpoints()
         } else {
-            return preferences.allowedEndpoints()
+            return preferences.excludedEndpoints()
         }
     }
 

--- a/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -52,6 +52,9 @@ struct OpenVPNView: View, ModuleDraftEditing {
     private var paywallReason: PaywallReason?
 
     @StateObject
+    private var preferences = ModulePreferences()
+
+    @StateObject
     private var providerPreferences = ProviderPreferences()
 
     @StateObject
@@ -85,6 +88,9 @@ struct OpenVPNView: View, ModuleDraftEditing {
             .navigationDestination(for: Subroute.self, destination: destination)
             .themeAnimation(on: draft.wrappedValue.providerId, category: .modules)
             .withErrorHandler(errorHandler)
+            .onLoad {
+                editor.loadPreferences(preferences, forModuleWithId: module.id, manager: preferencesManager)
+            }
     }
 }
 
@@ -199,10 +205,6 @@ private extension OpenVPNView {
 // MARK: - Logic
 
 private extension OpenVPNView {
-    var preferences: ModulePreferences {
-        editor.preferences(forModuleWithId: module.id, manager: preferencesManager)
-    }
-
     var excludedEndpoints: ObservableList<ExtendedEndpoint> {
         if draft.wrappedValue.providerSelection != nil {
             return providerPreferences.excludedEndpoints()

--- a/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Library/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -136,10 +136,7 @@ private extension ProfileCoordinator {
 
     // standard: always save, warn if purchase required
     func onCommitEditingStandard() async throws {
-        let savedProfile = try await profileEditor.save(
-            to: profileManager,
-            preferencesManager: preferencesManager
-        )
+        let savedProfile = try await profileEditor.save(to: profileManager)
         do {
             try iapManager.verify(savedProfile)
         } catch AppError.ineligibleProfile(let requiredFeatures) {
@@ -157,10 +154,7 @@ private extension ProfileCoordinator {
             paywallReason = .init(requiredFeatures)
             return
         }
-        try await profileEditor.save(
-            to: profileManager,
-            preferencesManager: preferencesManager
-        )
+        try await profileEditor.save(to: profileManager)
         onDismiss()
     }
 

--- a/Library/Sources/CommonLibrary/Business/PreferencesManager.swift
+++ b/Library/Sources/CommonLibrary/Business/PreferencesManager.swift
@@ -85,6 +85,9 @@ private final class DummyModulePreferencesRepository: ModulePreferencesRepositor
 
     func save() throws {
     }
+
+    func discard() {
+    }
 }
 
 private final class DummyProviderPreferencesRepository: ProviderPreferencesRepository {

--- a/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
@@ -34,13 +34,13 @@ public final class ModulePreferences: ObservableObject {
     public init() {
     }
 
-    public func allowedEndpoints() -> Blacklist<ExtendedEndpoint> {
-        Blacklist { [weak self] in
-            self?.repository?.isExcludedEndpoint($0) != true
-        } allow: { [weak self] in
-            self?.repository?.removeExcludedEndpoint($0)
-        } deny: { [weak self] in
+    public func excludedEndpoints() -> ObservableList<ExtendedEndpoint> {
+        ObservableList { [weak self] in
+            self?.repository?.isExcludedEndpoint($0) == true
+        } add: { [weak self] in
             self?.repository?.addExcludedEndpoint($0)
+        } remove: { [weak self] in
+            self?.repository?.removeExcludedEndpoint($0)
         }
     }
 

--- a/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
@@ -43,12 +43,4 @@ public final class ModulePreferences: ObservableObject {
             self?.repository?.removeExcludedEndpoint($0)
         }
     }
-
-    public func save() throws {
-        try repository?.save()
-    }
-
-    public func discard() {
-        repository?.discard()
-    }
 }

--- a/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ModulePreferences.swift
@@ -47,4 +47,8 @@ public final class ModulePreferences: ObservableObject {
     public func save() throws {
         try repository?.save()
     }
+
+    public func discard() {
+        repository?.discard()
+    }
 }

--- a/Library/Sources/CommonLibrary/Domain/ProviderPreferences.swift
+++ b/Library/Sources/CommonLibrary/Domain/ProviderPreferences.swift
@@ -44,13 +44,13 @@ public final class ProviderPreferences: ObservableObject {
         }
     }
 
-    public func allowedEndpoints() -> Blacklist<ExtendedEndpoint> {
-        Blacklist { [weak self] in
-            self?.repository?.isExcludedEndpoint($0) != true
-        } allow: { [weak self] in
-            self?.repository?.removeExcludedEndpoint($0)
-        } deny: { [weak self] in
+    public func excludedEndpoints() -> ObservableList<ExtendedEndpoint> {
+        ObservableList { [weak self] in
+            self?.repository?.isExcludedEndpoint($0) == true
+        } add: { [weak self] in
             self?.repository?.addExcludedEndpoint($0)
+        } remove: { [weak self] in
+            self?.repository?.removeExcludedEndpoint($0)
         }
     }
 

--- a/Library/Sources/CommonLibrary/Strategy/ModulePreferencesRepository.swift
+++ b/Library/Sources/CommonLibrary/Strategy/ModulePreferencesRepository.swift
@@ -34,4 +34,6 @@ public protocol ModulePreferencesRepository {
     func removeExcludedEndpoint(_ endpoint: ExtendedEndpoint)
 
     func save() throws
+
+    func discard()
 }

--- a/Library/Sources/CommonUtils/Business/CoreDataPersistentStore.swift
+++ b/Library/Sources/CommonUtils/Business/CoreDataPersistentStore.swift
@@ -114,7 +114,7 @@ extension CoreDataPersistentStore {
         container.viewContext
     }
 
-    public var backgroundContext: NSManagedObjectContext {
+    public func backgroundContext() -> NSManagedObjectContext {
         container.newBackgroundContext()
     }
 

--- a/Library/Sources/CommonUtils/Business/ObservableList.swift
+++ b/Library/Sources/CommonUtils/Business/ObservableList.swift
@@ -1,5 +1,5 @@
 //
-//  Blacklist.swift
+//  ObservableList.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 12/8/24.
@@ -26,34 +26,34 @@
 import Foundation
 
 @MainActor
-public final class Blacklist<T>: ObservableObject where T: Equatable {
-    private let isAllowed: (T) -> Bool
+public final class ObservableList<T>: ObservableObject where T: Equatable {
+    private let contains: (T) -> Bool
 
-    private let allow: (T) -> Void
+    private let add: (T) -> Void
 
-    private let deny: (T) -> Void
+    private let remove: (T) -> Void
 
     public init(
-        isAllowed: @escaping (T) -> Bool,
-        allow: @escaping (T) -> Void,
-        deny: @escaping (T) -> Void
+        contains: @escaping (T) -> Bool,
+        add: @escaping (T) -> Void,
+        remove: @escaping (T) -> Void
     ) {
-        self.isAllowed = isAllowed
-        self.allow = allow
-        self.deny = deny
+        self.contains = contains
+        self.add = add
+        self.remove = remove
     }
 
-    public func isAllowed(_ value: T) -> Bool {
-        isAllowed(value)
+    public func contains(_ value: T) -> Bool {
+        contains(value)
     }
 
-    public func allow(_ value: T) {
+    public func add(_ value: T) {
         objectWillChange.send()
-        allow(value)
+        add(value)
     }
 
-    public func deny(_ value: T) {
+    public func remove(_ value: T) {
         objectWillChange.send()
-        deny(value)
+        remove(value)
     }
 }

--- a/Library/Sources/LegacyV2/Strategy/ProfileV2MigrationStrategy.swift
+++ b/Library/Sources/LegacyV2/Strategy/ProfileV2MigrationStrategy.swift
@@ -66,8 +66,8 @@ public final class ProfileV2MigrationStrategy: ProfileMigrationStrategy, Sendabl
             cloudKitIdentifier: tvProfilesContainer.cloudKitIdentifier,
             author: nil
         )
-        profilesRepository = CDProfileRepositoryV2(context: store.backgroundContext)
-        tvProfilesRepository = CDProfileRepositoryV2(context: tvStore.backgroundContext)
+        profilesRepository = CDProfileRepositoryV2(context: store.backgroundContext())
+        tvProfilesRepository = CDProfileRepositoryV2(context: tvStore.backgroundContext())
     }
 }
 

--- a/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -208,7 +208,11 @@ extension ProfileEditor {
         removedModules = [:]
     }
 
-    public func loadPreferences(_ preferences: ModulePreferences, forModuleWithId moduleId: UUID, manager: PreferencesManager) {
+    public func loadPreferences(
+        _ preferences: ModulePreferences,
+        from manager: PreferencesManager,
+        forModuleWithId moduleId: UUID
+    ) {
         do {
             pp_log(.App.profiles, .debug, "Track preferences for module \(moduleId)")
             let repository = try trackedPreferences[moduleId] ?? manager.preferencesRepository(forModuleWithId: moduleId)
@@ -220,10 +224,7 @@ extension ProfileEditor {
     }
 
     @discardableResult
-    public func save(
-        to profileManager: ProfileManager,
-        preferencesManager: PreferencesManager
-    ) async throws -> Profile {
+    public func save(to profileManager: ProfileManager) async throws -> Profile {
         do {
             let newProfile = try build()
             try await profileManager.save(newProfile, isLocal: true, remotelyShared: isShared)

--- a/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -37,7 +37,7 @@ public final class ProfileEditor: ObservableObject {
     @Published
     public var isShared: Bool
 
-    private var trackedPreferences: [UUID: ModulePreferences]
+    private var trackedPreferences: [UUID: ModulePreferencesRepository]
 
     private(set) var removedModules: [UUID: any ModuleBuilder]
 
@@ -207,15 +207,14 @@ extension ProfileEditor {
         removedModules = [:]
     }
 
-    public func preferences(forModuleWithId moduleId: UUID, manager: PreferencesManager) -> ModulePreferences {
+    public func loadPreferences(_ preferences: ModulePreferences, forModuleWithId moduleId: UUID, manager: PreferencesManager) {
         do {
             pp_log(.App.profiles, .debug, "Track preferences for module \(moduleId)")
-            let observable = try trackedPreferences[moduleId] ?? manager.preferences(forModuleWithId: moduleId)
-            trackedPreferences[moduleId] = observable
-            return observable
+            let repository = try trackedPreferences[moduleId] ?? manager.preferencesRepository(forModuleWithId: moduleId)
+            trackedPreferences[moduleId] = repository
+            preferences.repository = repository
         } catch {
             pp_log(.App.profiles, .error, "Unable to track preferences for module \(moduleId): \(error)")
-            return ModulePreferences()
         }
     }
 

--- a/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -244,6 +244,11 @@ extension ProfileEditor {
     }
 
     public func discard() {
+        trackedPreferences.forEach {
+            pp_log(.App.profiles, .debug, "Discard tracked preferences for module \($0.key)")
+            $0.value.discard()
+        }
+        trackedPreferences.removeAll()
     }
 }
 

--- a/Library/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Library/Sources/UILibrary/Business/ProfileEditor.swift
@@ -37,6 +37,7 @@ public final class ProfileEditor: ObservableObject {
     @Published
     public var isShared: Bool
 
+    @Published
     private var trackedPreferences: [UUID: ModulePreferencesRepository]
 
     private(set) var removedModules: [UUID: any ModuleBuilder]
@@ -211,8 +212,8 @@ extension ProfileEditor {
         do {
             pp_log(.App.profiles, .debug, "Track preferences for module \(moduleId)")
             let repository = try trackedPreferences[moduleId] ?? manager.preferencesRepository(forModuleWithId: moduleId)
-            trackedPreferences[moduleId] = repository
             preferences.repository = repository
+            trackedPreferences[moduleId] = repository // @Published
         } catch {
             pp_log(.App.profiles, .error, "Unable to track preferences for module \(moduleId): \(error)")
         }

--- a/Library/Tests/UILibraryTests/ProfileEditorTests.swift
+++ b/Library/Tests/UILibraryTests/ProfileEditorTests.swift
@@ -251,7 +251,7 @@ extension ProfileEditorTests {
             }
             .store(in: &subscriptions)
 
-        try await sut.save(to: manager, preferencesManager: PreferencesManager())
+        try await sut.save(to: manager)
         await fulfillment(of: [exp])
     }
 }

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -93,7 +93,7 @@ extension AppContext {
                 cloudKitIdentifier: nil,
                 author: nil
             )
-            let repository = AppData.cdProviderRepositoryV3(context: store.backgroundContext)
+            let repository = AppData.cdProviderRepositoryV3(context: store.backgroundContext())
             return ProviderManager(repository: repository)
         }()
 

--- a/Passepartout/Shared/Dependencies+PreferencesManager.swift
+++ b/Passepartout/Shared/Dependencies+PreferencesManager.swift
@@ -42,10 +42,16 @@ extension Dependencies {
         )
         return PreferencesManager(
             modulesFactory: {
-                try AppData.cdModulePreferencesRepositoryV3(context: preferencesStore.context, moduleId: $0)
+                try AppData.cdModulePreferencesRepositoryV3(
+                    context: preferencesStore.backgroundContext,
+                    moduleId: $0
+                )
             },
             providersFactory: {
-                try AppData.cdProviderPreferencesRepositoryV3(context: preferencesStore.context, providerId: $0)
+                try AppData.cdProviderPreferencesRepositoryV3(
+                    context: preferencesStore.backgroundContext,
+                    providerId: $0
+                )
             }
         )
     }

--- a/Passepartout/Shared/Dependencies+PreferencesManager.swift
+++ b/Passepartout/Shared/Dependencies+PreferencesManager.swift
@@ -43,13 +43,13 @@ extension Dependencies {
         return PreferencesManager(
             modulesFactory: {
                 try AppData.cdModulePreferencesRepositoryV3(
-                    context: preferencesStore.backgroundContext,
+                    context: preferencesStore.backgroundContext(),
                     moduleId: $0
                 )
             },
             providersFactory: {
                 try AppData.cdProviderPreferencesRepositoryV3(
-                    context: preferencesStore.backgroundContext,
+                    context: preferencesStore.backgroundContext(),
                     providerId: $0
                 )
             }


### PR DESCRIPTION
- Save/rollback was done outside of MOC
- Use different contexts for module/provider preferences
  - Save providers → also saves modules
  - Discard modules → also discards providers
  - Use background context because it's not automatically merged (can rollback)
- Expose ModulePreferences in OpenVPNView as StateObject
- Rework Blacklist to a more reusable ObservableList
- Reapply #988 