### PR TITLE
Rework the app colors for upgrade icons

### DIFF
--- a/Packages/App/Sources/CommonUtils/Extensions/Color+Extensions.swift
+++ b/Packages/App/Sources/CommonUtils/Extensions/Color+Extensions.swift
@@ -1,0 +1,36 @@
+//
+//  Color+Extensions.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 2/10/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension Color {
+    public init(hex: UInt32) {
+        self.init(
+            red: Double((hex >> 16) & 0xff) / 255.0,
+            green: Double((hex >> 8) & 0xff) / 255.0,
+            blue: Double(hex & 0xff) / 255.0
+        )
+    }
+}

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -757,8 +757,8 @@ public enum Strings {
             public static func connect(_ p1: Int) -> String {
               return Strings.tr("Localizable", "views.paywall.alerts.confirmation.message.connect", p1, fallback: "You may test the connection for %d minutes.")
             }
-            /// Tap the upgrade icons to unlock the features.
-            public static let save = Strings.tr("Localizable", "views.paywall.alerts.confirmation.message.save", fallback: "Tap the upgrade icons to unlock the features.")
+            /// Tap the lock icons to purchase the missing features.
+            public static let save = Strings.tr("Localizable", "views.paywall.alerts.confirmation.message.save", fallback: "Tap the lock icons to purchase the missing features.")
           }
         }
         public enum Pending {

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Profil bearbeiten";
 "views.paywall.alerts.confirmation.message" = "Dieses Profil erfordert kostenpflichtige Funktionen, um zu funktionieren.";
 "views.paywall.alerts.confirmation.message.connect" = "Sie können die Verbindung für %d Minuten testen.";
-"views.paywall.alerts.confirmation.message.save" = "Tippen Sie auf die Upgrade-Symbole, um die Funktionen freizuschalten.";
+"views.paywall.alerts.confirmation.message.save" = "Tippen Sie auf die Schlosssymbole, um die fehlenden Funktionen zu kaufen.";
 "views.paywall.alerts.confirmation.title" = "Kauf erforderlich";
 "views.paywall.alerts.pending.message" = "Der Kauf wartet auf eine externe Bestätigung. Die Funktion wird nach Genehmigung gutgeschrieben.";
 "views.paywall.alerts.restricted.message" = "Einige Funktionen sind in dieser Version nicht verfügbar.";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Επεξεργασία προφίλ";
 "views.paywall.alerts.confirmation.message" = "Αυτό το προφίλ απαιτεί επί πληρωμή λειτουργίες για να λειτουργήσει.";
 "views.paywall.alerts.confirmation.message.connect" = "Μπορείτε να δοκιμάσετε τη σύνδεση για %d λεπτά.";
-"views.paywall.alerts.confirmation.message.save" = "Πατήστε στα εικονίδια αναβάθμισης για να ξεκλειδώσετε τις λειτουργίες.";
+"views.paywall.alerts.confirmation.message.save" = "Πατήστε στα εικονίδια κλειδώματος για να αγοράσετε τις ελλείπουσες λειτουργίες.";
 "views.paywall.alerts.confirmation.title" = "Απαιτείται αγορά";
 "views.paywall.alerts.pending.message" = "Η αγορά εκκρεμεί για εξωτερική επιβεβαίωση. Η λειτουργία θα πιστωθεί μετά την έγκριση.";
 "views.paywall.alerts.restricted.message" = "Ορισμένες λειτουργίες δεν είναι διαθέσιμες σε αυτήν την έκδοση.";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -87,7 +87,7 @@
 "views.paywall.alerts.confirmation.title" = "Purchase required";
 "views.paywall.alerts.confirmation.message" = "This profile requires paid features to work.";
 "views.paywall.alerts.confirmation.message.connect" = "You may test the connection for %d minutes.";
-"views.paywall.alerts.confirmation.message.save" = "Tap the upgrade icons to unlock the features.";
+"views.paywall.alerts.confirmation.message.save" = "Tap the lock icons to purchase the missing features.";
 "views.paywall.alerts.confirmation.edit_profile" = "Edit profile";
 "views.paywall.alerts.verification.connect.1" = "Your purchases are being verified.";
 "views.paywall.alerts.verification.connect.2" = "If verification cannot be completed, the connection will end in %d minutes.";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Editar perfil";
 "views.paywall.alerts.confirmation.message" = "Este perfil requiere características de pago para funcionar.";
 "views.paywall.alerts.confirmation.message.connect" = "Puedes probar la conexión durante %d minutos.";
-"views.paywall.alerts.confirmation.message.save" = "Toca los iconos de actualización para desbloquear las funciones.";
+"views.paywall.alerts.confirmation.message.save" = "Toca los iconos de candado para comprar las funciones faltantes.";
 "views.paywall.alerts.confirmation.title" = "Compra requerida";
 "views.paywall.alerts.pending.message" = "La compra está pendiente de confirmación externa. La característica será acreditada tras la aprobación.";
 "views.paywall.alerts.restricted.message" = "Algunas características no están disponibles en esta versión.";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Modifier le profil";
 "views.paywall.alerts.confirmation.message" = "Ce profil nécessite des fonctionnalités payantes pour fonctionner.";
 "views.paywall.alerts.confirmation.message.connect" = "Vous pouvez tester la connexion pendant %d minutes.";
-"views.paywall.alerts.confirmation.message.save" = "Touchez les icônes de mise à niveau pour débloquer les fonctionnalités.";
+"views.paywall.alerts.confirmation.message.save" = "Touchez les icônes de cadenas pour acheter les fonctionnalités manquantes.";
 "views.paywall.alerts.confirmation.title" = "Achat requis";
 "views.paywall.alerts.pending.message" = "L'achat est en attente de confirmation externe. La fonctionnalité sera créditée une fois approuvée.";
 "views.paywall.alerts.restricted.message" = "Certaines fonctionnalités ne sont pas disponibles dans cette version.";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Modifica profilo";
 "views.paywall.alerts.confirmation.message" = "Questo profilo richiede funzionalità a pagamento per funzionare.";
 "views.paywall.alerts.confirmation.message.connect" = "Puoi provare la connessione per %d minuti.";
-"views.paywall.alerts.confirmation.message.save" = "Tocca le icone di aggiornamento per sbloccare le funzionalità.";
+"views.paywall.alerts.confirmation.message.save" = "Tocca le icone del lucchetto per acquistare le funzionalità mancanti.";
 "views.paywall.alerts.confirmation.title" = "Acquisto richiesto";
 "views.paywall.alerts.pending.message" = "L'acquisto è in attesa di conferma esterna. La funzionalità verrà accreditata dopo l'approvazione.";
 "views.paywall.alerts.restricted.message" = "Alcune funzionalità non sono disponibili in questa versione.";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Profiel bewerken";
 "views.paywall.alerts.confirmation.message" = "Dit profiel vereist betaalde functies om te werken.";
 "views.paywall.alerts.confirmation.message.connect" = "Je kunt de verbinding %d minuten testen.";
-"views.paywall.alerts.confirmation.message.save" = "Tik op de upgrade-iconen om de functies te ontgrendelen.";
+"views.paywall.alerts.confirmation.message.save" = "Tik op de slotpictogrammen om de ontbrekende functies te kopen.";
 "views.paywall.alerts.confirmation.title" = "Aankoop vereist";
 "views.paywall.alerts.pending.message" = "De aankoop wacht op externe bevestiging. De functie wordt na goedkeuring gecrediteerd.";
 "views.paywall.alerts.restricted.message" = "Sommige functies zijn niet beschikbaar in deze versie.";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Edytuj profil";
 "views.paywall.alerts.confirmation.message" = "Ten profil wymaga płatnych funkcji do działania.";
 "views.paywall.alerts.confirmation.message.connect" = "Możesz przetestować połączenie przez %d minut.";
-"views.paywall.alerts.confirmation.message.save" = "Stuknij ikony aktualizacji, aby odblokować funkcje.";
+"views.paywall.alerts.confirmation.message.save" = "Stuknij ikony kłódki, aby kupić brakujące funkcje.";
 "views.paywall.alerts.confirmation.title" = "Wymagana zakup";
 "views.paywall.alerts.pending.message" = "Zakup oczekuje na zewnętrzne potwierdzenie. Funkcja zostanie przypisana po zatwierdzeniu.";
 "views.paywall.alerts.restricted.message" = "Niektóre funkcje są niedostępne w tej wersji.";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Editar perfil";
 "views.paywall.alerts.confirmation.message" = "Este perfil requer recursos pagos para funcionar.";
 "views.paywall.alerts.confirmation.message.connect" = "Você pode testar a conexão por %d minutos.";
-"views.paywall.alerts.confirmation.message.save" = "Toque nos ícones de atualização para desbloquear os recursos.";
+"views.paywall.alerts.confirmation.message.save" = "Toque nos ícones de cadeado para comprar os recursos ausentes.";
 "views.paywall.alerts.confirmation.title" = "Compra necessária";
 "views.paywall.alerts.pending.message" = "A compra está pendente de confirmação externa. O recurso será creditado após a aprovação.";
 "views.paywall.alerts.restricted.message" = "Alguns recursos estão indisponíveis nesta versão.";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Редактировать профиль";
 "views.paywall.alerts.confirmation.message" = "Этот профиль требует платных функций для работы.";
 "views.paywall.alerts.confirmation.message.connect" = "Вы можете протестировать подключение в течение %d минут.";
-"views.paywall.alerts.confirmation.message.save" = "Нажмите на значки обновления, чтобы разблокировать функции.";
+"views.paywall.alerts.confirmation.message.save" = "Нажмите на значки замка, чтобы приобрести недостающие функции.";
 "views.paywall.alerts.confirmation.title" = "Требуется покупка";
 "views.paywall.alerts.pending.message" = "Покупка ожидает внешнего подтверждения. Функция будет активирована после одобрения.";
 "views.paywall.alerts.restricted.message" = "Некоторые функции недоступны в этой версии.";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Redigera profil";
 "views.paywall.alerts.confirmation.message" = "Den här profilen kräver betalda funktioner för att fungera.";
 "views.paywall.alerts.confirmation.message.connect" = "Du kan testa anslutningen i %d minuter.";
-"views.paywall.alerts.confirmation.message.save" = "Tryck på uppgraderingsikonerna för att låsa upp funktionerna.";
+"views.paywall.alerts.confirmation.message.save" = "Tryck på låsikonerna för att köpa de saknade funktionerna.";
 "views.paywall.alerts.confirmation.title" = "Köp krävs";
 "views.paywall.alerts.pending.message" = "Köpet väntar på extern bekräftelse. Funktionen aktiveras efter godkännande.";
 "views.paywall.alerts.restricted.message" = "Vissa funktioner är inte tillgängliga i denna version.";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "Редагувати профіль";
 "views.paywall.alerts.confirmation.message" = "Цей профіль потребує платних функцій для роботи.";
 "views.paywall.alerts.confirmation.message.connect" = "Ви можете протестувати підключення протягом %d хвилин.";
-"views.paywall.alerts.confirmation.message.save" = "Торкніться значків оновлення, щоб розблокувати функції.";
+"views.paywall.alerts.confirmation.message.save" = "Торкніться значків замка, щоб придбати відсутні функції.";
 "views.paywall.alerts.confirmation.title" = "Потрібна покупка";
 "views.paywall.alerts.pending.message" = "Покупка очікує зовнішнього підтвердження. Функція буде увімкнена після схвалення.";
 "views.paywall.alerts.restricted.message" = "Деякі функції недоступні в цій версії.";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "views.paywall.alerts.confirmation.edit_profile" = "编辑配置文件";
 "views.paywall.alerts.confirmation.message" = "此配置文件需要付费功能才能工作。";
 "views.paywall.alerts.confirmation.message.connect" = "您可以试用连接 %d 分钟。";
-"views.paywall.alerts.confirmation.message.save" = "点击升级图标以解锁功能。";
+"views.paywall.alerts.confirmation.message.save" = "点击锁定图标以购买缺失的功能。";
 "views.paywall.alerts.confirmation.title" = "需要购买";
 "views.paywall.alerts.pending.message" = "购买正在等待外部确认。功能将在获得批准后被授予。";
 "views.paywall.alerts.restricted.message" = "某些功能在此版本中不可用。";

--- a/Packages/App/Sources/UILibrary/Theme/Theme+ImageName.swift
+++ b/Packages/App/Sources/UILibrary/Theme/Theme+ImageName.swift
@@ -137,7 +137,7 @@ extension Theme.ImageName {
                 }
             case .tvOn: return "tv"
             case .undisclose: return "chevron.up"
-            case .upgrade: return "arrow.up.circle"
+            case .upgrade: return "lock"
             case .warning: return "exclamationmark.triangle"
             }
         }

--- a/Packages/App/Sources/UILibrary/Theme/Theme.swift
+++ b/Packages/App/Sources/UILibrary/Theme/Theme.swift
@@ -54,7 +54,7 @@ public final class Theme: ObservableObject {
 
     public internal(set) var emptyMessageColor: Color = .secondary
 
-    public internal(set) var primaryColor = Color(hex: 0x515d70)
+    public internal(set) var primaryColor = Color(hex: 0xd69c68)
 
     public internal(set) var activeColor = Color(hex: 0x00aa00)
 
@@ -72,7 +72,9 @@ public final class Theme: ObservableObject {
         errorColor
     }
 
-    public internal(set) var upgradeColor: Color = .orange
+    public var upgradeColor: Color {
+        primaryColor
+    }
 
     public internal(set) var logoImage = "Logo"
 

--- a/Packages/App/Sources/UILibrary/Theme/Theme.swift
+++ b/Packages/App/Sources/UILibrary/Theme/Theme.swift
@@ -54,17 +54,9 @@ public final class Theme: ObservableObject {
 
     public internal(set) var emptyMessageColor: Color = .secondary
 
-    public internal(set) var primaryColor = Color(
-        red: Double(0x51) / 255.0,
-        green: Double(0x5D) / 255.0,
-        blue: Double(0x70) / 255.0
-    )
+    public internal(set) var primaryColor = Color(hex: 0x515d70)
 
-    public internal(set) var activeColor = Color(
-        red: .zero,
-        green: Double(0xAA) / 255.0,
-        blue: .zero
-    )
+    public internal(set) var activeColor = Color(hex: 0x00aa00)
 
     public internal(set) var inactiveColor: Color = .secondary
 

--- a/Packages/App/Sources/UILibrary/Views/UI/PurchaseRequiredView.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/PurchaseRequiredView.swift
@@ -147,8 +147,7 @@ public struct PurchaseRequiredImage: View {
         ThemeImage(.upgrade)
             .foregroundStyle(theme.upgradeColor)
             .help(Strings.Views.Ui.PurchaseRequired.Purchase.help)
-#if os(macOS)
             .imageScale(.large)
-#endif
+            .padding(.leading, 4)
     }
 }

--- a/Packages/App/Sources/UILibrary/Views/UI/PurchaseRequiredView.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/PurchaseRequiredView.swift
@@ -148,6 +148,8 @@ public struct PurchaseRequiredImage: View {
             .foregroundStyle(theme.upgradeColor)
             .help(Strings.Views.Ui.PurchaseRequired.Purchase.help)
             .imageScale(.large)
+#if os(iOS)
             .padding(.leading, 4)
+#endif
     }
 }

--- a/Passepartout/App/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Passepartout/App/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,40 +1,7 @@
 {
   "colors" : [
     {
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x68",
-          "green" : "0x9C",
-          "red" : "0xD6"
-        }
-      },
       "idiom" : "iphone"
-    },
-    {
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x68",
-          "green" : "0x9C",
-          "red" : "0xD6"
-        }
-      },
-      "idiom" : "ipad"
-    },
-    {
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x68",
-          "green" : "0x9C",
-          "red" : "0xD6"
-        }
-      },
-      "idiom" : "mac"
     }
   ],
   "info" : {


### PR DESCRIPTION
- Restore the default accent, but extend it to toggles on iOS
- Keep the "gold" color for the upgrade icon
- Replace the upgrade icon with the universally understandable lock icon