### PR TITLE
Fix iCloud/TV sync not working with Advanced Data Protection

### DIFF
--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -158,7 +158,7 @@ extension AppContext {
 
         let onEligibleFeaturesBlock: (Set<AppFeature>) async -> Void = { @MainActor features in
             let isEligibleForSharing = features.contains(.sharing)
-            let isRemoteImportingEnabled = isEligibleForSharing && isCloudKitEnabled
+            let isRemoteImportingEnabled = isEligibleForSharing
 
             // toggle CloudKit sync based on .sharing eligibility
             let remoteStore = newRemoteStore(isRemoteImportingEnabled)


### PR DESCRIPTION
The ubiquity token does not seem to be a reliable source of truth for the state of CloudKit. Faced with tvOS, now also with Advanced Data Protection. It is nil, but CloudKit actually works.

Therefore, start a CloudKit container regardless of the ubiquity token.

The only downside is that the iCloud/TV icons of a profile will now only appear crossed in case of in-app ineligibility, but this is in favor of better functionality.