### PR TITLE
Fix unselectable presets

### DIFF
--- a/Library/Sources/AppUIMain/Views/VPN/VPNFiltersView.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNFiltersView.swift
@@ -93,6 +93,8 @@ private extension VPNFiltersView {
 
     var presetPicker: some View {
         Picker(Strings.Views.Vpn.preset, selection: $model.filters.presetId) {
+            Text(Strings.Global.Nouns.any)
+                .tag(nil as String?)
             ForEach(model.presets, id: \.presetId) {
                 Text($0.description)
                     .tag($0.presetId as String?)

--- a/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
@@ -133,14 +133,17 @@ private extension VPNProviderServerView {
     }
 
     var initialFilters: VPNFilters? {
-        guard let selectedEntity, filtersWithSelection else {
+        guard let selectedEntity else {
             return nil
         }
         var filters = VPNFilters()
-        filters.categoryName = selectedEntity.server.provider.categoryName
+        filters.presetId = selectedEntity.preset.presetId
+        if filtersWithSelection {
+            filters.categoryName = selectedEntity.server.provider.categoryName
 #if os(macOS)
-        filters.countryCode = selectedEntity.server.provider.countryCode
+            filters.countryCode = selectedEntity.server.provider.countryCode
 #endif
+        }
         return filters
     }
 

--- a/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
@@ -132,29 +132,25 @@ private extension VPNProviderServerView {
         return servers
     }
 
-    var initialFilters: VPNFilters {
-        var filters = VPNFilters()
-
-        // force initial preset filter
-        filters.presetId = vpnManager.options.presets.first?.presetId
-
-        if let selectedEntity {
-            filters.presetId = selectedEntity.preset.presetId
-            if filtersWithSelection {
-                filters.categoryName = selectedEntity.server.provider.categoryName
-#if os(macOS)
-                filters.countryCode = selectedEntity.server.provider.countryCode
-#endif
-            }
+    var initialFilters: VPNFilters? {
+        guard let selectedEntity, filtersWithSelection else {
+            return nil
         }
+        var filters = VPNFilters()
+        filters.categoryName = selectedEntity.server.provider.categoryName
+#if os(macOS)
+        filters.countryCode = selectedEntity.server.provider.countryCode
+#endif
         return filters
     }
 
     func compatiblePreset(with server: VPNServer) -> VPNPreset<Configuration>? {
         vpnManager
             .presets
-            .filter {
-                $0.presetId == filtersViewModel.filters.presetId
+            .filter { preset in
+                filtersViewModel.presets.contains {
+                    preset.presetId == $0.presetId
+                }
             }
             .first {
                 if let supportedIds = server.provider.supportedPresetIds {

--- a/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerView.swift
@@ -144,15 +144,16 @@ private extension VPNProviderServerView {
         return filters
     }
 
-    func compatiblePreset(with server: VPNServer) -> VPNPreset<Configuration>? {
+    func compatiblePresets(with server: VPNServer) -> [VPNPreset<Configuration>] {
         vpnManager
             .presets
-            .filter { preset in
-                filtersViewModel.presets.contains {
-                    preset.presetId == $0.presetId
+            .filter {
+                if let selectedId = filtersViewModel.filters.presetId {
+                    return $0.presetId == selectedId
                 }
+                return true
             }
-            .first {
+            .filter {
                 if let supportedIds = server.provider.supportedPresetIds {
                     return supportedIds.contains($0.presetId)
                 }
@@ -215,7 +216,8 @@ private extension VPNProviderServerView {
     }
 
     func onSelectServer(_ server: VPNServer) {
-        guard let preset = compatiblePreset(with: server) else {
+        let presets = compatiblePresets(with: server)
+        guard let preset = presets.first else {
             pp_log(.app, .error, "Unable to find a compatible preset. Supported IDs: \(server.provider.supportedPresetIds ?? [])")
             assertionFailure("No compatible presets for server \(server.serverId) (provider=\(vpnManager.providerId), configuration=\(Configuration.configurationIdentifier), supported=\(server.provider.supportedPresetIds ?? []))")
             return


### PR DESCRIPTION
Revert #996 and do something midway:

- When set, use preset filter as selection (disambiguate compatible presets)
- Set initial preset filter with current selected server preset

Server selection still picks a random preset if:

- Preset filter is "Any"
- More than one preset is compatible