### PR TITLE
Fix regressions with CloudKit synchronization

### DIFF
--- a/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -212,7 +212,7 @@ private extension ProfileRowView {
     }
     .task {
         do {
-            try await profileManager.observeRemote(true)
+            try await profileManager.observeRemote(repository: InMemoryProfileRepository())
             try await profileManager.save(profile, isLocal: true, remotelyShared: true)
         } catch {
             fatalError(error.localizedDescription)

--- a/Library/Sources/CommonLibrary/Business/PreferencesManager.swift
+++ b/Library/Sources/CommonLibrary/Business/PreferencesManager.swift
@@ -29,18 +29,15 @@ import PassepartoutKit
 
 @MainActor
 public final class PreferencesManager: ObservableObject {
-    private let modulesFactory: (UUID) throws -> ModulePreferencesRepository
+    public var modulesRepositoryFactory: (UUID) throws -> ModulePreferencesRepository
 
-    private let providersFactory: (ProviderID) throws -> ProviderPreferencesRepository
+    public var providersRepositoryFactory: (ProviderID) throws -> ProviderPreferencesRepository
 
-    public init(
-        modulesFactory: ((UUID) throws -> ModulePreferencesRepository)? = nil,
-        providersFactory: ((ProviderID) throws -> ProviderPreferencesRepository)? = nil
-    ) {
-        self.modulesFactory = modulesFactory ?? { _ in
+    public init() {
+        modulesRepositoryFactory = { _ in
             DummyModulePreferencesRepository()
         }
-        self.providersFactory = providersFactory ?? { _ in
+        providersRepositoryFactory = { _ in
             DummyProviderPreferencesRepository()
         }
     }
@@ -48,11 +45,11 @@ public final class PreferencesManager: ObservableObject {
 
 extension PreferencesManager {
     public func preferencesRepository(forModuleWithId moduleId: UUID) throws -> ModulePreferencesRepository {
-        try modulesFactory(moduleId)
+        try modulesRepositoryFactory(moduleId)
     }
 
     public func preferencesRepository(forProviderWithId providerId: ProviderID) throws -> ProviderPreferencesRepository {
-        try providersFactory(providerId)
+        try providersRepositoryFactory(providerId)
     }
 }
 

--- a/Library/Sources/CommonUtils/Business/CoreDataPersistentStore.swift
+++ b/Library/Sources/CommonUtils/Business/CoreDataPersistentStore.swift
@@ -90,6 +90,10 @@ public final class CoreDataPersistentStore: Sendable {
         // container was formerly created with CloudKit option
         desc.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
 
+        // migrate automatically
+        desc.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
+        desc.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
+
         // report remote notifications (do this BEFORE loadPersistentStores)
         //
         // https://stackoverflow.com/a/69507329/784615

--- a/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
+++ b/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
@@ -180,20 +180,19 @@ private extension CoreDataRepository {
         request.predicate = predicate
         beforeFetch?(request)
 
-        let newController = try await context.perform {
-            let newController = NSFetchedResultsController(
-                fetchRequest: request,
-                managedObjectContext: self.context,
-                sectionNameKeyPath: nil,
-                cacheName: nil
-            )
-            newController.delegate = self
-            try newController.performFetch()
-            return newController
-        }
-
+        let newController = NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: self.context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+        newController.delegate = self
         resultsController = newController
-        return await sendResults(from: newController)
+
+        return try await context.perform {
+            try newController.performFetch()
+            return self.unsafeSendResults(from: newController)
+        }
     }
 
     @discardableResult

--- a/Passepartout/App/Context/ProfileManager+Testing.swift
+++ b/Passepartout/App/Context/ProfileManager+Testing.swift
@@ -31,14 +31,12 @@ extension ProfileManager {
     public static func forUITesting(withRegistry registry: Registry, processor: ProfileProcessor) -> ProfileManager {
         let repository = InMemoryProfileRepository()
         let remoteRepository = InMemoryProfileRepository()
-        let manager = ProfileManager(repository: repository, remoteRepositoryBlock: { _ in
-            remoteRepository
-        }, processor: processor)
+        let manager = ProfileManager(processor: processor, repository: repository)
 
         Task {
             do {
                 try await manager.observeLocal()
-                try await manager.observeRemote(true)
+                try await manager.observeRemote(repository: remoteRepository)
 
                 for parameters in mockParameters {
                     var builder = Profile.Builder()

--- a/Passepartout/Shared/Dependencies+PassepartoutKit.swift
+++ b/Passepartout/Shared/Dependencies+PassepartoutKit.swift
@@ -33,11 +33,15 @@ extension Dependencies {
         Self.sharedRegistry
     }
 
+    func profileCoder() -> ProfileCoder {
+        CodableProfileCoder()
+    }
+
     func neProtocolCoder() -> NEProtocolCoder {
         KeychainNEProtocolCoder(
             tunnelBundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
             registry: registry,
-            coder: CodableProfileCoder(),
+            coder: profileCoder(),
             keychain: AppleKeychain(group: BundleConfiguration.mainString(for: .keychainGroupId))
         )
     }


### PR DESCRIPTION
The remote container is shared by ProfileManager and
PreferencesManager, but it must be the same for CloudKit sync
to work properly.

Externalize the logic of onEligibleFeatures() so that the
AppContext singleton can update the managers (and their
repositories) with the new remote store.

Now that the remote profile repository is reloaded every time that
eligible features change, the .removeDuplicates() may also be
restored. Just add a .dropFirst() to skip the initially empty
value of eligible features. Even when features are eventually empty,
a value is always emitted after IAPManager.reloadReceipt()

Lastly, enable Core Data lightweight migration.

Regressions from #1017 