### PR TITLE
Fix a Core Data crash on Apple TV

### DIFF
--- a/Library/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
+++ b/Library/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
@@ -44,11 +44,15 @@ extension BundleConfiguration {
 
 extension BundleConfiguration {
     public static var urlForGroupCaches: URL {
-        appGroupURL.appending(components: "Library", "Caches")
+        let url = appGroupURL.appending(components: "Library", "Caches")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 
     public static var urlForGroupDocuments: URL {
-        appGroupURL.appending(components: "Library", "Documents")
+        let url = appGroupURL.appending(components: "Library", "Documents")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 }
 

--- a/Library/Sources/CommonUtils/Business/CoreDataPersistentStore.swift
+++ b/Library/Sources/CommonUtils/Business/CoreDataPersistentStore.swift
@@ -117,10 +117,6 @@ extension CoreDataPersistentStore {
     public func backgroundContext() -> NSManagedObjectContext {
         container.newBackgroundContext()
     }
-
-    public var coordinator: NSPersistentStoreCoordinator {
-        container.persistentStoreCoordinator
-    }
 }
 
 // MARK: Development


### PR DESCRIPTION
Could not create the Preferences Core Data container in the App Group because sub-directories did not exist. Create them upfront when using App Group URLs.

This was not an issue with other Core Data containers because they are stored in the app directories, where "Library/Documents" already exists.