### PR TITLE
Assume .appleTV to be enough on tvOS

### DIFF
--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
@@ -48,6 +48,10 @@ extension IAPManager {
         guard isEligible(for: .appleTV) else {
             throw AppError.ineligibleProfile([.appleTV])
         }
+        // require only .appleTV to cope with BuildProducts
+        // rely on iOS/macOS eligibility as profiles are not
+        // editable on tvOS
+        return
 #endif
         let requiredFeatures = features.filter {
             !isEligible(for: $0)


### PR DESCRIPTION
Eligibility is ensured on iOS/macOS "remote" app.

Regression due to BuildProducts not being credited on Apple TV.