### PR TITLE
OpenVPN: Prompt for credentials when needed

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPNView.swift
@@ -182,6 +182,7 @@ private extension OpenVPNView {
         case .credentials:
             Form {
                 OpenVPNCredentialsView(
+                    profileEditor: editor,
                     providerId: draft.wrappedValue.providerId,
                     isInteractive: draft.isInteractive,
                     credentials: draft.credentials

--- a/Packages/App/Sources/CommonIAP/Domain/AppFeature.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppFeature.swift
@@ -32,9 +32,9 @@ public enum AppFeature: String, CaseIterable {
 
     case httpProxy
 
-    case interactiveLogin
-
     case onDemand
+
+    case otp
 
     case providers
 

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Levels.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Levels.swift
@@ -30,7 +30,7 @@ extension AppUserLevel: AppFeatureProviding {
         switch self {
         case .beta:
             return [
-                .interactiveLogin,
+                .otp,
                 .routing,
                 .sharing
             ]

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Modules.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Modules.swift
@@ -63,8 +63,8 @@ extension OpenVPNModule.Builder: AppFeatureRequiring {
         providerSelection?.id.features.forEach {
             list.insert($0)
         }
-        if isInteractive {
-            list.insert(.interactiveLogin)
+        if isInteractive, let otpMethod = credentials?.otpMethod, otpMethod != .none {
+            list.insert(.otp)
         }
         return list
     }

--- a/Packages/App/Sources/UILibrary/L10n/AppFeature+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/AppFeature+L10n.swift
@@ -40,11 +40,11 @@ extension AppFeature: LocalizableEntity {
         case .httpProxy:
             return V.httpProxy
 
-        case .interactiveLogin:
-            return V.interactiveLogin
-
         case .onDemand:
             return V.onDemand
+
+        case .otp:
+            return Strings.Unlocalized.otp
 
         case .providers:
             return V.providers

--- a/Packages/App/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
@@ -31,6 +31,7 @@ extension OpenVPNModule.Builder: InteractiveViewProviding {
         let draft = editor[self]
 
         return OpenVPNCredentialsView(
+            profileEditor: editor,
             providerId: draft.wrappedValue.providerId,
             isInteractive: draft.isInteractive,
             credentials: draft.credentials,

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -135,7 +135,7 @@ private extension OpenVPNCredentialsView {
                     passwordField
                 }
             }
-            if isEligibleForInteractiveLogin, isAuthenticating, builder.otpMethod != .none {
+            if isEligibleForOTP, isAuthenticating, builder.otpMethod != .none {
                 otpField
             }
         }
@@ -198,12 +198,12 @@ private extension OpenVPNCredentialsView {
 }
 
 private extension OpenVPNCredentialsView {
-    var isEligibleForInteractiveLogin: Bool {
-        iapManager.isEligible(for: .interactiveLogin)
+    var isEligibleForOTP: Bool {
+        iapManager.isEligible(for: .otp)
     }
 
     var requiredFeatures: Set<AppFeature>? {
-        isInteractive ? [.interactiveLogin] : nil
+        isInteractive && builder.otpMethod != .none ? [.otp] : nil
     }
 
     var otpMethods: [OpenVPN.Credentials.OTPMethod] {
@@ -236,7 +236,7 @@ private extension OpenVPNCredentialsView {
 
     func onChange(_ builder: OpenVPN.Credentials.Builder) {
         var copy = builder
-        if isEligibleForInteractiveLogin {
+        if isEligibleForOTP {
             copy.otp = copy.otp ?? ""
         } else {
             copy.otpMethod = .none

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -43,6 +43,9 @@ public struct OpenVPNCredentialsView: View {
     @EnvironmentObject
     private var providerManager: ProviderManager
 
+    @ObservedObject
+    private var profileEditor: ProfileEditor
+
     private let providerId: ProviderID?
 
     @Binding
@@ -65,12 +68,14 @@ public struct OpenVPNCredentialsView: View {
     private var focusedField: Field?
 
     public init(
+        profileEditor: ProfileEditor,
         providerId: ProviderID?,
         isInteractive: Binding<Bool>,
         credentials: Binding<OpenVPN.Credentials?>,
         isAuthenticating: Bool = false,
         onSubmit: (() -> Void)? = nil
     ) {
+        self.profileEditor = profileEditor
         self.providerId = providerId
         _isInteractive = isInteractive
         _credentials = credentials
@@ -249,6 +254,7 @@ private extension OpenVPNCredentialsView {
         var body: some View {
             NavigationStack {
                 OpenVPNCredentialsView(
+                    profileEditor: ProfileEditor(),
                     providerId: nil,
                     isInteractive: $isInteractive,
                     credentials: $credentials

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -135,7 +135,7 @@ private extension OpenVPNCredentialsView {
                     passwordField
                 }
             }
-            if isEligibleForOTP, isAuthenticating, builder.otpMethod != .none {
+            if isAuthenticating, builder.otpMethod != .none {
                 otpField
             }
         }
@@ -198,10 +198,6 @@ private extension OpenVPNCredentialsView {
 }
 
 private extension OpenVPNCredentialsView {
-    var isEligibleForOTP: Bool {
-        iapManager.isEligible(for: .otp)
-    }
-
     var requiredFeatures: Set<AppFeature>? {
         isInteractive && builder.otpMethod != .none ? [.otp] : nil
     }
@@ -235,14 +231,7 @@ private extension OpenVPNCredentialsView {
     }
 
     func onChange(_ builder: OpenVPN.Credentials.Builder) {
-        var copy = builder
-        if isEligibleForOTP {
-            copy.otp = copy.otp ?? ""
-        } else {
-            copy.otpMethod = .none
-            copy.otp = nil
-        }
-        credentials = copy.build()
+        credentials = builder.build()
     }
 }
 

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -86,9 +86,7 @@ public struct OpenVPNCredentialsView: View {
     public var body: some View {
         debugChanges()
         return Group {
-            if !isAuthenticating {
-                interactiveSection
-            }
+            interactiveSection
             inputSection
             guidanceSection
         }
@@ -111,7 +109,7 @@ private extension OpenVPNCredentialsView {
             }
             .themeRowWithSubtitle(interactiveFooter)
 
-            if isInteractive {
+            if isInteractive && !isAuthenticating {
                 Picker(Strings.Unlocalized.otp, selection: $builder.otpMethod) {
                     ForEach(otpMethods, id: \.self) {
                         Text($0.localizedDescription(style: .entity))

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -183,7 +183,7 @@ extension IAPManagerTests {
         await sut.reloadReceipt()
         let excluded: Set<AppFeature> = [
             .appleTV,
-            .interactiveLogin
+            .otp
         ]
         AppFeature.allCases.forEach {
             if AppFeature.fullV2Features.contains($0) {
@@ -445,7 +445,7 @@ extension IAPManagerTests {
         await sut.reloadReceipt()
         let excluded: Set<AppFeature> = [
             .appleTV,
-            .interactiveLogin
+            .otp
         ]
         AppFeature.allCases.forEach {
             if AppFeature.fullV2Features.contains($0) {

--- a/Packages/App/Tests/CommonLibraryTests/Business/ProfileManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/ProfileManagerTests.swift
@@ -135,7 +135,7 @@ extension ProfileManagerTests {
         XCTAssertTrue(sut.isReady)
 
         XCTAssertEqual(sut.requiredFeatures(forProfileWithId: profile.id), processor.requiredFeatures)
-        processor.requiredFeatures = [.interactiveLogin]
+        processor.requiredFeatures = [.otp]
         XCTAssertNotEqual(sut.requiredFeatures(forProfileWithId: profile.id), processor.requiredFeatures)
         sut.reloadRequiredFeatures()
         XCTAssertEqual(sut.requiredFeatures(forProfileWithId: profile.id), processor.requiredFeatures)


### PR DESCRIPTION
Assume OpenVPN to be interactive if credentials are empty but required (--auth-user-pass).

For this change, change paywall restriction to OTP only. Allow interactive login similar to OpenVPN Connect "Save username/password".