### PR TITLE
Hijack environment to run tests in PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,6 @@ jobs:
           xcode-version: 16.1
       - name: "Run tests"
         run: |
+          sed -i '' "s/environment = .production/environment = .onlineDevelopment/" "Packages/PassepartoutKit-Framework/Package.swift"
           cd Packages/App
           swift test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: false
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
       - ".env.*"
       - "**/*.md"
       - "**/*.sh"
-      - "**/*.yml"
       - "fastlane/**"
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,13 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 10
     steps:
-      - uses: passepartoutvpn/action-prepare-xcode-build@master
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          access_token: ${{ secrets.ACCESS_TOKEN }}
+          bundler-cache: true
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.1
       - name: "Run tests"
         run: |
           cd Packages/App

--- a/.github/workflows/xcode_test.yml
+++ b/.github/workflows/xcode_test.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FASTLANE_USERNAME: ${{ secrets.FASTLANE_USERNAME }}
   FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
   XCODEPROJ: "Passepartout.xcodeproj/project.pbxproj"

--- a/Packages/PassepartoutKit-Framework/Package.swift
+++ b/Packages/PassepartoutKit-Framework/Package.swift
@@ -21,7 +21,7 @@ enum Environment {
             return []
         case .onlineDevelopment:
             return [
-                .package(url: "https://github.com/passepartoutvpn/passepartoutkit", from: "0.99.5")
+                .package(url: "https://github.com/passepartoutvpn/passepartoutkit", from: "0.99.7")
             ]
         case .production:
             return [


### PR DESCRIPTION
Avoid the complications of accessing the PassepartoutKit private repository by running tests against the public binary distribution.

Also a way to make sure that the framework is up to date.