### PR TITLE
Skip backup repository on simulator

### DIFF
--- a/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
+++ b/Library/Sources/CommonUtils/Business/CoreDataRepository.swift
@@ -182,7 +182,7 @@ private extension CoreDataRepository {
 
         let newController = NSFetchedResultsController(
             fetchRequest: request,
-            managedObjectContext: self.context,
+            managedObjectContext: context,
             sectionNameKeyPath: nil,
             cacheName: nil
         )

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -90,6 +90,7 @@ extension AppContext {
             model: cdRemoteModel,
             observingResults: true
         )
+        let backupProfileRepository: ProfileRepository? = nil
 #else
         let tunnelStrategy = NETunnelStrategy(
             bundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
@@ -99,15 +100,16 @@ extension AppContext {
         let mainProfileRepository = NEProfileRepository(repository: tunnelStrategy) {
             dependencies.profileTitle($0)
         }
+        let backupProfileRepository = dependencies.backupProfileRepository(
+            model: cdRemoteModel,
+            observingResults: false
+        )
 #endif
 
         let profileManager = ProfileManager(
             processor: processor,
             repository: mainProfileRepository,
-            backupRepository: dependencies.backupProfileRepository(
-                model: cdRemoteModel,
-                observingResults: false
-            ),
+            backupRepository: backupProfileRepository,
             mirrorsRemoteRepository: dependencies.mirrorsRemoteRepository,
             readyAfterRemote: true
         )


### PR DESCRIPTION
ProfileManager is behaving crazy because on simulator local and backup repository point to the same container.