### PR TITLE
Add recurring products to paywall

### DIFF
--- a/Library/.swiftpm/xcode/xcshareddata/xcschemes/Library-Package.xcscheme
+++ b/Library/.swiftpm/xcode/xcshareddata/xcschemes/Library-Package.xcscheme
@@ -147,6 +147,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UIAccessibility"
+               BuildableName = "UIAccessibility"
+               BlueprintName = "UIAccessibility"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Library/Sources/CommonIAP/Domain/AppProduct+Features.swift
+++ b/Library/Sources/CommonIAP/Domain/AppProduct+Features.swift
@@ -82,6 +82,15 @@ extension AppProduct.Full {
 }
 
 extension AppProduct {
+    public var isFullVersion: Bool {
+        switch self {
+        case .Full.OneTime.full, .Full.OneTime.fullTV, .Full.Recurring.monthly, .Full.Recurring.yearly:
+            return true
+        default:
+            return false
+        }
+    }
+
     public var isRecurring: Bool {
         switch self {
         case .Full.Recurring.monthly, .Full.Recurring.yearly:

--- a/Library/Sources/CommonIAP/Domain/AppProduct+Features.swift
+++ b/Library/Sources/CommonIAP/Domain/AppProduct+Features.swift
@@ -81,6 +81,17 @@ extension AppProduct.Full {
     }
 }
 
+extension AppProduct {
+    public var isRecurring: Bool {
+        switch self {
+        case .Full.Recurring.monthly, .Full.Recurring.yearly:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 // MARK: - Discontinued
 
 extension AppProduct.Features {

--- a/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -33,42 +33,42 @@ extension IAPManager {
         purchasedProducts.contains(.Full.OneTime.full) || purchasedProducts.contains(.Full.OneTime.fullTV) || (purchasedProducts.contains(.Full.OneTime.iOS) && purchasedProducts.contains(.Full.OneTime.macOS))
     }
 
-    public func suggestedProducts(for features: Set<AppFeature>) -> (oneTime: [AppProduct], recurring: [AppProduct])? {
-        guard !features.isEmpty else {
+    public func suggestedProducts(for requiredFeatures: Set<AppFeature>) -> [AppProduct]? {
+        guard !requiredFeatures.isEmpty else {
             return nil
         }
-        guard !eligibleFeatures.isSuperset(of: features) else {
+        guard !eligibleFeatures.isSuperset(of: requiredFeatures) else {
             return nil
         }
 
-        var oneTime: [AppProduct] = []
-        let requiredFeatures = features.subtracting(eligibleFeatures)
+        var products: [AppProduct] = []
+        let ineligibleFeatures = requiredFeatures.subtracting(eligibleFeatures)
 
         if isFullVersionPurchaser {
-            if requiredFeatures == [.appleTV] {
-                oneTime.append(.Features.appleTV)
+            if ineligibleFeatures == [.appleTV] {
+                products.append(.Features.appleTV)
             } else {
                 assertionFailure("Full version purchaser requiring other than [.appleTV]")
             }
         } else { // !isFullVersionPurchaser
-            if requiredFeatures == [.appleTV] {
-                oneTime.append(.Features.appleTV)
-                oneTime.append(.Full.OneTime.fullTV)
-            } else if requiredFeatures.contains(.appleTV) {
-                oneTime.append(.Full.OneTime.fullTV)
+            if ineligibleFeatures == [.appleTV] {
+                products.append(.Features.appleTV)
+                products.append(.Full.OneTime.fullTV)
+            } else if ineligibleFeatures.contains(.appleTV) {
+                products.append(.Full.OneTime.fullTV)
             } else {
-                oneTime.append(.Full.OneTime.full)
+                products.append(.Full.OneTime.full)
                 if !eligibleFeatures.contains(.appleTV) {
-                    oneTime.append(.Full.OneTime.fullTV)
+                    products.append(.Full.OneTime.fullTV)
                 }
             }
         }
 
-        var recurring: [AppProduct] = []
-        if oneTime.contains(.Full.OneTime.fullTV) {
-            recurring = [.Full.Recurring.monthly, .Full.Recurring.yearly]
+        if products.contains(.Full.OneTime.fullTV) {
+            products.insert(.Full.Recurring.monthly, at: 0)
+            products.insert(.Full.Recurring.yearly, at: 0)
         }
 
-        return (oneTime, recurring)
+        return products
     }
 }

--- a/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -57,10 +57,10 @@ extension IAPManager {
             } else if ineligibleFeatures.contains(.appleTV) {
                 products.append(.Full.OneTime.fullTV)
             } else {
-                products.append(.Full.OneTime.full)
                 if !eligibleFeatures.contains(.appleTV) {
                     products.append(.Full.OneTime.fullTV)
                 }
+                products.append(.Full.OneTime.full)
             }
         }
 

--- a/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -64,6 +64,11 @@ extension IAPManager {
             }
         }
 
+        if list.contains(.Full.OneTime.fullTV) {
+            list.append(.Full.Recurring.monthly)
+            list.append(.Full.Recurring.yearly)
+        }
+
         return list
     }
 }

--- a/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -33,7 +33,7 @@ extension IAPManager {
         purchasedProducts.contains(.Full.OneTime.full) || purchasedProducts.contains(.Full.OneTime.fullTV) || (purchasedProducts.contains(.Full.OneTime.iOS) && purchasedProducts.contains(.Full.OneTime.macOS))
     }
 
-    public func suggestedProducts(for requiredFeatures: Set<AppFeature>) -> Set<AppProduct>? {
+    public func suggestedProducts(for requiredFeatures: Set<AppFeature>, withRecurring: Bool = true) -> Set<AppProduct>? {
         guard !requiredFeatures.isEmpty else {
             return nil
         }
@@ -64,7 +64,7 @@ extension IAPManager {
             }
         }
 
-        if products.contains(.Full.OneTime.fullTV) {
+        if withRecurring && products.contains(.Full.OneTime.fullTV) {
             products.insert(.Full.Recurring.monthly)
             products.insert(.Full.Recurring.yearly)
         }

--- a/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -33,42 +33,42 @@ extension IAPManager {
         purchasedProducts.contains(.Full.OneTime.full) || purchasedProducts.contains(.Full.OneTime.fullTV) || (purchasedProducts.contains(.Full.OneTime.iOS) && purchasedProducts.contains(.Full.OneTime.macOS))
     }
 
-    public func suggestedProducts(for features: Set<AppFeature>) -> [AppProduct] {
+    public func suggestedProducts(for features: Set<AppFeature>) -> (oneTime: [AppProduct], recurring: [AppProduct])? {
         guard !features.isEmpty else {
-            return []
+            return nil
         }
         guard !eligibleFeatures.isSuperset(of: features) else {
-            return []
+            return nil
         }
 
-        var list: [AppProduct] = []
+        var oneTime: [AppProduct] = []
         let requiredFeatures = features.subtracting(eligibleFeatures)
 
         if isFullVersionPurchaser {
             if requiredFeatures == [.appleTV] {
-                list.append(.Features.appleTV)
+                oneTime.append(.Features.appleTV)
             } else {
                 assertionFailure("Full version purchaser requiring other than [.appleTV]")
             }
         } else { // !isFullVersionPurchaser
             if requiredFeatures == [.appleTV] {
-                list.append(.Features.appleTV)
-                list.append(.Full.OneTime.fullTV)
+                oneTime.append(.Features.appleTV)
+                oneTime.append(.Full.OneTime.fullTV)
             } else if requiredFeatures.contains(.appleTV) {
-                list.append(.Full.OneTime.fullTV)
+                oneTime.append(.Full.OneTime.fullTV)
             } else {
-                list.append(.Full.OneTime.full)
+                oneTime.append(.Full.OneTime.full)
                 if !eligibleFeatures.contains(.appleTV) {
-                    list.append(.Full.OneTime.fullTV)
+                    oneTime.append(.Full.OneTime.fullTV)
                 }
             }
         }
 
-        if list.contains(.Full.OneTime.fullTV) {
-            list.append(.Full.Recurring.monthly)
-            list.append(.Full.Recurring.yearly)
+        var recurring: [AppProduct] = []
+        if oneTime.contains(.Full.OneTime.fullTV) {
+            recurring = [.Full.Recurring.monthly, .Full.Recurring.yearly]
         }
 
-        return list
+        return (oneTime, recurring)
     }
 }

--- a/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Library/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -33,7 +33,7 @@ extension IAPManager {
         purchasedProducts.contains(.Full.OneTime.full) || purchasedProducts.contains(.Full.OneTime.fullTV) || (purchasedProducts.contains(.Full.OneTime.iOS) && purchasedProducts.contains(.Full.OneTime.macOS))
     }
 
-    public func suggestedProducts(for requiredFeatures: Set<AppFeature>) -> [AppProduct]? {
+    public func suggestedProducts(for requiredFeatures: Set<AppFeature>) -> Set<AppProduct>? {
         guard !requiredFeatures.isEmpty else {
             return nil
         }
@@ -41,32 +41,32 @@ extension IAPManager {
             return nil
         }
 
-        var products: [AppProduct] = []
+        var products: Set<AppProduct> = []
         let ineligibleFeatures = requiredFeatures.subtracting(eligibleFeatures)
 
         if isFullVersionPurchaser {
             if ineligibleFeatures == [.appleTV] {
-                products.append(.Features.appleTV)
+                products.insert(.Features.appleTV)
             } else {
                 assertionFailure("Full version purchaser requiring other than [.appleTV]")
             }
         } else { // !isFullVersionPurchaser
             if ineligibleFeatures == [.appleTV] {
-                products.append(.Features.appleTV)
-                products.append(.Full.OneTime.fullTV)
+                products.insert(.Features.appleTV)
+                products.insert(.Full.OneTime.fullTV)
             } else if ineligibleFeatures.contains(.appleTV) {
-                products.append(.Full.OneTime.fullTV)
+                products.insert(.Full.OneTime.fullTV)
             } else {
                 if !eligibleFeatures.contains(.appleTV) {
-                    products.append(.Full.OneTime.fullTV)
+                    products.insert(.Full.OneTime.fullTV)
                 }
-                products.append(.Full.OneTime.full)
+                products.insert(.Full.OneTime.full)
             }
         }
 
         if products.contains(.Full.OneTime.fullTV) {
-            products.insert(.Full.Recurring.monthly, at: 0)
-            products.insert(.Full.Recurring.yearly, at: 0)
+            products.insert(.Full.Recurring.monthly)
+            products.insert(.Full.Recurring.yearly)
         }
 
         return products

--- a/Library/Sources/LegacyV2/Strategy/CDProfileRepositoryV2.swift
+++ b/Library/Sources/LegacyV2/Strategy/CDProfileRepositoryV2.swift
@@ -44,10 +44,7 @@ final class CDProfileRepositoryV2: Sendable {
 
     var hasMigratableProfiles: Bool {
         do {
-            return try context.performAndWait { [weak self] in
-                guard let self else {
-                    return false
-                }
+            return try context.performAndWait {
                 let entities = try CDProfile.fetchRequest().execute()
                 return !entities.compactMap {
                     ($0.encryptedJSON ?? $0.json) != nil

--- a/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Library/Sources/UILibrary/Business/AppContext.swift
@@ -98,7 +98,9 @@ private extension AppContext {
 
         pp_log(.App.profiles, .info, "\tObserve in-app events...")
         iapManager.observeObjects()
-        await iapManager.reloadReceipt()
+        Task {
+            await iapManager.reloadReceipt()
+        }
 
         pp_log(.App.profiles, .info, "\tObserve eligible features...")
         iapManager

--- a/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -749,9 +749,9 @@ public enum Strings {
           /// Full version includes
           public static let header = Strings.tr("Localizable", "views.paywall.sections.all_features.header", fallback: "Full version includes")
         }
-        public enum OneTime {
-          /// Lifetime
-          public static let header = Strings.tr("Localizable", "views.paywall.sections.one_time.header", fallback: "Lifetime")
+        public enum FullProducts {
+          /// Full version
+          public static let header = Strings.tr("Localizable", "views.paywall.sections.full_products.header", fallback: "Full version")
         }
         public enum RequiredFeatures {
           /// Required features
@@ -762,10 +762,6 @@ public enum Strings {
           public static let footer = Strings.tr("Localizable", "views.paywall.sections.restore.footer", fallback: "If you bought this app or feature in the past, you can restore your purchases.")
           /// Restore
           public static let header = Strings.tr("Localizable", "views.paywall.sections.restore.header", fallback: "Restore")
-        }
-        public enum Subscription {
-          /// Subscription
-          public static let header = Strings.tr("Localizable", "views.paywall.sections.subscription.header", fallback: "Subscription")
         }
       }
     }

--- a/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Library/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -749,9 +749,9 @@ public enum Strings {
           /// Full version includes
           public static let header = Strings.tr("Localizable", "views.paywall.sections.all_features.header", fallback: "Full version includes")
         }
-        public enum FullProducts {
-          /// Full version
-          public static let header = Strings.tr("Localizable", "views.paywall.sections.full_products.header", fallback: "Full version")
+        public enum OneTime {
+          /// Lifetime
+          public static let header = Strings.tr("Localizable", "views.paywall.sections.one_time.header", fallback: "Lifetime")
         }
         public enum RequiredFeatures {
           /// Required features
@@ -763,9 +763,9 @@ public enum Strings {
           /// Restore
           public static let header = Strings.tr("Localizable", "views.paywall.sections.restore.header", fallback: "Restore")
         }
-        public enum SuggestedProduct {
-          /// One-time purchase
-          public static let header = Strings.tr("Localizable", "views.paywall.sections.suggested_product.header", fallback: "One-time purchase")
+        public enum Subscription {
+          /// Subscription
+          public static let header = Strings.tr("Localizable", "views.paywall.sections.subscription.header", fallback: "Subscription")
         }
       }
     }

--- a/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -78,8 +78,7 @@
 "views.migration.alerts.delete.message" = "Do you want to discard these profiles? You will not be able to recover them later.\n\n%@";
 
 "views.paywall.sections.required_features.header" = "Required features";
-"views.paywall.sections.subscription.header" = "Subscription";
-"views.paywall.sections.one_time.header" = "Lifetime";
+"views.paywall.sections.full_products.header" = "Full version";
 "views.paywall.sections.all_features.header" = "Full version includes";
 "views.paywall.sections.restore.header" = "Restore";
 "views.paywall.sections.restore.footer" = "If you bought this app or feature in the past, you can restore your purchases.";

--- a/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Library/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -78,8 +78,8 @@
 "views.migration.alerts.delete.message" = "Do you want to discard these profiles? You will not be able to recover them later.\n\n%@";
 
 "views.paywall.sections.required_features.header" = "Required features";
-"views.paywall.sections.suggested_product.header" = "One-time purchase";
-"views.paywall.sections.full_products.header" = "Full version";
+"views.paywall.sections.subscription.header" = "Subscription";
+"views.paywall.sections.one_time.header" = "Lifetime";
 "views.paywall.sections.all_features.header" = "Full version includes";
 "views.paywall.sections.restore.header" = "Restore";
 "views.paywall.sections.restore.footer" = "If you bought this app or feature in the past, you can restore your purchases.";

--- a/Library/Sources/UILibrary/Views/Paywall/PaywallProductViewStyle.swift
+++ b/Library/Sources/UILibrary/Views/Paywall/PaywallProductViewStyle.swift
@@ -26,9 +26,7 @@
 import Foundation
 
 public enum PaywallProductViewStyle {
-    case oneTime
-
-    case recurring
-
     case donation
+
+    case paywall
 }

--- a/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -282,15 +282,15 @@ private extension AppProduct {
     var fullVersionRank: Int {
         switch self {
         case .Full.Recurring.yearly:
-            return 4
+            return .min
         case .Full.Recurring.monthly:
-            return 3
+            return 1
         case .Full.OneTime.fullTV:
             return 2
         case .Full.OneTime.full:
-            return 1
+            return 3
         default:
-            return 0
+            return .max
         }
     }
 }

--- a/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -189,12 +189,14 @@ private extension PaywallView {
             guard !availableProducts.isEmpty else {
                 throw AppError.emptyProducts
             }
-            iaps = try await iapManager.purchasableProducts(for: availableProducts)
+            let iaps = try await iapManager.purchasableProducts(for: availableProducts)
             pp_log(.App.iap, .info, "Suggested products: \(availableProducts)")
             pp_log(.App.iap, .info, "\tIAPs: \(iaps)")
             guard !iaps.isEmpty else {
                 throw AppError.emptyProducts
             }
+
+            self.iaps = iaps
         } catch {
             onError(error, dismissing: true)
         }

--- a/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -87,8 +87,8 @@ private extension PaywallView {
     var contentView: some View {
         Form {
             requiredFeaturesView
-            oneTimeProductsView
             recurringProductsView
+            oneTimeProductsView
             if !iapManager.isFullVersionPurchaser {
                 fullVersionFeaturesView
             }
@@ -110,6 +110,23 @@ private extension PaywallView {
         )
     }
 
+    var recurringProductsView: some View {
+        recurringIAPs.nilIfEmpty.map { iaps in
+            ForEach(iaps, id: \.productIdentifier) {
+                PaywallProductView(
+                    iapManager: iapManager,
+                    style: .recurring,
+                    product: $0,
+                    purchasingIdentifier: $purchasingIdentifier,
+                    onComplete: onComplete,
+                    onError: onError
+                )
+            }
+            // FIXME: ### l10n
+            .themeSection(header: "Subscription")
+        }
+    }
+
     var oneTimeProductsView: some View {
         oneTimeIAPs.nilIfEmpty.map {
             ForEach($0, id: \.productIdentifier) {
@@ -122,22 +139,8 @@ private extension PaywallView {
                     onError: onError
                 )
             }
-            .themeSection(header: Strings.Global.Nouns.purchases)
-        }
-    }
-
-    var recurringProductsView: some View {
-        recurringIAPs.nilIfEmpty.map {
-            ForEach($0, id: \.productIdentifier) {
-                PaywallProductView(
-                    iapManager: iapManager,
-                    style: .recurring,
-                    product: $0,
-                    purchasingIdentifier: $purchasingIdentifier,
-                    onComplete: onComplete,
-                    onError: onError
-                )
-            }
+            // FIXME: ### l10n
+            .themeSection(header: "Lifetime")
         }
     }
 

--- a/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Library/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -122,8 +122,7 @@ private extension PaywallView {
                     onError: onError
                 )
             }
-            // FIXME: ### l10n
-            .themeSection(header: "Subscription")
+            .themeSection(header: Strings.Views.Paywall.Sections.Subscription.header)
         }
     }
 
@@ -139,8 +138,7 @@ private extension PaywallView {
                     onError: onError
                 )
             }
-            // FIXME: ### l10n
-            .themeSection(header: "Lifetime")
+            .themeSection(header: Strings.Views.Paywall.Sections.OneTime.header)
         }
     }
 

--- a/Library/Sources/UILibrary/Views/Paywall/StoreKitProductView.swift
+++ b/Library/Sources/UILibrary/Views/Paywall/StoreKitProductView.swift
@@ -65,14 +65,14 @@ private extension ProductView {
     func withPaywallStyle(_ paywallStyle: PaywallProductViewStyle) -> some View {
 #if os(tvOS)
         switch paywallStyle {
-        case .oneTime, .recurring:
-            productViewStyle(.regular)
-                .listRowBackground(Color.clear)
-                .listRowInsets(.init())
-
         case .donation:
             productViewStyle(.compact)
                 .padding()
+
+        case .paywall:
+            productViewStyle(.regular)
+                .listRowBackground(Color.clear)
+                .listRowInsets(.init())
         }
 #else
         productViewStyle(.compact)

--- a/Library/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Library/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -263,12 +263,12 @@ extension IAPManagerTests {
 extension IAPManagerTests {
     func test_givenFree_whenRequireNothing_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [])
-        XCTAssertTrue(sut.suggestedProducts(for: []).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: []))
     }
 
     func test_givenFree_whenRequireFeature_thenSuggestsFullAndFullTV() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: [.dns]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.dns])?.oneTime, [
             .Full.OneTime.full,
             .Full.OneTime.fullTV
         ])
@@ -276,7 +276,7 @@ extension IAPManagerTests {
 
     func test_givenFree_whenRequireAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
             .Features.appleTV,
             .Full.OneTime.fullTV
         ])
@@ -284,19 +284,19 @@ extension IAPManagerTests {
 
     func test_givenFree_whenRequireFeatureAndAppleTV_thenSuggestsFullTV() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
             .Full.OneTime.fullTV
         ])
     }
 
     func test_givenCurrentPlatform_whenRequireFeature_thenSuggestsNothing() async {
         let sut = await IAPManager.withFullCurrentPlatform()
-        XCTAssertTrue(sut.suggestedProducts(for: [.dns]).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: [.dns]))
     }
 
     func test_givenCurrentPlatform_whenRequireAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager.withFullCurrentPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
             .Features.appleTV,
             .Full.OneTime.fullTV
         ])
@@ -304,7 +304,7 @@ extension IAPManagerTests {
 
     func test_givenCurrentPlatform_whenRequireFeatureAndAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager.withFullCurrentPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
             .Features.appleTV,
             .Full.OneTime.fullTV
         ])
@@ -312,7 +312,7 @@ extension IAPManagerTests {
 
     func test_givenOtherPlatform_whenRequireFeature_thenSuggestsFullAndFullTV() async {
         let sut = await IAPManager.withFullOtherPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.dns]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.dns])?.oneTime, [
             .Full.OneTime.full,
             .Full.OneTime.fullTV
         ])
@@ -320,7 +320,7 @@ extension IAPManagerTests {
 
     func test_givenOtherPlatform_whenRequireAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager.withFullOtherPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
             .Features.appleTV,
             .Full.OneTime.fullTV
         ])
@@ -328,62 +328,62 @@ extension IAPManagerTests {
 
     func test_givenOtherPlatform_whenRequireFeatureAndAppleTV_thenSuggestsFullTV() async {
         let sut = await IAPManager.withFullOtherPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
             .Full.OneTime.fullTV
         ])
     }
 
     func test_givenFull_whenRequireFeature_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Full.OneTime.full])
-        XCTAssertTrue(sut.suggestedProducts(for: [.dns]).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: [.dns]))
     }
 
     func test_givenFull_whenRequireAppleTV_thenSuggestsAppleTV() async {
         let sut = await IAPManager(products: [.Full.OneTime.full])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
             .Features.appleTV
         ])
     }
 
     func test_givenFull_whenRequireFeatureAndAppleTV_thenSuggestsAppleTV() async {
         let sut = await IAPManager(products: [.Full.OneTime.full])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
             .Features.appleTV
         ])
     }
 
     func test_givenAppleTV_whenRequireFeature_thenSuggestsFull() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: [.dns]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.dns])?.oneTime, [
             .Full.OneTime.full
         ])
     }
 
     func test_givenAppleTV_whenRequireAppleTV_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertTrue(sut.suggestedProducts(for: [.appleTV]).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: [.appleTV]))
     }
 
     func test_givenAppleTV_whenRequireFeatureAndAppleTV_thenSuggestsFull() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
             .Full.OneTime.full
         ])
     }
 
     func test_givenAll_whenRequireFeature_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Full.OneTime.fullTV])
-        XCTAssertTrue(sut.suggestedProducts(for: [.dns]).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: [.dns]))
     }
 
     func test_givenAll_whenRequireAppleTV_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Full.OneTime.fullTV])
-        XCTAssertTrue(sut.suggestedProducts(for: [.appleTV]).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: [.appleTV]))
     }
 
     func test_givenAll_whenRequireFeatureAndAppleTV_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Full.OneTime.fullTV])
-        XCTAssertTrue(sut.suggestedProducts(for: [.appleTV, .providers]).isEmpty)
+        XCTAssertNil(sut.suggestedProducts(for: [.appleTV, .providers]))
     }
 }
 

--- a/Library/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Library/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -268,7 +268,9 @@ extension IAPManagerTests {
 
     func test_givenFree_whenRequireFeature_thenSuggestsFullAndFullTV() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: [.dns])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.dns]), [
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.full,
             .Full.OneTime.fullTV
         ])
@@ -276,15 +278,19 @@ extension IAPManagerTests {
 
     func test_givenFree_whenRequireAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
             .Features.appleTV,
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.fullTV
         ])
     }
 
     func test_givenFree_whenRequireFeatureAndAppleTV_thenSuggestsFullTV() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.fullTV
         ])
     }
@@ -296,39 +302,49 @@ extension IAPManagerTests {
 
     func test_givenCurrentPlatform_whenRequireAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager.withFullCurrentPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
             .Features.appleTV,
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.fullTV
         ])
     }
 
     func test_givenCurrentPlatform_whenRequireFeatureAndAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager.withFullCurrentPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
             .Features.appleTV,
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.fullTV
         ])
     }
 
     func test_givenOtherPlatform_whenRequireFeature_thenSuggestsFullAndFullTV() async {
         let sut = await IAPManager.withFullOtherPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.dns])?.oneTime, [
-            .Full.OneTime.full,
-            .Full.OneTime.fullTV
+        XCTAssertEqual(sut.suggestedProducts(for: [.dns]), [
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
+            .Full.OneTime.fullTV,
+            .Full.OneTime.full
         ])
     }
 
     func test_givenOtherPlatform_whenRequireAppleTV_thenSuggestsAppleTVAndFullTV() async {
         let sut = await IAPManager.withFullOtherPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
             .Features.appleTV,
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.fullTV
         ])
     }
 
     func test_givenOtherPlatform_whenRequireFeatureAndAppleTV_thenSuggestsFullTV() async {
         let sut = await IAPManager.withFullOtherPlatform()
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
+            .Full.Recurring.yearly,
+            .Full.Recurring.monthly,
             .Full.OneTime.fullTV
         ])
     }
@@ -340,21 +356,21 @@ extension IAPManagerTests {
 
     func test_givenFull_whenRequireAppleTV_thenSuggestsAppleTV() async {
         let sut = await IAPManager(products: [.Full.OneTime.full])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV]), [
             .Features.appleTV
         ])
     }
 
     func test_givenFull_whenRequireFeatureAndAppleTV_thenSuggestsAppleTV() async {
         let sut = await IAPManager(products: [.Full.OneTime.full])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
             .Features.appleTV
         ])
     }
 
     func test_givenAppleTV_whenRequireFeature_thenSuggestsFull() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: [.dns])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.dns]), [
             .Full.OneTime.full
         ])
     }
@@ -366,7 +382,7 @@ extension IAPManagerTests {
 
     func test_givenAppleTV_whenRequireFeatureAndAppleTV_thenSuggestsFull() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers])?.oneTime, [
+        XCTAssertEqual(sut.suggestedProducts(for: [.appleTV, .providers]), [
             .Full.OneTime.full
         ])
     }


### PR DESCRIPTION
Suggest whenever .fullTV is suggested.  For this reason, subscriptions are not suggested to existing full version purchasers, because they only miss the one-time .appleTV purchase. Group purchases by feature products and full version products, e.g.:

- Features
  - Apple TV
- Full version
  - Yearly
  - Monthly
  - Full
  - Full + TV

Additionally, fix reloadReceipt() slowing down onLaunch() sometimes. The warning sign would appear on restricted profiles until the receipt is loaded.