### PR TITLE
Fix error alert when importing files from external apps

### DIFF
--- a/Packages/App/Sources/AppUIMain/Business/ProfileImporter.swift
+++ b/Packages/App/Sources/AppUIMain/Business/ProfileImporter.swift
@@ -115,11 +115,11 @@ private extension ProfileImporter {
         profileManager: ProfileManager,
         importer: ModuleImporter
     ) async throws {
-        guard url.startAccessingSecurityScopedResource() else {
-            throw AppError.permissionDenied
-        }
+        let didStartAccess = url.startAccessingSecurityScopedResource()
         defer {
-            url.stopAccessingSecurityScopedResource()
+            if didStartAccess {
+                url.stopAccessingSecurityScopedResource()
+            }
         }
 
         let module = try importer.module(fromURL: url, object: passphrase)

--- a/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -51,7 +51,7 @@ extension AppError: LocalizedError {
             return V.malformedModule(module.moduleType.localizedDescription, error.localizedDescription)
 
         case .permissionDenied:
-            return V.default
+            return V.permissionDenied
 
         case .generic(let error):
             return error.localizedDescription

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -112,6 +112,8 @@ public enum Strings {
       public static func malformedModule(_ p1: Any, _ p2: Any) -> String {
         return Strings.tr("Localizable", "errors.app.malformed_module", String(describing: p1), String(describing: p2), fallback: "Module %@ is malformed. %@")
       }
+      /// Permission denied
+      public static let permissionDenied = Strings.tr("Localizable", "errors.app.permission_denied", fallback: "Permission denied")
       /// Unable to execute operation.
       public static let tunnel = Strings.tr("Localizable", "errors.app.tunnel", fallback: "Unable to execute operation.")
       public enum Passepartout {

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Das Profil hat keine aktiven Module.";
 "errors.app.passepartout.parsing" = "Datei konnte nicht analysiert werden.";
 "errors.app.passepartout.provider_required" = "Kein Anbieter ausgewählt.";
+"errors.app.permission_denied" = "Zugriff verweigert";
 "errors.app.tunnel" = "Aktion konnte nicht ausgeführt werden.";
 "errors.tunnel.auth" = "Authentifizierung fehlgeschlagen";
 "errors.tunnel.compression" = "Kompression wird nicht unterstützt";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Το προφίλ δεν έχει ενεργές μονάδες.";
 "errors.app.passepartout.parsing" = "Δεν ήταν δυνατή η ανάλυση αρχείου.";
 "errors.app.passepartout.provider_required" = "Δεν έχει επιλεγεί πάροχος.";
+"errors.app.permission_denied" = "Άρνηση άδειας";
 "errors.app.tunnel" = "Δεν ήταν δυνατή η εκτέλεση της ενέργειας.";
 "errors.tunnel.auth" = "Η επαλήθευση απέτυχε";
 "errors.tunnel.compression" = "Η συμπίεση δεν υποστηρίζεται";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -339,6 +339,7 @@
 "errors.app.empty_profile_name" = "Profile name is empty.";
 "errors.app.import" = "Unable to import profiles.";
 "errors.app.malformed_module" = "Module %@ is malformed. %@";
+"errors.app.permission_denied" = "Permission denied";
 "errors.app.tunnel" = "Unable to execute operation.";
 
 // MARK: Global (PassepartoutKit errors)

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "El perfil no tiene módulos activos.";
 "errors.app.passepartout.parsing" = "No se pudo analizar el archivo.";
 "errors.app.passepartout.provider_required" = "No se ha seleccionado proveedor.";
+"errors.app.permission_denied" = "Permiso denegado";
 "errors.app.tunnel" = "No se pudo ejecutar la operación.";
 "errors.tunnel.auth" = "Autenticación fallida";
 "errors.tunnel.compression" = "Compresión no soportada";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Le profil n'a pas de modules actifs.";
 "errors.app.passepartout.parsing" = "Impossible d'analyser le fichier.";
 "errors.app.passepartout.provider_required" = "Aucun fournisseur sélectionné.";
+"errors.app.permission_denied" = "Permission refusée";
 "errors.app.tunnel" = "Impossible d'exécuter l'opération.";
 "errors.tunnel.auth" = "Échec de l'authentification";
 "errors.tunnel.compression" = "Compression non supportée";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Il profilo non ha moduli attivi.";
 "errors.app.passepartout.parsing" = "Impossibile analizzare il file.";
 "errors.app.passepartout.provider_required" = "Nessun provider selezionato.";
+"errors.app.permission_denied" = "Permesso negato";
 "errors.app.tunnel" = "Impossibile eseguire l'operazione.";
 "errors.tunnel.auth" = "Autenticazione fallita";
 "errors.tunnel.compression" = "Compressione non supportata";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Het profiel heeft geen actieve modules.";
 "errors.app.passepartout.parsing" = "Kan bestand niet parseren.";
 "errors.app.passepartout.provider_required" = "Geen provider geselecteerd.";
+"errors.app.permission_denied" = "Toegang geweigerd";
 "errors.app.tunnel" = "Actie kan niet worden uitgevoerd.";
 "errors.tunnel.auth" = "Verificatie mislukt";
 "errors.tunnel.compression" = "Compressie niet ondersteund";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Profil nie ma aktywnych modułów.";
 "errors.app.passepartout.parsing" = "Nie można przeanalizować pliku.";
 "errors.app.passepartout.provider_required" = "Nie wybrano dostawcy.";
+"errors.app.permission_denied" = "Brak uprawnień";
 "errors.app.tunnel" = "Nie można wykonać operacji.";
 "errors.tunnel.auth" = "Błąd uwierzytelniania";
 "errors.tunnel.compression" = "Kompresja nieobsługiwana";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "O perfil não possui módulos ativos.";
 "errors.app.passepartout.parsing" = "Não foi possível analisar o arquivo.";
 "errors.app.passepartout.provider_required" = "Nenhum provedor selecionado.";
+"errors.app.permission_denied" = "Permissão negada";
 "errors.app.tunnel" = "Não foi possível executar a operação.";
 "errors.tunnel.auth" = "Falha na autenticação";
 "errors.tunnel.compression" = "Compressão não suportada";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "В профиле нет активных модулей.";
 "errors.app.passepartout.parsing" = "Не удалось разобрать файл.";
 "errors.app.passepartout.provider_required" = "Поставщик не выбран.";
+"errors.app.permission_denied" = "Доступ запрещен";
 "errors.app.tunnel" = "Не удалось выполнить операцию.";
 "errors.tunnel.auth" = "Ошибка аутентификации";
 "errors.tunnel.compression" = "Сжатие не поддерживается";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Profilen har inga aktiva moduler.";
 "errors.app.passepartout.parsing" = "Kan inte tolka filen.";
 "errors.app.passepartout.provider_required" = "Ingen leverantör vald.";
+"errors.app.permission_denied" = "Åtkomst nekad";
 "errors.app.tunnel" = "Kunde inte utföra åtgärden.";
 "errors.tunnel.auth" = "Autentisering misslyckades";
 "errors.tunnel.compression" = "Kompression stöds inte";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "Профіль не має активних модулів.";
 "errors.app.passepartout.parsing" = "Не вдалося обробити файл.";
 "errors.app.passepartout.provider_required" = "Не вибрано постачальника.";
+"errors.app.permission_denied" = "Доступ заборонено";
 "errors.app.tunnel" = "Не вдалося виконати операцію.";
 "errors.tunnel.auth" = "Помилка аутентифікації";
 "errors.tunnel.compression" = "Стиснення не підтримується";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "errors.app.passepartout.no_active_modules" = "配置文件没有激活模块。";
 "errors.app.passepartout.parsing" = "无法解析文件。";
 "errors.app.passepartout.provider_required" = "未选择提供商。";
+"errors.app.permission_denied" = "权限被拒绝";
 "errors.app.tunnel" = "无法执行操作。";
 "errors.tunnel.auth" = "认证失败";
 "errors.tunnel.compression" = "不支持压缩";

--- a/Passepartout/Config.xcconfig
+++ b/Passepartout/Config.xcconfig
@@ -27,7 +27,7 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 MARKETING_VERSION = 3.0.1
-CURRENT_PROJECT_VERSION = 3719
+CURRENT_PROJECT_VERSION = 3721
 
 // tweak these based on app and team
 CFG_APP_ID = com.algoritmico.ios.Passepartout


### PR DESCRIPTION
URL.startAccessingSecurityScopedResource() fails in that case, but permission is not required at all.

Could reproduce by importing .ovpn file from a Telegram chat.