### PR TITLE
Do not show "Activating" when the tunnel is actually idle

### DIFF
--- a/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
@@ -219,9 +219,12 @@ extension TunnelStatus {
     func withEnvironment(_ environment: TunnelEnvironment) -> TunnelStatus {
         var status = self
         if status == .active, let connectionStatus = environment.environmentValue(forKey: TunnelEnvironmentKeys.connectionStatus) {
-            if connectionStatus == .connected {
+            switch connectionStatus {
+            case .connected:
                 status = .active
-            } else {
+            case .disconnected:
+                status = .inactive
+            default:
                 status = .activating
             }
         }

--- a/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
@@ -220,12 +220,14 @@ extension TunnelStatus {
         var status = self
         if status == .active, let connectionStatus = environment.environmentValue(forKey: TunnelEnvironmentKeys.connectionStatus) {
             switch connectionStatus {
+            case .connecting:
+                status = .activating
             case .connected:
                 status = .active
+            case .disconnecting:
+                status = .deactivating
             case .disconnected:
                 status = .inactive
-            default:
-                status = .activating
             }
         }
         return status

--- a/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
@@ -151,12 +151,19 @@ extension ExtendedTunnelTests {
         env.setEnvironmentValue(ConnectionStatus.connected, forKey: key)
         XCTAssertEqual(tunnelActive.withEnvironment(env), .active)
         allConnectionStatuses
-            .filter {
-                $0 != .connected
-            }
             .forEach {
                 env.setEnvironmentValue($0, forKey: key)
-                XCTAssertEqual(tunnelActive.withEnvironment(env), .activating)
+                let statusWithEnv = tunnelActive.withEnvironment(env)
+                switch $0 {
+                case .connecting:
+                    XCTAssertEqual(statusWithEnv, .activating)
+                case .connected:
+                    XCTAssertEqual(statusWithEnv, .active)
+                case .disconnecting:
+                    XCTAssertEqual(statusWithEnv, .deactivating)
+                case .disconnected:
+                    XCTAssertEqual(statusWithEnv, .inactive)
+                }
             }
 
         // unaffected otherwise


### PR DESCRIPTION
E.g. in airplane mode, the status shows as "Activating", but the tunnel is not actively establishing any connection. It's just idle.

Reported here: https://www.reddit.com/r/passepartout/comments/1i957zj/when_phone_going_into_airplane_mode_passepartout/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button