### PR TITLE
Fix macOS not reconnecting on wake-up

### DIFF
--- a/Library/Package.resolved
+++ b/Library/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:passepartoutvpn/passepartoutkit-source",
       "state" : {
-        "revision" : "f1b8f8fde72a1fbd792c8c7393f834ff2478017e"
+        "revision" : "9422ff9fb429c09cce7ebaedd4daee755db9bac0"
       }
     },
     {

--- a/Library/Package.swift
+++ b/Library/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
     ],
     dependencies: [
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", from: "0.14.0"),
-        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "f1b8f8fde72a1fbd792c8c7393f834ff2478017e"),
+        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source", revision: "9422ff9fb429c09cce7ebaedd4daee755db9bac0"),
 //        .package(path: "../../passepartoutkit-source"),
 //        .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", from: "1.0.0"),
         .package(url: "git@github.com:passepartoutvpn/passepartoutkit-source-openvpn-openssl", revision: "12c8b9166ba2bf98b63d3ebc5b561ac2ac5a2f86"),


### PR DESCRIPTION
Resolve persistent DNS failures in the library. DNS requests were likely going through a stale tunnel.