### PR TITLE
Do not connect TV profile on server selection

### DIFF
--- a/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
+++ b/Library/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
@@ -88,14 +88,14 @@ private extension ProfileContextMenu {
     }
 
     var providerConnectToButton: some View {
-        profile.map {
+        profile.map { profile in
             ProviderConnectToButton(
-                profile: $0,
+                profile: profile,
                 onTap: {
                     flow?.connectionFlow?.onProviderEntityRequired($0)
                 },
                 label: {
-                    ThemeImageLabel(Strings.Views.App.ProfileContext.connectTo.withTrailingDots, .profileProvider)
+                    ThemeImageLabel(profile.providerServerSelectionTitle, .profileProvider)
                 }
             )
             .uiAccessibility(.App.ProfileMenu.connectTo)
@@ -140,6 +140,13 @@ private extension ProfileContextMenu {
         ) {
             ThemeImageLabel(Strings.Global.Actions.remove, .contextRemove)
         }
+    }
+}
+
+private extension Profile {
+    var providerServerSelectionTitle: String {
+        (attributes.isAvailableForTV == true ?
+         Strings.Views.Providers.selectEntity : Strings.Views.App.ProfileContext.connectTo).withTrailingDots
     }
 }
 

--- a/Library/Sources/AppUIMain/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
@@ -37,6 +37,7 @@ extension OpenVPNModule.Builder: ModuleViewProviding {
 extension OpenVPNModule: ProviderEntityViewProviding {
     public func providerEntityView(
         errorHandler: ErrorHandler,
+        selectTitle: String,
         onSelect: @escaping (Module) async throws -> Void
     ) -> some View {
         providerSelection.map {
@@ -44,6 +45,7 @@ extension OpenVPNModule: ProviderEntityViewProviding {
                 moduleId: id,
                 providerId: $0.id,
                 selectedEntity: $0.entity,
+                selectTitle: selectTitle,
                 onSelect: {
                     var newBuilder = builder()
                     newBuilder.providerEntity = $0

--- a/Library/Sources/AppUIMain/Views/Modules/Extensions/WireGuardModule+Extensions.swift
+++ b/Library/Sources/AppUIMain/Views/Modules/Extensions/WireGuardModule+Extensions.swift
@@ -37,6 +37,7 @@ extension WireGuardModule.Builder: ModuleViewProviding {
 extension WireGuardModule: ProviderEntityViewProviding {
     public func providerEntityView(
         errorHandler: ErrorHandler,
+        selectTitle: String,
         onSelect: @escaping (Module) async throws -> Void
     ) -> some View {
         providerSelection.map {
@@ -44,6 +45,7 @@ extension WireGuardModule: ProviderEntityViewProviding {
                 moduleId: id,
                 providerId: $0.id,
                 selectedEntity: $0.entity,
+                selectTitle: selectTitle,
                 onSelect: {
                     var newBuilder = builder()
                     newBuilder.providerEntity = $0

--- a/Library/Sources/AppUIMain/Views/Providers/ProviderEntitySelector.swift
+++ b/Library/Sources/AppUIMain/Views/Providers/ProviderEntitySelector.swift
@@ -33,12 +33,15 @@ struct ProviderEntitySelector: View {
 
     let errorHandler: ErrorHandler
 
+    let selectTitle: String
+
     let onSelect: (Module) async throws -> Void
 
     var body: some View {
         if let viewProvider = module as? any ProviderEntityViewProviding {
             AnyView(viewProvider.providerEntityView(
                 errorHandler: errorHandler,
+                selectTitle: selectTitle,
                 onSelect: onSelect
             ))
         } else {

--- a/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerCoordinator.swift
+++ b/Library/Sources/AppUIMain/Views/VPN/VPNProviderServerCoordinator.swift
@@ -38,6 +38,8 @@ struct VPNProviderServerCoordinator<Configuration>: View where Configuration: Id
 
     let selectedEntity: VPNEntity<Configuration>?
 
+    let selectTitle: String
+
     let onSelect: (VPNEntity<Configuration>) async throws -> Void
 
     @ObservedObject
@@ -49,7 +51,7 @@ struct VPNProviderServerCoordinator<Configuration>: View where Configuration: Id
             providerId: providerId,
             selectedEntity: selectedEntity,
             filtersWithSelection: false,
-            selectTitle: Strings.Global.Actions.connect,
+            selectTitle: selectTitle,
             onSelect: onSelect
         )
         .themeNavigationStack(closable: true)

--- a/Library/Sources/UILibrary/Strategy/ProviderEntityViewProviding.swift
+++ b/Library/Sources/UILibrary/Strategy/ProviderEntityViewProviding.swift
@@ -33,6 +33,7 @@ public protocol ProviderEntityViewProviding {
     @MainActor
     func providerEntityView(
         errorHandler: ErrorHandler,
+        selectTitle: String,
         onSelect: @escaping (Module) async throws -> Void
     ) -> EntityContent
 }


### PR DESCRIPTION
You may still connect manually, but iOS/macOS apps mainly serve as remote to switch servers on the TV.