### PR TITLE
tvOS: Override focus behavior to enforce button colors

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -186,7 +186,7 @@ private struct ToggleButton: View {
             nextProfileId: $nextProfileId,
             errorHandler: errorHandler,
             flow: flow?.connectionFlow,
-            label: { _ in
+            label: { _, _ in
                 ThemeImage(.tunnelToggle)
                     .scaleEffect(1.5, anchor: .trailing)
             }

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
@@ -78,10 +78,10 @@ private extension ProfileContextMenu {
             nextProfileId: .constant(nil),
             errorHandler: errorHandler,
             flow: flow?.connectionFlow,
-            label: {
+            label: { canConnect, _ in
                 ThemeImageLabel(
-                    $0 ? Strings.Global.Actions.enable : Strings.Global.Actions.disable,
-                    $0 ? .tunnelEnable : .tunnelDisable
+                    canConnect ? Strings.Global.Actions.enable : Strings.Global.Actions.disable,
+                    canConnect ? .tunnelEnable : .tunnelDisable
                 )
             }
         )

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -147,7 +147,7 @@ private extension ProfileRowView {
             nextProfileId: $nextProfileId,
             errorHandler: errorHandler,
             flow: flow?.connectionFlow,
-            label: { _ in
+            label: { _, _ in
                 ProfileCardView(
                     style: style,
                     preview: preview

--- a/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
@@ -180,10 +180,10 @@ private extension View {
             .background(disabled ? .gray : color)
             .cornerRadius(50)
             .font(.title3)
-            .foregroundColor(.white)
+            .foregroundColor(disabled ? .white.opacity(0.6) : .white)
             .overlay(
                 RoundedRectangle(cornerRadius: 50)
-                    .fill(Color.white.opacity(focused ? 0.3 : 0.0))
+                    .fill(.white.opacity(focused ? 0.3 : 0.0))
             )
             .scaleEffect(focused ? 1.05 : 1.0)
     }

--- a/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
@@ -71,7 +71,7 @@ struct ActiveProfileView: View {
                     toggleConnectionButton
                     switchProfileButton
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 50))
+                .buttonStyle(.borderless)
             }
             .padding(.horizontal, 100)
 //            .padding(.top, 50)
@@ -136,11 +136,14 @@ private extension ActiveProfileView {
             label: {
                 Text($0 ? Strings.Global.Actions.connect : Strings.Global.Actions.disconnect)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 10)
+                    .fontWeight(theme.relevantWeight)
+                    .forMainButton(
+                        withColor: toggleConnectionColor,
+                        focused: focusedField == .connect,
+                        disabled: $1
+                    )
             }
         )
-        .background(toggleConnectionColor)
-        .fontWeight(theme.relevantWeight)
         .focused($focusedField, equals: .connect)
     }
 
@@ -159,9 +162,30 @@ private extension ActiveProfileView {
         } label: {
             Text(Strings.Global.Actions.select)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
+                .forMainButton(
+                    withColor: .gray,
+                    focused: focusedField == .switchProfile,
+                    disabled: false
+                )
         }
         .focused($focusedField, equals: .switchProfile)
+    }
+}
+
+// MARK: - Local modifiers
+
+private extension View {
+    func forMainButton(withColor color: Color, focused: Bool, disabled: Bool) -> some View {
+        padding(.vertical, 25)
+            .background(disabled ? .gray : color)
+            .cornerRadius(50)
+            .font(.title3)
+            .foregroundColor(.white)
+            .overlay(
+                RoundedRectangle(cornerRadius: 50)
+                    .fill(Color.white.opacity(focused ? 0.3 : 0.0))
+            )
+            .scaleEffect(focused ? 1.05 : 1.0)
     }
 }
 

--- a/Packages/App/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -80,7 +80,7 @@ private extension ProfileListView {
             nextProfileId: .constant(nil),
             errorHandler: errorHandler,
             flow: flow,
-            label: { _ in
+            label: { _, _ in
                 toggleView(for: preview)
             }
         )

--- a/Packages/App/Sources/UILibrary/Views/UI/TunnelToggleButton.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/TunnelToggleButton.swift
@@ -45,7 +45,7 @@ public struct TunnelToggleButton<Label>: View, Routable, ThemeProviding where La
 
     public let flow: ConnectionFlow?
 
-    private let label: (Bool) -> Label
+    private let label: (Bool, Bool) -> Label
 
     public init(
         tunnel: ExtendedTunnel,
@@ -53,7 +53,7 @@ public struct TunnelToggleButton<Label>: View, Routable, ThemeProviding where La
         nextProfileId: Binding<Profile.ID?>,
         errorHandler: ErrorHandler,
         flow: ConnectionFlow?,
-        label: @escaping (Bool) -> Label
+        label: @escaping (_ canConnect: Bool, _ isDisabled: Bool) -> Label
     ) {
         self.tunnel = tunnel
         self.profile = profile
@@ -65,13 +65,13 @@ public struct TunnelToggleButton<Label>: View, Routable, ThemeProviding where La
 
     public var body: some View {
         Button(action: tryPerform) {
-            label(canConnect)
+            label(canConnect, isDisabled)
         }
 #if os(macOS)
         .buttonStyle(.plain)
         .cursor(.hand)
 #endif
-        .disabled(profile == nil || (isInstalled && tunnel.status == .deactivating))
+        .disabled(isDisabled)
     }
 }
 
@@ -82,6 +82,10 @@ private extension TunnelToggleButton {
 
     var canConnect: Bool {
         !isInstalled || (tunnel.status == .inactive && tunnel.currentProfile?.onDemand != true)
+    }
+
+    var isDisabled: Bool {
+        profile == nil || (isInstalled && tunnel.status == .deactivating)
     }
 }
 


### PR DESCRIPTION
The default gray color on focus defeats the purpose of having green/red for Connect/Disconnect.