### PR TITLE
Only apply cellular/Ethernet on-demand rules on devices that support the interface

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
@@ -121,12 +121,8 @@ private extension OnDemandView {
 
     var networkSection: some View {
         Group {
-            if OnDemandModule.supportsCellular {
-                Toggle(Strings.Modules.OnDemand.mobile, isOn: draft.withMobileNetwork)
-            }
-            if OnDemandModule.supportsEthernet {
-                Toggle(Strings.Modules.OnDemand.ethernet, isOn: draft.withEthernetNetwork)
-            }
+            Toggle(Strings.Modules.OnDemand.mobile, isOn: draft.withMobileNetwork)
+            Toggle(Strings.Modules.OnDemand.ethernet, isOn: draft.withEthernetNetwork)
         }
         .themeSection(header: Strings.Global.Nouns.networks)
     }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
@@ -121,10 +121,10 @@ private extension OnDemandView {
 
     var networkSection: some View {
         Group {
-            if Utils.hasCellularData() {
+            if OnDemandModule.supportsCellular {
                 Toggle(Strings.Modules.OnDemand.mobile, isOn: draft.withMobileNetwork)
             }
-            if Utils.hasEthernet() {
+            if OnDemandModule.supportsEthernet {
                 Toggle(Strings.Modules.OnDemand.ethernet, isOn: draft.withEthernetNetwork)
             }
         }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
@@ -124,7 +124,11 @@ private extension OnDemandView {
             Toggle(Strings.Modules.OnDemand.mobile, isOn: draft.withMobileNetwork)
             Toggle(Strings.Modules.OnDemand.ethernet, isOn: draft.withEthernetNetwork)
         }
-        .themeSection(header: Strings.Global.Nouns.networks)
+        .themeSection(
+            header: Strings.Global.Nouns.networks,
+            footer: Strings.Modules.OnDemand.Networks.footer,
+            forcesFooter: true
+        )
     }
 
     var wifiSection: some View {

--- a/Packages/App/Sources/CommonUtils/Extensions/Utils+Network.swift
+++ b/Packages/App/Sources/CommonUtils/Extensions/Utils+Network.swift
@@ -26,41 +26,9 @@
 import Foundation
 #if os(iOS)
 import NetworkExtension
-#elseif os(macOS)
-import CoreWLAN
 #endif
 
 extension Utils {
-#if targetEnvironment(simulator)
-    public static func hasCellularData() -> Bool {
-        true
-    }
-#else
-    // TODO: ###, move this check to kit, and try something similar for Ethernet
-    public static func hasCellularData() -> Bool {
-        var addrs: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&addrs) == 0 else {
-            return false
-        }
-        var isFound = false
-        var cursor = addrs?.pointee
-        while let ifa = cursor {
-            let name = String(cString: ifa.ifa_name)
-            if name == "pdp_ip0" {
-                isFound = true
-                break
-            }
-            cursor = ifa.ifa_next?.pointee
-        }
-        freeifaddrs(addrs)
-        return isFound
-    }
-#endif
-
-    public static func hasEthernet() -> Bool {
-        true
-    }
-
     public static func currentWifiSSID() async -> String? {
 #if targetEnvironment(simulator)
         ["My Home Network", "Safe Wi-Fi", "Friend's House"].randomElement()

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -434,6 +434,10 @@ public enum Strings {
       public static let mobile = Strings.tr("Localizable", "modules.on_demand.mobile", fallback: "Mobile")
       /// Policy
       public static let policy = Strings.tr("Localizable", "modules.on_demand.policy", fallback: "Policy")
+      public enum Networks {
+        /// These rules will only apply on devices where the interface type is supported.
+        public static let footer = Strings.tr("Localizable", "modules.on_demand.networks.footer", fallback: "These rules will only apply on devices where the interface type is supported.")
+      }
       public enum Policy {
         /// Activate the VPN %@.
         public static func footer(_ p1: Any) -> String {

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Eingeschlossene Routen";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Mobil";
+"modules.on_demand.networks.footer" = "Diese Regeln gelten nur für Geräte, auf denen der Schnittstellentyp unterstützt wird.";
 "modules.on_demand.policy" = "Richtlinie";
 "modules.on_demand.policy.footer" = "Aktiviere den VPN %@.";
 "modules.on_demand.policy.footer.any" = "in jedem Netzwerk";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Συμπεριλαμβανόμενες διαδρομές";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Κινητό";
+"modules.on_demand.networks.footer" = "Αυτοί οι κανόνες θα ισχύουν μόνο σε συσκευές όπου υποστηρίζεται ο τύπος διεπαφής.";
 "modules.on_demand.policy" = "Πολιτική";
 "modules.on_demand.policy.footer" = "Ενεργοποιήστε το VPN %@.";
 "modules.on_demand.policy.footer.any" = "σε οποιοδήποτε δίκτυο";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.on_demand.policy.footer.any" = "in any network";
 "modules.on_demand.policy.footer.including" = "only in the networks below";
 "modules.on_demand.policy.footer.excluding" = "except in the networks below";
+"modules.on_demand.networks.footer" = "These rules will only apply on devices where the interface type is supported.";
 "modules.on_demand.mobile" = "Mobile";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.ssid.add" = "Add SSID";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Rutas incluidas";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Móvil";
+"modules.on_demand.networks.footer" = "Estas reglas solo se aplicarán en dispositivos donde el tipo de interfaz sea compatible.";
 "modules.on_demand.policy" = "Política";
 "modules.on_demand.policy.footer" = "Activa la VPN %@.";
 "modules.on_demand.policy.footer.any" = "en cualquier red";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Routes incluses";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Mobile";
+"modules.on_demand.networks.footer" = "Ces règles s'appliqueront uniquement aux appareils où le type d'interface est pris en charge.";
 "modules.on_demand.policy" = "Politique";
 "modules.on_demand.policy.footer" = "Activez le VPN %@.";
 "modules.on_demand.policy.footer.any" = "dans tous les réseaux";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Rotte incluse";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Mobile";
+"modules.on_demand.networks.footer" = "Queste regole si applicheranno solo sui dispositivi in cui il tipo di interfaccia è supportato.";
 "modules.on_demand.policy" = "Politica";
 "modules.on_demand.policy.footer" = "Attiva la VPN %@.";
 "modules.on_demand.policy.footer.any" = "in qualsiasi rete";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Opgenomen routes";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Mobiel";
+"modules.on_demand.networks.footer" = "Deze regels zijn alleen van toepassing op apparaten waar het type interface wordt ondersteund.";
 "modules.on_demand.policy" = "Beleid";
 "modules.on_demand.policy.footer" = "Activeer de VPN %@.";
 "modules.on_demand.policy.footer.any" = "in elk netwerk";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Uwzględnione trasy";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Mobilne";
+"modules.on_demand.networks.footer" = "Te zasady będą obowiązywać tylko na urządzeniach, na których obsługiwany jest dany typ interfejsu.";
 "modules.on_demand.policy" = "Polityka";
 "modules.on_demand.policy.footer" = "Aktywuj VPN %@.";
 "modules.on_demand.policy.footer.any" = "w każdej sieci";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Rotas incluídas";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Celular";
+"modules.on_demand.networks.footer" = "Essas regras serão aplicadas apenas em dispositivos onde o tipo de interface seja suportado.";
 "modules.on_demand.policy" = "Política";
 "modules.on_demand.policy.footer" = "Ative o VPN %@.";
 "modules.on_demand.policy.footer.any" = "em qualquer rede";

--- a/Packages/App/Sources/UILibrary/Resources/replacez.sh
+++ b/Packages/App/Sources/UILibrary/Resources/replacez.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-for lang in `ls -d *.lproj`; do
-    src="$lang/Localizable.strings"
-    grep -f list.txt -v $src >tmp.strings
-    mv tmp.strings $src
-done

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Включенные маршруты";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Мобильные";
+"modules.on_demand.networks.footer" = "Эти правила будут применяться только на устройствах, где поддерживается данный тип интерфейса.";
 "modules.on_demand.policy" = "Политика";
 "modules.on_demand.policy.footer" = "Активировать VPN %@.";
 "modules.on_demand.policy.footer.any" = "в любой сети";

--- a/Packages/App/Sources/UILibrary/Resources/sortz.sh
+++ b/Packages/App/Sources/UILibrary/Resources/sortz.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-for lang in `ls -d *.lproj`; do
-    src="$lang/Localizable.strings"
-    sort $src | grep -v ^$ | grep -v ^// >tmp.strings
-    mv tmp.strings $src
-done

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Inkluderade rutter";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Mobil";
+"modules.on_demand.networks.footer" = "Dessa regler gäller endast på enheter där gränssnittstypen stöds.";
 "modules.on_demand.policy" = "Policy";
 "modules.on_demand.policy.footer" = "Aktivera VPN %@.";
 "modules.on_demand.policy.footer.any" = "i alla nätverk";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "Включені маршрути";
 "modules.on_demand.ethernet" = "Ethernet";
 "modules.on_demand.mobile" = "Мобільний";
+"modules.on_demand.networks.footer" = "Ці правила застосовуватимуться лише на пристроях, де підтримується тип інтерфейсу.";
 "modules.on_demand.policy" = "Політика";
 "modules.on_demand.policy.footer" = "Активуйте VPN %@.";
 "modules.on_demand.policy.footer.any" = "у будь-якій мережі";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "modules.ip.routes.included" = "已包含路由";
 "modules.on_demand.ethernet" = "以太网";
 "modules.on_demand.mobile" = "移动网络";
+"modules.on_demand.networks.footer" = "这些规则仅适用于支持该接口类型的设备。";
 "modules.on_demand.policy" = "策略";
 "modules.on_demand.policy.footer" = "激活 VPN %@。";
 "modules.on_demand.policy.footer.any" = "在任何网络中";


### PR DESCRIPTION
Fixes #1096 but somewhat revives #1119