### PR TITLE
Retain WireGuardAdapterDelegate

### DIFF
--- a/Packages/PassepartoutKit-Framework/Package.swift
+++ b/Packages/PassepartoutKit-Framework/Package.swift
@@ -34,8 +34,8 @@ enum Environment {
         case .onlineDevelopment:
             targets.append(.binaryTarget(
                 name: "Target",
-                url: "https://github.com/passepartoutvpn/passepartoutkit/releases/download/0.99.2/PassepartoutKit.xcframework.zip",
-                checksum: "9fd6db5de77af9e8fe7aa425c1baf434ad54ca8bf2370946899ab344fd03eacc"
+                url: "https://github.com/passepartoutvpn/passepartoutkit/releases/download/0.99.3/PassepartoutKit.xcframework.zip",
+                checksum: "6da09eca9fe26504ac7aa416dcdbccc65c57090f6809c547b3641a3712540041"
             ))
         case .production:
             targets.append(.target(

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/WireGuardConnection.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/WireGuardConnection.swift
@@ -50,10 +50,12 @@ public final class WireGuardConnection: Connection {
     private var dataCountTimer: AnyCancellable?
 
     private lazy var adapter: WireGuardAdapter = {
-        WireGuardAdapter(with: AdapterDelegate(connection: self), backend: WireGuardBackendGo()) { logLevel, message in
+        WireGuardAdapter(with: delegate, backend: WireGuardBackendGo()) { logLevel, message in
             pp_log(.wireguard, osLogLevel: logLevel.osLogLevel, message)
         }
     }()
+
+    private lazy var delegate: WireGuardAdapterDelegate = AdapterDelegate(connection: self)
 
     public init(
         parameters: ConnectionParameters,


### PR DESCRIPTION
The delegate was lost due to not being retained anywhere, and the WireGuard adapter was therefore not finalizing the connection (i.e. set tunnel settings).

Regression in #1057