### PR TITLE
Improve variables in Config.xcconfig

### DIFF
--- a/Passepartout/Config.xcconfig
+++ b/Passepartout/Config.xcconfig
@@ -29,8 +29,7 @@
 // tweak these for local development
 CFG_APP_ID = com.algoritmico.ios.Passepartout
 CFG_APP_STORE_ID = 1433648537
-CFG_CLOUDKIT_ID = iCloud.com.algoritmico.Passepartout.v3
-CFG_CLOUDKIT_PREFERENCES_ID = iCloud.com.algoritmico.Passepartout.v3.Preferences
+CFG_CLOUDKIT_ROOT = iCloud.com.algoritmico.Passepartout
 CFG_IAP_BUNDLE_PREFIX = com.algoritmico.ios.Passepartout
 CFG_RAW_GROUP_ID = group.com.algoritmico.Passepartout
 CFG_TEAM_ID = DTDYD63ZX9
@@ -47,8 +46,10 @@ CFG_INTENTS_ID = $(CFG_APP_ID).Intents
 CFG_LOGIN_ITEM_ID = $(CFG_APP_ID).LoginItem
 CFG_TUNNEL_ID = $(CFG_APP_ID).Tunnel
 
-CFG_LEGACY_V2_CLOUDKIT_ID = iCloud.com.algoritmico.Passepartout
-CFG_LEGACY_V2_TV_CLOUDKIT_ID = iCloud.com.algoritmico.Passepartout.Shared
+CFG_CLOUDKIT_ID = $(CFG_CLOUDKIT_ROOT).v3
+CFG_CLOUDKIT_PREFERENCES_ID = $(CFG_CLOUDKIT_ROOT).v3.Preferences
+CFG_LEGACY_V2_CLOUDKIT_ID = $(CFG_CLOUDKIT_ROOT)
+CFG_LEGACY_V2_TV_CLOUDKIT_ID = $(CFG_CLOUDKIT_ROOT).Shared
 
 PATH = $(PATH):/opt/homebrew/bin:/usr/local/bin:/usr/local/go/bin
 CUSTOM_SCRIPT_PATH = $(PATH)

--- a/Passepartout/Config.xcconfig
+++ b/Passepartout/Config.xcconfig
@@ -26,10 +26,15 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
+// tweak these for local development
 CFG_APP_ID = com.algoritmico.ios.Passepartout
 CFG_APP_STORE_ID = 1433648537
 CFG_CLOUDKIT_ID = iCloud.com.algoritmico.Passepartout.v3
 CFG_CLOUDKIT_PREFERENCES_ID = iCloud.com.algoritmico.Passepartout.v3.Preferences
+CFG_IAP_BUNDLE_PREFIX = com.algoritmico.ios.Passepartout
+CFG_RAW_GROUP_ID = group.com.algoritmico.Passepartout
+CFG_TEAM_ID = DTDYD63ZX9
+
 CFG_COPYRIGHT = Copyright © 2024 Davide De Rosa. All rights reserved.
 CFG_DISPLAY_NAME = Passepartout
 CFG_GROUP_ID[sdk=appletvos*] = $(CFG_RAW_GROUP_ID)
@@ -38,11 +43,8 @@ CFG_GROUP_ID[sdk=iphoneos*] = $(CFG_RAW_GROUP_ID)
 CFG_GROUP_ID[sdk=iphonesimulator*] = $(CFG_RAW_GROUP_ID)
 CFG_GROUP_ID[sdk=macosx*] = $(CFG_TEAM_ID).$(CFG_RAW_GROUP_ID)
 CFG_KEYCHAIN_GROUP_ID = $(CFG_TEAM_ID).$(CFG_RAW_GROUP_ID)
-CFG_IAP_BUNDLE_PREFIX = com.algoritmico.ios.Passepartout
 CFG_INTENTS_ID = $(CFG_APP_ID).Intents
 CFG_LOGIN_ITEM_ID = $(CFG_APP_ID).LoginItem
-CFG_RAW_GROUP_ID = group.com.algoritmico.Passepartout
-CFG_TEAM_ID = DTDYD63ZX9
 CFG_TUNNEL_ID = $(CFG_APP_ID).Tunnel
 
 CFG_LEGACY_V2_CLOUDKIT_ID = iCloud.com.algoritmico.Passepartout

--- a/Passepartout/Config.xcconfig
+++ b/Passepartout/Config.xcconfig
@@ -30,7 +30,6 @@
 CFG_APP_ID = com.algoritmico.ios.Passepartout
 CFG_APP_STORE_ID = 1433648537
 CFG_CLOUDKIT_ROOT = iCloud.com.algoritmico.Passepartout
-CFG_IAP_BUNDLE_PREFIX = com.algoritmico.ios.Passepartout
 CFG_RAW_GROUP_ID = group.com.algoritmico.Passepartout
 CFG_TEAM_ID = DTDYD63ZX9
 
@@ -41,6 +40,7 @@ CFG_GROUP_ID[sdk=appletvsimulator*] = $(CFG_RAW_GROUP_ID)
 CFG_GROUP_ID[sdk=iphoneos*] = $(CFG_RAW_GROUP_ID)
 CFG_GROUP_ID[sdk=iphonesimulator*] = $(CFG_RAW_GROUP_ID)
 CFG_GROUP_ID[sdk=macosx*] = $(CFG_TEAM_ID).$(CFG_RAW_GROUP_ID)
+CFG_IAP_BUNDLE_PREFIX = $(CFG_APP_ID)
 CFG_KEYCHAIN_GROUP_ID = $(CFG_TEAM_ID).$(CFG_RAW_GROUP_ID)
 CFG_INTENTS_ID = $(CFG_APP_ID).Intents
 CFG_LOGIN_ITEM_ID = $(CFG_APP_ID).LoginItem

--- a/Passepartout/Config.xcconfig
+++ b/Passepartout/Config.xcconfig
@@ -26,7 +26,7 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-// tweak these for local development
+// tweak these based on app and team
 CFG_APP_ID = com.algoritmico.ios.Passepartout
 CFG_APP_STORE_ID = 1433648537
 CFG_CLOUDKIT_ROOT = iCloud.com.algoritmico.Passepartout


### PR DESCRIPTION
- Group variables linked to App Store Connect
- Reuse App ID as IAP prefix
- Reuse CloudKit prefix in container identifiers