### PR TITLE
Do not require purchase for empty on-demand rules

### DIFF
--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Modules.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Modules.swift
@@ -49,7 +49,11 @@ extension OnDemandModule.Builder: AppFeatureRequiring {
         guard isEnabled else {
             return []
         }
-        return policy != .any ? [.onDemand] : []
+        // empty rules require no purchase
+        if !withMobileNetwork && !withEthernetNetwork && !withSSIDs.map(\.value).contains(true) {
+            return []
+        }
+        return [.onDemand]
     }
 }
 


### PR DESCRIPTION
Major issue with migrated profiles with the "Excluding" policy. Existing users are being opted into an unnecessary purchase.