### PR TITLE
Restore server entitlement for WireGuard to work on macOS

### DIFF
--- a/Passepartout/Tunnel/Tunnel.entitlements
+++ b/Passepartout/Tunnel/Tunnel.entitlements
@@ -14,6 +14,8 @@
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(CFG_KEYCHAIN_GROUP_ID)</string>


### PR DESCRIPTION
The entitlement "clean-up" was pushed by the App Review, but this had horrible consequences apparently.

In fact, the WireGuard Go adapter is unable to bind the UDP socket without the "server" entitlement, making WireGuard on macOS silently broken:

```
Unable to update bind: listen udp4 :0: bind: operation not permitted
```

Regression in #1042