### PR TITLE
Always refresh app features onForeground()

### DIFF
--- a/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Library/Sources/UILibrary/Business/AppContext.swift
@@ -98,14 +98,21 @@ private extension AppContext {
 
         pp_log(.App.profiles, .info, "\tObserve in-app events...")
         iapManager.observeObjects()
+
+        // load in background, see comment right below
         Task {
             await iapManager.reloadReceipt()
         }
 
+        // using Task above (#1019) causes the receipt to be loaded asynchronously.
+        // the initial call to onEligibleFeatures() may execute before the receipt is
+        // loaded and therefore do nothing. with .removeDuplicates(), there would
+        // not be a second chance to call onEligibleFeatures() after reloading the
+        // receipt. that's why it's commented now
         pp_log(.App.profiles, .info, "\tObserve eligible features...")
         iapManager
             .$eligibleFeatures
-            .removeDuplicates()
+//            .removeDuplicates()
             .sink { [weak self] eligible in
                 Task {
                     try await self?.onEligibleFeatures(eligible)

--- a/Library/Sources/UILibrary/Business/AppContext.swift
+++ b/Library/Sources/UILibrary/Business/AppContext.swift
@@ -107,8 +107,10 @@ private extension AppContext {
         // using Task above (#1019) causes the receipt to be loaded asynchronously.
         // the initial call to onEligibleFeatures() may execute before the receipt is
         // loaded and therefore do nothing. with .removeDuplicates(), there would
-        // not be a second chance to call onEligibleFeatures() after reloading the
-        // receipt. that's why it's commented now
+        // not be a second chance to call onEligibleFeatures() if the eligible
+        // features haven't changed after reloading the receipt (this is the case
+        // for TestFlight where some features are set statically). that's why it's
+        // commented now
         pp_log(.App.profiles, .info, "\tObserve eligible features...")
         iapManager
             .$eligibleFeatures


### PR DESCRIPTION
Even if they haven't changed since the app was last sent to the background.

Regression from #1019 where the initial .reloadReceipt() call was wrapped in a Task to make it asynchronous.