### PR TITLE
Fix purchased features on Apple TV

### DIFF
--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -37,8 +37,20 @@ extension AppProduct: AppFeatureProviding {
         case .Features.appleTV:
 #if os(tvOS)
             // treat .appleTV as full version on tvOS to cope
-            // with BuildProducts limitations. rely on iOS/macOS
-            // eligibility as profiles are not editable on tvOS
+            // with BuildProducts limitations
+            //
+            // some old iOS/macOS users are acknowledged certain
+            // purchases based on the build number of their first
+            // download, e.g. "Full version (iOS)". unfortunately,
+            // that build number is not the same on tvOS, so
+            // those purchases do not exist and the TV may complain
+            // about missing features other than .appleTV
+            //
+            // we avoid this by relying on iOS/macOS eligibility
+            // alone while only requiring .appleTV on tvOS
+            //
+            // this is a solid workaround as long as profiles are
+            // not editable on tvOS
             return AppFeature.allCases
 #else
             return [.appleTV, .sharing]

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -35,7 +35,14 @@ extension AppProduct: AppFeatureProviding {
             return AppFeature.allCases
 
         case .Features.appleTV:
+#if os(tvOS)
+            // treat .appleTV as full version on tvOS to cope
+            // with BuildProducts limitations. rely on iOS/macOS
+            // eligibility as profiles are not editable on tvOS
+            return AppFeature.allCases
+#else
             return [.appleTV, .sharing]
+#endif
 
         // MARK: Discontinued
 

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
@@ -48,10 +48,6 @@ extension IAPManager {
         guard isEligible(for: .appleTV) else {
             throw AppError.ineligibleProfile([.appleTV])
         }
-        // require only .appleTV to cope with BuildProducts
-        // rely on iOS/macOS eligibility as profiles are not
-        // editable on tvOS
-        return
 #endif
         let requiredFeatures = features.filter {
             !isEligible(for: $0)


### PR DESCRIPTION
Refactor #1074 to show the appropriate list of eligible features in the "Purchased" screen. The "X" signs are highly misleading.