### PR TITLE
Fix uncredited features on tvOS

### DIFF
--- a/Library/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Library/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -45,14 +45,14 @@ extension AppProduct: AppFeatureProviding {
             }
 
         case .Full.OneTime.iOS:
-#if os(iOS)
+#if os(iOS) || os(tvOS)
             return AppProduct.Full.OneTime.iOS_macOS.features
 #else
             return []
 #endif
 
         case .Full.OneTime.macOS:
-#if os(macOS)
+#if os(macOS) || os(tvOS)
             return AppProduct.Full.OneTime.iOS_macOS.features
 #else
             return []


### PR DESCRIPTION
This was not apparent on TestFlight, but features from single iOS and macOS "Full version" purchases were not being credited on the Apple TV because of the incomplete `#if` conditionals.