### PR TITLE
Minimize dependencies of VPN implementations

### DIFF
--- a/Packages/App/Sources/UILibrary/L10n/Modules/OpenVPNModule+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/Modules/OpenVPNModule+L10n.swift
@@ -133,10 +133,10 @@ extension OpenVPN.XORMethod: StyledLocalizableEntity {
     private var longDescription: String {
         switch self {
         case .xormask(let mask):
-            return "\(shortDescription) \(mask.zData.toHex())"
+            return "\(shortDescription) \(mask.toHex())"
 
         case .obfuscate(let mask):
-            return "\(shortDescription) \(mask.zData.toHex())"
+            return "\(shortDescription) \(mask.toHex())"
 
         default:
             return shortDescription

--- a/Packages/PassepartoutOpenVPNOpenSSL/Package.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Package.swift
@@ -31,14 +31,14 @@ let package = Package(
     targets: [
         .target(
             name: "CPassepartoutCryptoOpenSSL",
-            dependencies: [
-                "openssl-apple",
-                "PassepartoutKit-Framework"
-            ]
+            dependencies: ["openssl-apple",]
         ),
         .target(
             name: "CPassepartoutOpenVPNOpenSSL",
-            dependencies: ["CPassepartoutCryptoOpenSSL"],
+            dependencies: [
+                "CPassepartoutCryptoOpenSSL",
+                "PassepartoutKit-Framework"
+            ],
             exclude: [
                 "lib/COPYING",
                 "lib/Makefile",
@@ -58,7 +58,7 @@ let package = Package(
             ]
         ),
         .testTarget(
-            name: "PassepartoutCryptoOpenSSLTests",
+            name: "CPassepartoutCryptoOpenSSLTests",
             dependencies: ["PassepartoutCryptoOpenSSL"]
         ),
         .testTarget(

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/Crypto.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/Crypto.m
@@ -25,10 +25,4 @@
 
 #import "Crypto.h"
 
-#define MAX_BLOCK_SIZE  16  // AES only, block is 128-bit
-
-size_t pp_alloc_crypto_capacity(size_t size, size_t overhead) {
-
-    // encryption, byte-alignment, overhead (e.g. IV, digest)
-    return 2 * size + MAX_BLOCK_SIZE + overhead;
-}
+NSString *const PassepartoutCryptoErrorDomain = @"PassepartoutCrypto";

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/CryptoAEAD.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/CryptoAEAD.m
@@ -34,11 +34,12 @@
 //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <PassepartoutKit/PassepartoutKit.h>
 #import <openssl/evp.h>
 
+#import "Allocation.h"
+#import "Crypto.h"
 #import "CryptoAEAD.h"
-#import "CryptoMacros.h"
+#import "ZeroingData.h"
 
 @interface CryptoAEAD ()
 
@@ -75,8 +76,8 @@
 
         self.cipherCtxEnc = EVP_CIPHER_CTX_new();
         self.cipherCtxDec = EVP_CIPHER_CTX_new();
-        self.cipherIVEnc = pp_alloc(self.cipherIVLength);
-        self.cipherIVDec = pp_alloc(self.cipherIVLength);
+        self.cipherIVEnc = pp_alloc_crypto(self.cipherIVLength);
+        self.cipherIVDec = pp_alloc_crypto(self.cipherIVLength);
 
         self.mappedError = ^NSError *(CryptoAEADError errorCode) {
             return [NSError errorWithDomain:PassepartoutCryptoErrorDomain code:0 userInfo:nil];
@@ -116,7 +117,7 @@
 
 - (void)configureEncryptionWithCipherKey:(ZeroingData *)cipherKey hmacKey:(ZeroingData *)hmacKey
 {
-    NSParameterAssert(cipherKey.count >= self.cipherKeyLength);
+    NSParameterAssert(cipherKey.length >= self.cipherKeyLength);
     NSParameterAssert(hmacKey);
 
     EVP_CIPHER_CTX_reset(self.cipherCtxEnc);
@@ -157,7 +158,7 @@
 
 - (void)configureDecryptionWithCipherKey:(ZeroingData *)cipherKey hmacKey:(ZeroingData *)hmacKey
 {
-    NSParameterAssert(cipherKey.count >= self.cipherKeyLength);
+    NSParameterAssert(cipherKey.length >= self.cipherKeyLength);
     NSParameterAssert(hmacKey);
 
     EVP_CIPHER_CTX_reset(self.cipherCtxDec);

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/ZeroingData.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/ZeroingData.m
@@ -1,0 +1,319 @@
+//
+//  ZeroingData.m
+//  PassepartoutKit
+//
+//  Created by Davide De Rosa on 4/28/17.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of PassepartoutKit.
+//
+//  PassepartoutKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  PassepartoutKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  This file incorporates work covered by the following copyright and
+//  permission notice:
+//
+//      Copyright (c) 2018-Present Private Internet Access
+//
+//      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//      The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+//      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#import "ZeroingData.h"
+#import "Allocation.h"
+
+@interface ZeroingData () {
+    uint8_t *_bytes;
+}
+
+@end
+
+@implementation ZeroingData
+
+- (instancetype)init
+{
+    return [self initWithBytes:NULL length:0];
+}
+
+- (instancetype)initWithLength:(NSInteger)length
+{
+    if ((self = [super init])) {
+        _length = length;
+        _bytes = pp_alloc_crypto(length);
+        bzero(_bytes, _length);
+    }
+    return self;
+}
+
+- (instancetype)initWithBytes:(const uint8_t *)bytes length:(NSInteger)length
+{
+//    NSParameterAssert(bytes);
+
+    if ((self = [super init])) {
+        _length = length;
+        _bytes = pp_alloc_crypto(length);
+        memcpy(_bytes, bytes, length);
+    }
+    return self;
+}
+
+- (instancetype)initWithBytesNoCopy:(uint8_t *)bytes length:(NSInteger)length
+{
+    NSParameterAssert(bytes);
+
+    if ((self = [super init])) {
+        _length = length;
+        _bytes = bytes;
+    }
+    return self;
+}
+
+- (instancetype)initWithUInt8:(uint8_t)uint8
+{
+    if ((self = [super init])) {
+        _length = 1;
+        _bytes = pp_alloc_crypto(_length);
+        _bytes[0] = uint8;
+    }
+    return self;
+}
+
+- (instancetype)initWithUInt16:(uint16_t)uint16
+{
+    if ((self = [super init])) {
+        _length = 2;
+        _bytes = pp_alloc_crypto(_length);
+        _bytes[0] = (uint16 & 0xff);
+        _bytes[1] = (uint16 >> 8);
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(NSData *)data
+{
+    return [self initWithData:data offset:0 length:data.length];
+}
+
+- (instancetype)initWithData:(NSData *)data offset:(NSInteger)offset length:(NSInteger)length
+{
+    NSParameterAssert(data);
+    NSParameterAssert(length >= 0);
+    NSParameterAssert(offset + length <= data.length);
+
+    if ((self = [super init])) {
+        _length = length;
+        _bytes = pp_alloc_crypto(length);
+        memcpy(_bytes, data.bytes + offset, length);
+    }
+    return self;
+}
+
+- (instancetype)initWithString:(NSString *)string nullTerminated:(BOOL)nullTerminated
+{
+    NSParameterAssert(string);
+
+    if ((self = [super init])) {
+        const int stringLength = (int)string.length;
+        _length = stringLength + (nullTerminated ? 1 : 0);
+        _bytes = pp_alloc_crypto(_length);
+
+        const char *stringBytes = [string cStringUsingEncoding:NSUTF8StringEncoding];
+        if (stringBytes) {
+            memcpy(_bytes, stringBytes, stringLength);
+        } else {
+            NSAssert(stringBytes != NULL, @"Cannot encode string to UTF-8");
+            bzero(_bytes, stringLength);
+        }
+        if (nullTerminated) {
+            _bytes[stringLength] = '\0';
+        }
+    }
+    return self;
+}
+
+- (instancetype)copy
+{
+    return [[ZeroingData alloc] initWithBytes:_bytes length:_length];
+}
+
+- (void)dealloc
+{
+    bzero(_bytes, _length);
+    free(_bytes);
+}
+
+- (const uint8_t *)bytes
+{
+    return _bytes;
+}
+
+- (uint8_t *)mutableBytes
+{
+    return _bytes;
+}
+
+- (void)appendData:(ZeroingData *)other
+{
+    NSParameterAssert(other);
+
+    const NSInteger newLength = _length + other.length;
+    uint8_t *newBytes = pp_alloc_crypto(newLength);
+    memcpy(newBytes, _bytes, _length);
+    memcpy(newBytes + _length, other.bytes, other.length);
+    
+    bzero(_bytes, _length);
+    free(_bytes);
+    
+    _bytes = newBytes;
+    _length = newLength;
+}
+
+- (void)truncateToSize:(NSInteger)size
+{
+    NSParameterAssert(size <= _length);
+    
+    uint8_t *newBytes = pp_alloc_crypto(size);
+    memcpy(newBytes, _bytes, size);
+
+    bzero(_bytes, _length);
+    free(_bytes);
+    
+    _bytes = newBytes;
+    _length = size;
+}
+
+- (void)removeUntilOffset:(NSInteger)until
+{
+    NSParameterAssert(until <= _length);
+    
+    const NSInteger newLength = _length - until;
+    uint8_t *newBytes = pp_alloc_crypto(newLength);
+    memcpy(newBytes, _bytes + until, newLength);
+    
+    bzero(_bytes, _length);
+    free(_bytes);
+    
+    _bytes = newBytes;
+    _length = newLength;
+}
+
+- (void)zero
+{
+    bzero(_bytes, _length);
+}
+
+- (ZeroingData *)appendingData:(ZeroingData *)other
+{
+    NSParameterAssert(other);
+
+    const NSInteger newLength = _length + other.length;
+    uint8_t *newBytes = pp_alloc_crypto(newLength);
+    memcpy(newBytes, _bytes, _length);
+    memcpy(newBytes + _length, other.bytes, other.length);
+    
+    return [[ZeroingData alloc] initWithBytesNoCopy:newBytes length:newLength];
+}
+
+- (ZeroingData *)withOffset:(NSInteger)offset length:(NSInteger)length
+{
+    NSParameterAssert(offset + length <= _length);
+
+    uint8_t *newBytes = pp_alloc_crypto(length);
+    memcpy(newBytes, _bytes + offset, length);
+    
+    return [[ZeroingData alloc] initWithBytesNoCopy:newBytes length:length];
+}
+
+- (uint16_t)UInt16ValueFromOffset:(NSInteger)from
+{
+    NSParameterAssert(from + 2 <= _length);
+
+    uint16_t value = 0;
+    value |= _bytes[from];
+    value |= _bytes[from + 1] << 8;
+    return value;
+}
+
+- (uint16_t)networkUInt16ValueFromOffset:(NSInteger)from
+{
+    NSParameterAssert(from + 2 <= _length);
+    
+    uint16_t value = 0;
+    value |= _bytes[from];
+    value |= _bytes[from + 1] << 8;
+    return CFSwapInt16BigToHost(value);
+}
+
+- (NSString *)nullTerminatedStringFromOffset:(NSInteger)from
+{
+    NSParameterAssert(from <= _length);
+
+    NSInteger nullOffset = NSNotFound;
+    for (NSInteger i = from; i < _length; ++i) {
+        if (_bytes[i] == 0) {
+            nullOffset = i;
+            break;
+        }
+    }
+    if (nullOffset == NSNotFound) {
+        return nil;
+    }
+    const NSInteger stringLength = nullOffset - from;
+    return [[NSString alloc] initWithBytes:_bytes length:stringLength encoding:NSUTF8StringEncoding];
+}
+
+- (BOOL)isEqual:(id)object
+{
+    NSParameterAssert(object);
+
+    if (![object isKindOfClass:[ZeroingData class]]) {
+        return NO;
+    }
+    ZeroingData *other = (ZeroingData *)object;
+    if (other.length != _length) {
+        return NO;
+    }
+    return !memcmp(_bytes, other.bytes, _length);
+}
+
+- (BOOL)isEqualToData:(NSData *)data
+{
+    NSParameterAssert(data);
+
+    if (data.length != _length) {
+        return NO;
+    }
+    return !memcmp(_bytes, data.bytes, _length);
+}
+
+- (NSData *)toData
+{
+    return [NSData dataWithBytes:_bytes length:_length];
+}
+
+- (NSString *)toHex
+{
+    const NSUInteger capacity = _length * 2;
+    NSMutableString *hexString = [[NSMutableString alloc] initWithCapacity:capacity];
+    for (int i = 0; i < _length; ++i) {
+        [hexString appendFormat:@"%02x", _bytes[i]];
+    }
+    return hexString;
+}
+
+@end

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/Allocation.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/Allocation.h
@@ -39,7 +39,7 @@
 static inline void *_Nullable pp_alloc_crypto(size_t size) {
     void *memory = malloc(size);
     if (!memory) {
-        NSCAssert(NO, @"malloc() call failed");
+        NSCAssert(NO, @"pp_alloc_crypto: malloc() call failed");
         abort();
         return NULL;
     }

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/Allocation.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/Allocation.h
@@ -1,8 +1,8 @@
 //
-//  CryptoMacros.h
+//  Allocation.h
 //  PassepartoutKit
 //
-//  Created by Davide De Rosa on 7/6/18.
+//  Created by Davide De Rosa on 3/3/17.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -36,13 +36,24 @@
 
 #import <Foundation/Foundation.h>
 
-#define CRYPTO_OPENSSL_SUCCESS(ret) (ret > 0)
-#define CRYPTO_OPENSSL_TRACK_STATUS(ret) if (ret > 0) ret =
-#define CRYPTO_OPENSSL_RETURN_STATUS(ret, raised)\
-if (ret <= 0) {\
-    if (error) {\
-        *error = raised;\
-    }\
-    return NO;\
-}\
-return YES;
+static inline void *_Nullable pp_alloc_crypto(size_t size) {
+    void *memory = malloc(size);
+    if (!memory) {
+        NSCAssert(NO, @"malloc() call failed");
+        abort();
+        return NULL;
+    }
+    return memory;
+}
+
+#define MAX_BLOCK_SIZE  16  // AES only, block is 128-bit
+
+/// - Parameters:
+///   - size: The base number of bytes.
+///   - overhead: The extra number of bytes.
+/// - Returns: The number of bytes to store a crypto buffer safely.
+static inline size_t pp_alloc_crypto_capacity(size_t size, size_t overhead) {
+
+    // encryption, byte-alignment, overhead (e.g. IV, digest)
+    return 2 * size + MAX_BLOCK_SIZE + overhead;
+}

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/CryptoAEAD.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/CryptoAEAD.h
@@ -36,6 +36,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Crypto.h"
+#import "CryptoProtocols.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/CryptoCBC.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/CryptoCBC.h
@@ -36,6 +36,7 @@
 
 #import <Foundation/Foundation.h>
 #import "Crypto.h"
+#import "CryptoProtocols.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/CryptoProtocols.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutCryptoOpenSSL/include/CryptoProtocols.h
@@ -1,0 +1,91 @@
+//
+//  CryptoProtocols.swift
+//  PassepartoutKit
+//
+//  Created by Davide De Rosa on 1/14/25.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of PassepartoutKit.
+//
+//  PassepartoutKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  PassepartoutKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#import <Foundation/Foundation.h>
+
+@class ZeroingData;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol Crypto
+
+/// The digest length or 0.
+- (int)digestLength;
+
+/// The tag length or 0.
+- (int)tagLength;
+
+/// The preferred encryption capacity.
+/// - Parameter length: The number of bytes to encrypt.
+- (NSInteger)encryptionCapacityWithLength:(NSInteger)length;
+
+@end
+
+@protocol Encrypter <Crypto>
+
+/// Configures the object.
+/// - Parameters:
+///   - cipherKey: The cipher key data.
+///   - hmacKey: The HMAC key data.
+- (void)configureEncryptionWithCipherKey:(nullable ZeroingData *)cipherKey hmacKey:(nullable ZeroingData *)hmacKey;
+
+/// Encrypts a buffer.
+/// - Parameters:
+///   - bytes: Bytes to encrypt.
+///   - length: The number of bytes.
+///   - dest: The destination buffer.
+///   - destLength: The number of bytes written to ``dest``.
+///   - flags: The optional encryption flags.
+- (BOOL)encryptBytes:(const uint8_t *)bytes length:(NSInteger)length dest:(uint8_t *)dest destLength:(NSInteger *)destLength flags:(const CryptoFlags *_Nullable)flags error:(NSError **)error;
+
+@end
+
+@protocol Decrypter <Crypto>
+
+/// Configures the object.
+/// - Parameters:
+///   - cipherKey: The cipher key data.
+///   - hmacKey: The HMAC key data.
+- (void)configureDecryptionWithCipherKey:(nullable ZeroingData *)cipherKey hmacKey:(nullable ZeroingData *)hmacKey;
+
+/// Decrypts a buffer.
+/// - Parameters:
+///   - bytes: Bytes to decrypt.
+///   - length: The number of bytes.
+///   - dest: The destination buffer.
+///   - destLength: The number of bytes written to ``dest``.
+///   - flags: The optional encryption flags.
+- (BOOL)decryptBytes:(const uint8_t *)bytes length:(NSInteger)length dest:(uint8_t *)dest destLength:(NSInteger *)destLength flags:(const CryptoFlags *_Nullable)flags error:(NSError **)error;
+
+/// Verifies an encrypted buffer.
+/// - Parameters:
+///   - bytes: Bytes to decrypt.
+///   - length: The number of bytes.
+///   - flags: The optional encryption flags.
+- (BOOL)verifyBytes:(const uint8_t *)bytes length:(NSInteger)length flags:(const CryptoFlags *_Nullable)flags error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/CryptoCBC+OpenVPN.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/CryptoCBC+OpenVPN.m
@@ -37,7 +37,7 @@
 #import <Foundation/Foundation.h>
 
 #import "CryptoCBC+OpenVPN.h"
-#import "CryptoMacros.h"
+#import "Crypto.h"
 #import "Errors.h"
 #import "PacketMacros.h"
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/DataPath.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/DataPath.m
@@ -37,6 +37,7 @@
 #import <PassepartoutKit/PassepartoutKit.h>
 #import <arpa/inet.h>
 
+#import "Allocation.h"
 #import "DataPath.h"
 #import "DataPathCrypto.h"
 #import "Errors.h"
@@ -107,11 +108,11 @@
         self.outPackets = [[NSMutableArray alloc] initWithCapacity:maxPackets];
         self.outPacketId = 0;
         self.encBufferCapacity = 65000;
-        self.encBuffer = pp_alloc(self.encBufferCapacity);
-        
+        self.encBuffer = pp_alloc_crypto(self.encBufferCapacity);
+
         self.inPackets = [[NSMutableArray alloc] initWithCapacity:maxPackets];
         self.decBufferCapacity = 65000;
-        self.decBuffer = pp_alloc(self.decBufferCapacity);
+        self.decBuffer = pp_alloc_crypto(self.decBufferCapacity);
         if (usesReplayProtection) {
             self.inReplay = [[ReplayProtector alloc] init];
         }
@@ -144,7 +145,7 @@
     bzero(self.encBuffer, self.encBufferCapacity);
     free(self.encBuffer);
     self.encBufferCapacity = neededCapacity;
-    self.encBuffer = pp_alloc(self.encBufferCapacity);
+    self.encBuffer = pp_alloc_crypto(self.encBufferCapacity);
 }
 
 - (void)adjustDecBufferToPacketSize:(int)size
@@ -156,7 +157,7 @@
     bzero(self.decBuffer, self.decBufferCapacity);
     free(self.decBuffer);
     self.decBufferCapacity = neededCapacity;
-    self.decBuffer = pp_alloc(self.decBufferCapacity);
+    self.decBuffer = pp_alloc_crypto(self.decBufferCapacity);
 }
 
 - (uint8_t *)encBufferAligned

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/OSSLCryptoBox.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/OSSLCryptoBox.m
@@ -65,7 +65,7 @@ static const NSInteger CryptoCTRPayloadLength = PacketOpcodeLength + PacketSessi
 
 #pragma mark Initialization
 
-- (instancetype)initWithSeed:(const uint8_t *)seed length:(NSInteger)length
+- (instancetype)initWithSeed:(ZeroingData *)seed
 {
     if ((self = [super init])) {
         unsigned char x[1];
@@ -73,7 +73,7 @@ static const NSInteger CryptoCTRPayloadLength = PacketOpcodeLength + PacketSessi
         if (RAND_bytes(x, 1) != 1) {
             return nil;
         }
-        RAND_seed(seed, (int)length);
+        RAND_seed(seed.bytes, (int)seed.length);
     }
     return self;
 }

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/OSSLTLSBox.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/OSSLTLSBox.m
@@ -39,6 +39,7 @@
 #import <openssl/x509v3.h>
 #import <openssl/err.h>
 
+#import "Allocation.h"
 #import "Errors.h"
 #import "OSSLTLSBox.h"
 
@@ -128,7 +129,7 @@ static BIO *create_BIO_from_PEM(NSString *pem) {
     NSAssert(self.options == nil, @"Already configured");
     self.options = options;
     self.onFailure = onFailure;
-    self.bufferCipherText = pp_alloc(self.options.bufferLength);
+    self.bufferCipherText = pp_alloc_crypto(self.options.bufferLength);
     return YES;
 }
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/OpenVPNCryptoProtocol.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/OpenVPNCryptoProtocol.m
@@ -24,6 +24,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <PassepartoutKit/PassepartoutKit.h>
 
 #import "OpenVPNCryptoProtocol.h"
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/ReplayProtector.m
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/ReplayProtector.m
@@ -34,8 +34,7 @@
 //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <PassepartoutKit/PassepartoutKit.h>
-
+#import "Allocation.h"
 #import "ReplayProtector.h"
 
 @import CPassepartoutCryptoOpenSSL;
@@ -61,7 +60,7 @@
 {
     if ((self = [super init])) {
         self.highestPacketId = 0;
-        self.bitmap =  pp_alloc(BITMAP_LEN * sizeof(uint32_t));
+        self.bitmap =  pp_alloc_crypto(BITMAP_LEN * sizeof(uint32_t));
         bzero(self.bitmap, BITMAP_LEN * sizeof(uint32_t));
     }
     return self;

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/OSSLCryptoBox.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/OSSLCryptoBox.h
@@ -38,12 +38,14 @@
 
 #import "OpenVPNCryptoProtocol.h"
 
+@class ZeroingData;
+
 NS_ASSUME_NONNULL_BEGIN
 
 // WARNING: not thread-safe!
 @interface OSSLCryptoBox : NSObject <OpenVPNCryptoProtocol>
 
-- (nullable instancetype)initWithSeed:(const uint8_t *)seed length:(NSInteger)length;
+- (nullable instancetype)initWithSeed:(ZeroingData *)seed;
 
 @end
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/OpenVPNCryptoProtocol.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/OpenVPNCryptoProtocol.h
@@ -24,8 +24,8 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <PassepartoutKit/PassepartoutKit.h>
 
-#import "Crypto.h"
 #import "CryptoProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/PacketStream.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/PacketStream.h
@@ -23,10 +23,10 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#import <PassepartoutKit/PassepartoutKit.h>
 #import <Foundation/Foundation.h>
 
 #import "XORMethodNative.h"
+#import "ZeroingData.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/XOR.h
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/CPassepartoutOpenVPNOpenSSL/include/XOR.h
@@ -30,9 +30,9 @@
 
 static inline void xor_mask(uint8_t *dst, const uint8_t *src, ZeroingData *xorMask, size_t length)
 {
-    if (xorMask.count > 0) {
+    if (xorMask.length > 0) {
         for (size_t i = 0; i < length; ++i) {
-            dst[i] = src[i] ^ ((uint8_t *)(xorMask.bytes))[i % xorMask.count];
+            dst[i] = src[i] ^ ((uint8_t *)(xorMask.bytes))[i % xorMask.length];
         }
         return;
     }

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ControlChannel.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ControlChannel.swift
@@ -81,7 +81,7 @@ actor ControlChannel {
         queue = BidirectionalState(withResetValue: [])
         currentPacketId = BidirectionalState(withResetValue: 0)
         pendingAcks = []
-        plainBuffer = Z(count: OpenVPNTLSOptionsDefaultBufferLength)
+        plainBuffer = Z(length: OpenVPNTLSOptionsDefaultBufferLength)
         sentDates = [:]
     }
 }
@@ -245,6 +245,6 @@ extension ControlChannel {
     func currentControlData(withTLS tls: OpenVPNTLSProtocol) throws -> ZeroingData {
         var length = 0
         try tls.pullRawPlainText(plainBuffer.mutableBytes, length: &length)
-        return plainBuffer.withOffset(0, count: length)
+        return plainBuffer.withOffset(0, length: length)
     }
 }

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ControlChannelSerializer.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ControlChannelSerializer.swift
@@ -23,6 +23,7 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+internal import CPassepartoutCryptoOpenSSL
 internal import CPassepartoutOpenVPNOpenSSL
 import Foundation
 import PassepartoutKit

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/OpenVPNCryptoProtocol+Extensions.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/OpenVPNCryptoProtocol+Extensions.swift
@@ -129,7 +129,7 @@ private extension OpenVPNCryptoProtocol {
         var keysArray = [ZeroingData]()
         for i in 0..<Constants.keysCount {
             let offset = i * Constants.keyLength
-            let zbuf = keysData.withOffset(offset, count: Constants.keyLength)
+            let zbuf = keysData.withOffset(offset, length: Constants.keyLength)
             keysArray.append(zbuf)
         }
 
@@ -156,16 +156,16 @@ private extension OpenVPNCryptoProtocol {
         if let ssi = parameters.serverSessionId {
             seed.append(Z(ssi))
         }
-        let len = parameters.secret.count / 2
-        let lenx = len + (parameters.secret.count & 1)
-        let secret1 = parameters.secret.withOffset(0, count: lenx)
-        let secret2 = parameters.secret.withOffset(len, count: lenx)
+        let len = parameters.secret.length / 2
+        let lenx = len + (parameters.secret.length & 1)
+        let secret1 = parameters.secret.withOffset(0, length: lenx)
+        let secret2 = parameters.secret.withOffset(len, length: lenx)
 
         let hash1 = try keysHash("md5", secret1, seed, parameters.size)
         let hash2 = try keysHash("sha1", secret2, seed, parameters.size)
 
         let prf = Z()
-        for i in 0..<hash1.count {
+        for i in 0..<hash1.length {
             let h1 = hash1.bytes[i]
             let h2 = hash2.bytes[i]
 
@@ -176,13 +176,13 @@ private extension OpenVPNCryptoProtocol {
 
     func keysHash(_ digestName: String, _ secret: ZeroingData, _ seed: ZeroingData, _ size: Int) throws -> ZeroingData {
         let out = Z()
-        let buffer = Z(count: maxHmacLength)
+        let buffer = Z(length: maxHmacLength)
         var chain = try hmac(buffer, digestName, secret, seed)
-        while out.count < size {
+        while out.length < size {
             out.append(try hmac(buffer, digestName, secret, chain.appending(seed)))
             chain = try hmac(buffer, digestName, secret, chain)
         }
-        return out.withOffset(0, count: size)
+        return out.withOffset(0, length: size)
     }
 
     func hmac(_ buffer: ZeroingData, _ digestName: String, _ secret: ZeroingData, _ data: ZeroingData) throws -> ZeroingData {
@@ -191,13 +191,13 @@ private extension OpenVPNCryptoProtocol {
         try hmac(
             withDigestName: digestName,
             secret: secret.bytes,
-            secretLength: secret.count,
+            secretLength: secret.length,
             data: data.bytes,
-            dataLength: data.count,
+            dataLength: data.length,
             hmac: buffer.mutableBytes,
             hmacLength: &length
         )
 
-        return buffer.withOffset(0, count: length)
+        return buffer.withOffset(0, length: length)
     }
 }

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/OpenVPNTCPLink.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/OpenVPNTCPLink.swift
@@ -24,6 +24,7 @@
 //
 
 import Combine
+internal import CPassepartoutCryptoOpenSSL
 internal import CPassepartoutOpenVPNOpenSSL
 import Foundation
 import PassepartoutKit

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/XORProcessor.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/XORProcessor.swift
@@ -59,7 +59,7 @@ struct XORProcessor {
      - Returns: The packet after XOR processing.
      **/
     func processPacket(_ packet: Data, outbound: Bool) -> Data {
-        guard let method = method else {
+        guard let method else {
             return packet
         }
         switch method {
@@ -85,7 +85,7 @@ struct XORProcessor {
 extension XORProcessor {
     private static func xormask(packet: Data, mask: ZeroingData) -> Data {
         Data(packet.enumerated().map { (index, byte) in
-            byte ^ mask.bytes[index % mask.count]
+            byte ^ mask.bytes[index % mask.length]
         })
     }
 

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ZeroingData+Extensions.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ZeroingData+Extensions.swift
@@ -1,0 +1,57 @@
+//
+//  ZeroingData+Extensions.swift
+//  PassepartoutKit
+//
+//  Created by Davide De Rosa on 1/14/25.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of PassepartoutKit.
+//
+//  PassepartoutKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  PassepartoutKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+internal import CPassepartoutCryptoOpenSSL
+import Foundation
+import PassepartoutKit
+
+extension PRNGProtocol {
+    func safeData(length: Int) -> ZeroingData {
+        precondition(length > 0)
+        let randomBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: length)
+        defer {
+            bzero(randomBytes, length)
+            randomBytes.deallocate()
+        }
+
+        guard SecRandomCopyBytes(kSecRandomDefault, length, randomBytes) == errSecSuccess else {
+            fatalError("SecRandomCopyBytes failed")
+        }
+
+        return Z(Data(bytes: randomBytes, count: length))
+    }
+}
+
+extension SecureData {
+    var zData: ZeroingData {
+        Z(innerData.toData())
+    }
+}
+
+extension ZeroingData: @retroactive SensitiveDebugStringConvertible {
+    func debugDescription(withSensitiveData: Bool) -> String {
+        withSensitiveData ? "[\(length) bytes, \(toHex())]" : "[\(length) bytes]"
+    }
+}

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ZeroingData.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/ZeroingData.swift
@@ -1,8 +1,8 @@
 //
-//  CryptoCTR.h
+//  ZeroingData.swift
 //  PassepartoutKit
 //
-//  Created by Davide De Rosa on 9/18/18.
+//  Created by Davide De Rosa on 1/8/25.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,26 +23,37 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#import <Foundation/Foundation.h>
-#import "Crypto.h"
-#import "CryptoProtocols.h"
+internal import CPassepartoutCryptoOpenSSL
+import Foundation
 
-NS_ASSUME_NONNULL_BEGIN
+func Z() -> ZeroingData {
+    ZeroingData()
+}
 
-typedef NS_ENUM(NSInteger, CryptoCTRError) {
-    CryptoCTRErrorGeneric,
-    CryptoCTRErrorHMAC
-};
+func Z(length: Int) -> ZeroingData {
+    ZeroingData(length: length)
+}
 
-@interface CryptoCTR : NSObject <Encrypter, Decrypter>
+func Z(bytes: UnsafePointer<UInt8>, length: Int) -> ZeroingData {
+    ZeroingData(bytes: bytes, length: length)
+}
 
-- (instancetype)initWithCipherName:(nullable NSString *)cipherName
-                        digestName:(NSString *)digestName
-                         tagLength:(NSInteger)tagLength
-                     payloadLength:(NSInteger)payloadLength;
+func Z(_ uint8: UInt8) -> ZeroingData {
+    ZeroingData(uInt8: uint8)
+}
 
-@property (nonatomic, copy) NSError * (^mappedError)(CryptoCTRError);
+func Z(_ uint16: UInt16) -> ZeroingData {
+    ZeroingData(uInt16: uint16)
+}
 
-@end
+func Z(_ data: Data) -> ZeroingData {
+    ZeroingData(data: data)
+}
 
-NS_ASSUME_NONNULL_END
+func Z(_ data: Data, _ offset: Int, _ length: Int) -> ZeroingData {
+    ZeroingData(data: data, offset: offset, length: length)
+}
+
+func Z(_ string: String, nullTerminated: Bool) -> ZeroingData {
+    ZeroingData(string: string, nullTerminated: nullTerminated)
+}

--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/OpenVPNConnection+Default.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/OpenVPNConnection+Default.swift
@@ -46,7 +46,7 @@ extension OpenVPNConnection {
         }
         let cryptoFactory = { @Sendable in
             let seed = prng.safeData(length: 64)
-            guard let box = OSSLCryptoBox(seed: seed.zData.bytes, length: seed.zData.count) else {
+            guard let box = OSSLCryptoBox(seed: seed) else {
                 fatalError("Unable to create OSSLCryptoBox")
             }
             return box

--- a/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/CryptoAEADTests.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/CryptoAEADTests.swift
@@ -1,5 +1,5 @@
 //
-//  CryptoCTRTests.swift
+//  CryptoAEADTests.swift
 //  PassepartoutKit
 //
 //  Created by Davide De Rosa on 12/12/23.
@@ -25,21 +25,17 @@
 
 internal import CPassepartoutCryptoOpenSSL
 @testable import PassepartoutCryptoOpenSSL
-import PassepartoutKit
 import XCTest
 
-final class CryptoCTRTests: XCTestCase {
+final class CryptoAEADTests: XCTestCase {
     func test_givenData_whenEncrypt_thenDecrypts() {
-        let sut = CryptoCTR(cipherName: "aes-128-ctr",
-                            digestName: "sha256",
-                            tagLength: 32,
-                            payloadLength: 128)
+        let sut = CryptoAEAD(cipherName: "aes-256-gcm", tagLength: 16, idLength: 4)
+        var flags = newFlags()
 
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
         sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
         let encryptedData: Data
 
-        var flags = newFlags()
         do {
             encryptedData = try sut.encryptData(plainData, flags: &flags)
         } catch {
@@ -55,13 +51,13 @@ final class CryptoCTRTests: XCTestCase {
     }
 }
 
-private extension CryptoCTRTests {
+private extension CryptoAEADTests {
     var cipherKey: ZeroingData {
-        ZeroingData(count: 32)
+        ZeroingData(length: 32)
     }
 
     var hmacKey: ZeroingData {
-        ZeroingData(count: 32)
+        ZeroingData(length: 32)
     }
 
     var plainData: Data {

--- a/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/CryptoCBCTests.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/CryptoCBCTests.swift
@@ -25,7 +25,6 @@
 
 internal import CPassepartoutCryptoOpenSSL
 @testable import PassepartoutCryptoOpenSSL
-import PassepartoutKit
 import XCTest
 
 final class CryptoCBCTests: XCTestCase {
@@ -93,11 +92,11 @@ final class CryptoCBCTests: XCTestCase {
 
 private extension CryptoCBCTests {
     var cipherKey: ZeroingData {
-        ZeroingData(count: 32)
+        ZeroingData(length: 32)
     }
 
     var hmacKey: ZeroingData {
-        ZeroingData(count: 32)
+        ZeroingData(length: 32)
     }
 
     var plainData: Data {

--- a/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/CryptoCTRTests.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/CryptoCTRTests.swift
@@ -1,5 +1,5 @@
 //
-//  CryptoAEADTests.swift
+//  CryptoCTRTests.swift
 //  PassepartoutKit
 //
 //  Created by Davide De Rosa on 12/12/23.
@@ -25,18 +25,20 @@
 
 internal import CPassepartoutCryptoOpenSSL
 @testable import PassepartoutCryptoOpenSSL
-import PassepartoutKit
 import XCTest
 
-final class CryptoAEADTests: XCTestCase {
+final class CryptoCTRTests: XCTestCase {
     func test_givenData_whenEncrypt_thenDecrypts() {
-        let sut = CryptoAEAD(cipherName: "aes-256-gcm", tagLength: 16, idLength: 4)
-        var flags = newFlags()
+        let sut = CryptoCTR(cipherName: "aes-128-ctr",
+                            digestName: "sha256",
+                            tagLength: 32,
+                            payloadLength: 128)
 
         sut.configureEncryption(withCipherKey: cipherKey, hmacKey: hmacKey)
         sut.configureDecryption(withCipherKey: cipherKey, hmacKey: hmacKey)
         let encryptedData: Data
 
+        var flags = newFlags()
         do {
             encryptedData = try sut.encryptData(plainData, flags: &flags)
         } catch {
@@ -52,13 +54,13 @@ final class CryptoAEADTests: XCTestCase {
     }
 }
 
-private extension CryptoAEADTests {
+private extension CryptoCTRTests {
     var cipherKey: ZeroingData {
-        ZeroingData(count: 32)
+        ZeroingData(length: 32)
     }
 
     var hmacKey: ZeroingData {
-        ZeroingData(count: 32)
+        ZeroingData(length: 32)
     }
 
     var plainData: Data {

--- a/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/Extensions.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/Extensions.swift
@@ -1,8 +1,8 @@
 //
-//  CryptoMacros.m
+//  Extensions.swift
 //  PassepartoutKit
 //
-//  Created by Davide De Rosa on 3/1/24.
+//  Created by Davide De Rosa on 1/14/25.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,6 +23,22 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#import <Foundation/Foundation.h>
+import Foundation
 
-NSString *const PassepartoutCryptoErrorDomain = @"PassepartoutCrypto";
+extension Data {
+    init(hex: String) {
+        assert(hex.count & 1 == 0)
+        var data = Data()
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            if let byte = UInt8(hex[index..<nextIndex], radix: 16) {
+                data.append(byte)
+            } else {
+                break
+            }
+            index = nextIndex
+        }
+        self.init(data)
+    }
+}

--- a/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/ZeroingDataTests.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Tests/CPassepartoutCryptoOpenSSLTests/ZeroingDataTests.swift
@@ -1,0 +1,114 @@
+//
+//  ZeroingDataTests.swift
+//  PassepartoutKit
+//
+//  Created by Davide De Rosa on 4/9/24.
+//  Copyright (c) 2024 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of PassepartoutKit.
+//
+//  PassepartoutKit is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  PassepartoutKit is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+internal import CPassepartoutCryptoOpenSSL
+import Foundation
+import PassepartoutCryptoOpenSSL
+import XCTest
+
+final class ZeroingDataTests: XCTestCase {
+    func test_givenInput_whenInit_thenReturnsExpected() {
+        XCTAssertEqual(ZeroingData(length: 123).length, 123)
+        XCTAssertEqual(ZeroingData(bytes: [0x11, 0x22, 0x33, 0x44, 0x55], length: 3).length, 3)
+        XCTAssertEqual(ZeroingData(uInt8: UInt8(78)).length, 1)
+        XCTAssertEqual(ZeroingData(uInt16: UInt16(4756)).length, 2)
+        XCTAssertEqual(ZeroingData(data: Data(count: 12)).length, 12)
+        XCTAssertEqual(ZeroingData(data: Data(count: 12), offset: 3, length: 7).length, 7)
+        XCTAssertEqual(ZeroingData(string: "hello", nullTerminated: false).length, 5)
+        XCTAssertEqual(ZeroingData(string: "hello", nullTerminated: true).length, 6)
+    }
+
+    func test_givenData_whenOffset_thenReturnsExpected() {
+        let sut = ZeroingData(string: "Hello", nullTerminated: true)
+        XCTAssertEqual(sut.networkUInt16Value(fromOffset: 3), 0x6c6f)
+        XCTAssertEqual(sut.nullTerminatedString(fromOffset: 0), "Hello")
+        XCTAssertEqual(sut.withOffset(3, length: 2), ZeroingData(string: "lo", nullTerminated: false))
+    }
+
+    func test_givenData_whenAppend_thenIsAppended() {
+        let sut = ZeroingData(string: "this_data", nullTerminated: false)
+        let other = ZeroingData(string: "that_data", nullTerminated: false)
+
+        let merged = sut.copy()
+        merged.append(other)
+        XCTAssertEqual(merged, ZeroingData(string: "this_datathat_data", nullTerminated: false))
+        XCTAssertEqual(merged, sut.appending(other))
+    }
+
+    func test_givenData_whenTruncate_thenIsTruncated() {
+        let data = Data(hex: "438ac4729847fb3975345983")
+        let sut = ZeroingData(data: data)
+
+        sut.truncate(toSize: 5)
+        XCTAssertEqual(sut.length, 5)
+        XCTAssertEqual(sut.toData(), data.subdata(in: 0..<5))
+    }
+
+    func test_givenData_whenRemove_thenIsRemoved() {
+        let data = Data(hex: "438ac4729847fb3975345983")
+        let sut = ZeroingData(data: data)
+
+        sut.remove(untilOffset: 5)
+        XCTAssertEqual(sut.length, data.count - 5)
+        XCTAssertEqual(sut.toData(), data.subdata(in: 5..<data.count))
+    }
+
+    func test_givenData_whenZero_thenIsZeroedOut() {
+        let data = Data(hex: "438ac4729847fb3975345983")
+        let sut = ZeroingData(data: data)
+
+        sut.zero()
+        XCTAssertEqual(sut.length, data.count)
+        XCTAssertEqual(sut.toData(), Data(repeating: 0, count: data.count))
+    }
+
+    func test_givenData_whenCompareEqual_thenIsEqual() {
+        let data = Data(hex: "438ac4729847fb3975345983")
+        let sut = ZeroingData(data: data)
+        let other = ZeroingData(data: data)
+
+        XCTAssertEqual(sut, other)
+        XCTAssertEqual(sut, sut.copy())
+        XCTAssertEqual(other, other.copy())
+        XCTAssertEqual(sut.copy(), other.copy())
+
+        sut.append(ZeroingData(length: 1))
+        XCTAssertNotEqual(sut, other)
+        other.append(ZeroingData(length: 1))
+        XCTAssertEqual(sut, other)
+    }
+
+    func test_givenData_whenManipulate_thenDataIsExpected() {
+        let z1 = ZeroingData()
+        z1.append(ZeroingData(data: Data(hex: "12345678")))
+        z1.append(ZeroingData(data: Data(hex: "abcdef")))
+        let z2 = z1.withOffset(2, length: 3) // 5678ab
+        let z3 = z2.appending(ZeroingData(data: Data(hex: "aaddcc"))) // 5678abaaddcc
+
+        XCTAssertEqual(z1.toData(), Data(hex: "12345678abcdef"))
+        XCTAssertEqual(z2.toData(), Data(hex: "5678ab"))
+        XCTAssertEqual(z3.toData(), Data(hex: "5678abaaddcc"))
+    }
+}

--- a/Packages/PassepartoutOpenVPNOpenSSL/Tests/PassepartoutOpenVPNOpenSSLTests/ZeroingDataExtensionsTests.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Tests/PassepartoutOpenVPNOpenSSLTests/ZeroingDataExtensionsTests.swift
@@ -1,8 +1,8 @@
 //
-//  CryptoCTR.h
+//  ZeroingDataExtensionsTests.swift
 //  PassepartoutKit
 //
-//  Created by Davide De Rosa on 9/18/18.
+//  Created by Davide De Rosa on 1/14/25.
 //  Copyright (c) 2024 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,26 +23,20 @@
 //  along with PassepartoutKit.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#import <Foundation/Foundation.h>
-#import "Crypto.h"
-#import "CryptoProtocols.h"
+import Foundation
+import PassepartoutKit
+@testable import PassepartoutOpenVPNOpenSSL
+import XCTest
 
-NS_ASSUME_NONNULL_BEGIN
+final class ZeroingDataExtensionsTests: XCTestCase {
+    func test_givenPRNG_whenGenerateSafeData_thenHasGivenLength() {
+        let sut = SecureRandom()
+        XCTAssertEqual(sut.safeData(length: 500).length, 500)
+    }
 
-typedef NS_ENUM(NSInteger, CryptoCTRError) {
-    CryptoCTRErrorGeneric,
-    CryptoCTRErrorHMAC
-};
-
-@interface CryptoCTR : NSObject <Encrypter, Decrypter>
-
-- (instancetype)initWithCipherName:(nullable NSString *)cipherName
-                        digestName:(NSString *)digestName
-                         tagLength:(NSInteger)tagLength
-                     payloadLength:(NSInteger)payloadLength;
-
-@property (nonatomic, copy) NSError * (^mappedError)(CryptoCTRError);
-
-@end
-
-NS_ASSUME_NONNULL_END
+    func test_givenZeroingData_whenAsSensitive_thenOmitsSensitiveData() throws {
+        let sut = Z(Data(hex: "12345678abcdef"))
+        XCTAssertEqual(sut.debugDescription(withSensitiveData: true), "[7 bytes, 12345678abcdef]")
+        XCTAssertEqual(sut.debugDescription(withSensitiveData: false), "[7 bytes]")
+    }
+}

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Internal/ParseError+L10n.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Internal/ParseError+L10n.swift
@@ -24,7 +24,7 @@
 //
 
 import Foundation
-import WireGuardKit
+internal import WireGuardKit
 
 extension TunnelConfiguration.ParseError: LocalizedError {
     public var errorDescription: String? {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Internal/TunnelConfiguration+WgQuickConfig.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Internal/TunnelConfiguration+WgQuickConfig.swift
@@ -1,4 +1,4 @@
-import WireGuardKit
+internal import WireGuardKit
 
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2021 WireGuard LLC. All Rights Reserved.

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Configuration+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Configuration+WireGuardKit.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 extension WireGuard.Configuration {
     init(wgQuickConfig: String) throws {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Endpoint+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Endpoint+WireGuardKit.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 extension PassepartoutKit.Endpoint {
     init?(wg: WireGuardKit.Endpoint) {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/LocalInterface+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/LocalInterface+WireGuardKit.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 extension WireGuard.LocalInterface {
     init(wg: InterfaceConfiguration) throws {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/PassepartoutError+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/PassepartoutError+WireGuardKit.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 // MARK: - Mapping
 

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/RemoteInterface+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/RemoteInterface+WireGuardKit.swift
@@ -26,7 +26,7 @@
 import Foundation
 import Network
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 extension WireGuard.RemoteInterface {
     init(wg: PeerConfiguration) throws {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Subnet+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Subnet+WireGuardKit.swift
@@ -26,7 +26,7 @@
 import Foundation
 import Network
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 extension Subnet {
     init?(wg: IPAddressRange) {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/StandardWireGuardKeyGenerator.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/StandardWireGuardKeyGenerator.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 public final class StandardWireGuardKeyGenerator: WireGuardKeyGenerator {
     public init() {

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/StandardWireGuardParser.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/StandardWireGuardParser.swift
@@ -25,7 +25,7 @@
 
 import Foundation
 import PassepartoutKit
-import WireGuardKit
+internal import WireGuardKit
 
 /// Parses WireGuard configurations in `wg-quick` format.
 public final class StandardWireGuardParser {

--- a/Packages/PassepartoutWireGuardGo/Tests/PassepartoutWireGuardGoTests/ParseErrorTests.swift
+++ b/Packages/PassepartoutWireGuardGo/Tests/PassepartoutWireGuardGoTests/ParseErrorTests.swift
@@ -25,7 +25,7 @@
 
 import PassepartoutKit
 @testable import PassepartoutWireGuardGo
-import WireGuardKit
+internal import WireGuardKit
 import XCTest
 
 final class ParseErrorTests: XCTestCase {

--- a/Passepartout/Passepartout.xctestplan
+++ b/Passepartout/Passepartout.xctestplan
@@ -14,13 +14,6 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:Packages\/PassepartoutOpenVPNOpenSSL",
-        "identifier" : "PassepartoutCryptoOpenSSLTests",
-        "name" : "PassepartoutCryptoOpenSSLTests"
-      }
-    },
-    {
-      "target" : {
         "containerPath" : "container:Packages\/PassepartoutKit",
         "identifier" : "PassepartoutSupportTests",
         "name" : "PassepartoutSupportTests"
@@ -36,9 +29,9 @@
     },
     {
       "target" : {
-        "containerPath" : "container:Packages\/PassepartoutWireGuardGo",
-        "identifier" : "PassepartoutWireGuardGoTests",
-        "name" : "PassepartoutWireGuardGoTests"
+        "containerPath" : "container:Packages\/PassepartoutOpenVPNOpenSSL",
+        "identifier" : "PassepartoutOpenVPNOpenSSLTests",
+        "name" : "PassepartoutOpenVPNOpenSSLTests"
       }
     },
     {
@@ -51,36 +44,8 @@
     {
       "target" : {
         "containerPath" : "container:Packages\/PassepartoutKit",
-        "identifier" : "PassepartoutAPITests",
-        "name" : "PassepartoutAPITests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:Packages\/App",
-        "identifier" : "CommonLibraryTests",
-        "name" : "CommonLibraryTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:Packages\/App",
-        "identifier" : "LegacyV2Tests",
-        "name" : "LegacyV2Tests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:Packages\/PassepartoutKit",
-        "identifier" : "PassepartoutWireGuardTests",
-        "name" : "PassepartoutWireGuardTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:Packages\/PassepartoutKit",
-        "identifier" : "PassepartoutCoreTests",
-        "name" : "PassepartoutCoreTests"
+        "identifier" : "PassepartoutNETests",
+        "name" : "PassepartoutNETests"
       }
     },
     {
@@ -92,9 +57,23 @@
     },
     {
       "target" : {
+        "containerPath" : "container:Packages\/App",
+        "identifier" : "CommonLibraryTests",
+        "name" : "CommonLibraryTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:Packages\/PassepartoutKit",
-        "identifier" : "PassepartoutNETests",
-        "name" : "PassepartoutNETests"
+        "identifier" : "PassepartoutCoreTests",
+        "name" : "PassepartoutCoreTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/PassepartoutKit",
+        "identifier" : "PassepartoutAPITests",
+        "name" : "PassepartoutAPITests"
       }
     },
     {
@@ -106,9 +85,30 @@
     },
     {
       "target" : {
+        "containerPath" : "container:Packages\/App",
+        "identifier" : "LegacyV2Tests",
+        "name" : "LegacyV2Tests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/PassepartoutWireGuardGo",
+        "identifier" : "PassepartoutWireGuardGoTests",
+        "name" : "PassepartoutWireGuardGoTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages\/PassepartoutKit",
+        "identifier" : "PassepartoutWireGuardTests",
+        "name" : "PassepartoutWireGuardTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:Packages\/PassepartoutOpenVPNOpenSSL",
-        "identifier" : "PassepartoutOpenVPNOpenSSLTests",
-        "name" : "PassepartoutOpenVPNOpenSSLTests"
+        "identifier" : "CPassepartoutCryptoOpenSSLTests",
+        "name" : "CPassepartoutCryptoOpenSSLTests"
       }
     }
   ],


### PR DESCRIPTION
### OpenVPN

- Make CPassepartoutCryptoOpenSSL agnostic of PassepartoutKit
  - Move Allocation/ZeroingData from PassepartoutKit to package for internal use
  - Rename ZeroingData.count to .length for consistency with NSData
  - Duplicate some Data manipulation code in CryptoOpenSSL
  - Retain a simplified version of ZeroingData in PassepartoutKit (AutoerasingData)

### WireGuard

- Make WireGuardKit imports `internal`