### PR TITLE
Wrap rather than truncate long profile names

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -90,7 +90,7 @@ private extension InstalledProfileView {
         Text(profile?.name ?? Strings.Views.App.InstalledProfile.None.name)
             .font(.title2)
             .fontWeight(theme.relevantWeight)
-            .themeTruncating(.tail)
+            .themeMultiLine(true)
     }
 
     var statusView: some View {

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileCardView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileCardView.swift
@@ -51,7 +51,7 @@ struct ProfileCardView: View {
             } label: {
                 Text(preview.name)
                     .font(.headline)
-                    .themeTruncating()
+                    .themeMultiLine(true)
             }
             tunnelView
                 .font(.subheadline)


### PR DESCRIPTION
Better trade-off than the fixed list/grid height now that the animations are off.

https://www.reddit.com/r/passepartout/comments/1ik8tm2/comment/mbn1o1h/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button