### PR TITLE
Resolve Apple TV crashing on launch

### DIFF
--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -127,7 +127,6 @@ extension AppContext {
             let preferencesStore = CoreDataPersistentStore(
                 logger: dependencies.coreDataLogger(),
                 containerName: Constants.shared.containers.preferences,
-                baseURL: BundleConfiguration.urlForGroupDocuments,
                 model: AppData.cdPreferencesModel,
                 cloudKitIdentifier: BundleConfiguration.mainString(for: .cloudKitPreferencesId),
                 author: nil


### PR DESCRIPTION
Create preferences container locally because tvOS cannot write to App Group container.

Fixes #1007 