### PR TITLE
Fix UI tests for screenshots

### DIFF
--- a/Packages/App/Sources/AppUIMain/AppUIMain.swift
+++ b/Packages/App/Sources/AppUIMain/AppUIMain.swift
@@ -27,6 +27,7 @@ import CommonLibrary
 import Foundation
 import PassepartoutKit
 import TipKit
+import UIAccessibility
 @_exported import UILibrary
 
 public final class AppUIMain: UILibraryConfiguring {
@@ -40,6 +41,9 @@ public final class AppUIMain: UILibraryConfiguring {
 
             // for debugging
 //            Tips.showAllTipsForTesting()
+            if AppCommandLine.contains(.uiTesting) {
+                Tips.hideAllTipsForTesting()
+            }
 
             try? Tips.configure([
                 .displayFrequency(.immediate)

--- a/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -50,7 +50,6 @@ struct InstalledProfileView: View, Routable {
         debugChanges()
         return HStack(alignment: .center) {
             cardView
-                .uiAccessibility(.App.installedProfile)
             Spacer()
             toggleButton
         }

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileCardView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileCardView.swift
@@ -53,6 +53,8 @@ struct ProfileCardView: View {
                     .font(.headline)
                     .themeMultiLine(true)
             }
+            .uiAccessibility(.App.profileEdit)
+
             tunnelView
                 .font(.subheadline)
 

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -94,7 +94,6 @@ private extension ProfileRowView {
             flow: flow?.connectionFlow
         )
         .labelsHidden()
-        // FIXME: ###, UI tests
         .uiAccessibility(.App.profileToggle)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -73,9 +73,6 @@ private extension ProfileRowView {
         )
         .contentShape(.rect)
         .foregroundStyle(.primary)
-
-        // FIXME: ###, UI tests
-        .uiAccessibility(.App.profileMenu)
     }
 
     var attributesView: some View {

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfilesHeaderView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfilesHeaderView.swift
@@ -39,5 +39,6 @@ struct ProfilesHeaderView: View {
                 Text(Strings.Views.Verification.message)
             }
         }
+        .uiAccessibility(.App.profilesHeader)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+Extensions.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+Extensions.swift
@@ -50,6 +50,7 @@ extension OpenVPNModule.Builder: ModuleShortcutsProviding {
             NavigationLink(value: OpenVPNView.Subroute.providerServer) {
                 ProviderServerRow(selectedEntity: providerSelection.entity)
             }
+            .uiAccessibility(.Profile.providerServerLink)
         }
         if providerSelection != nil || configurationBuilder?.authUserPass == true {
             NavigationLink(value: OpenVPNView.Subroute.credentials) {

--- a/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
@@ -86,7 +86,7 @@ private extension ActiveProfileView {
             .font(.title)
             .fontWeight(theme.relevantWeight)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .uiAccessibility(.App.installedProfile)
+            .uiAccessibility(.App.profilesHeader)
     }
 
     var statusView: some View {

--- a/Packages/App/Sources/UIAccessibility/Domain/AccessibilityInfo.swift
+++ b/Packages/App/Sources/UIAccessibility/Domain/AccessibilityInfo.swift
@@ -36,6 +36,8 @@ public struct AccessibilityInfo: Equatable, Sendable {
         case menuItem
 
         case text
+
+        case toggle
     }
 
     public let id: String

--- a/Packages/App/Sources/UIAccessibility/Screens/App.swift
+++ b/Packages/App/Sources/UIAccessibility/Screens/App.swift
@@ -41,6 +41,6 @@ extension AccessibilityInfo {
 
         public static let profileToggle = AccessibilityInfo("app.profileToggle", .toggle)
 
-        public static let profileMenu = AccessibilityInfo("app.profileMenu", .menu)
+        public static let profileEdit = AccessibilityInfo("app.profileEdit", .button)
     }
 }

--- a/Packages/App/Sources/UIAccessibility/Screens/App.swift
+++ b/Packages/App/Sources/UIAccessibility/Screens/App.swift
@@ -37,9 +37,9 @@ extension AccessibilityInfo {
             public static let profile = AccessibilityInfo("app.profileList.profile", .button)
         }
 
-        public static let installedProfile = AccessibilityInfo("app.installedProfile", .text)
+        public static let profilesHeader = AccessibilityInfo("app.profilesHeader", .text)
 
-        public static let profileToggle = AccessibilityInfo("app.profileToggle", .button)
+        public static let profileToggle = AccessibilityInfo("app.profileToggle", .toggle)
 
         public static let profileMenu = AccessibilityInfo("app.profileMenu", .menu)
     }

--- a/Packages/App/Sources/UIAccessibility/Screens/Profile.swift
+++ b/Packages/App/Sources/UIAccessibility/Screens/Profile.swift
@@ -31,6 +31,8 @@ extension AccessibilityInfo {
 
         public static let moduleLink = AccessibilityInfo("profile.moduleLink", .link)
 
+        public static let providerServerLink = AccessibilityInfo("profile.providerServerLink", .link)
+
         public static let cancel = AccessibilityInfo("profile.cancel", .button)
     }
 }

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutUITests.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutUITests.xcscheme
@@ -13,8 +13,9 @@
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
-            <AutocreatedTestPlanReference>
-            </AutocreatedTestPlanReference>
+            <TestPlanReference
+               reference = "container:Passepartout/UITests/TVScreenshots.xctestplan">
+            </TestPlanReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
@@ -25,7 +26,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Passepartout/UITests/TVScreenshots.xctestplan">
+            reference = "container:Passepartout/UITests/TVScreenshots.xctestplan"
+            default = "YES">
          </TestPlanReference>
          <TestPlanReference
             reference = "container:Passepartout/UITests/MainScreenshots.xctestplan">

--- a/Passepartout/App/Context/ProfileManager+Testing.swift
+++ b/Passepartout/App/Context/ProfileManager+Testing.swift
@@ -52,7 +52,11 @@ extension ProfileManager {
 
                         if parameters.name == "Hide.me" {
                             if var ovpnBuilder = moduleBuilder as? OpenVPNModule.Builder {
+#if !os(tvOS)
+                                ovpnBuilder.isInteractive = true
+#endif
                                 ovpnBuilder.providerEntity = mockHideMeEntity
+                                ovpnBuilder.credentials = OpenVPN.Credentials.Builder(username: "foo", password: "bar").build()
                                 moduleBuilder = ovpnBuilder
                             } else if var onDemandBuilder = moduleBuilder as? OnDemandModule.Builder {
 #if !os(tvOS)

--- a/Passepartout/App/Context/ProfileManager+Testing.swift
+++ b/Passepartout/App/Context/ProfileManager+Testing.swift
@@ -168,7 +168,7 @@ private extension ProfileManager {
                         serverId: "be-v4",
                         supportedConfigurationIdentifiers: ["OpenVPN"],
                         supportedPresetIds: nil,
-                        categoryName: "",
+                        categoryName: "default",
                         countryCode: "BE",
                         otherCountryCodes: nil,
                         area: nil

--- a/Passepartout/App/Context/ProfileManager+Testing.swift
+++ b/Passepartout/App/Context/ProfileManager+Testing.swift
@@ -93,6 +93,11 @@ extension ProfileManager {
                             }
                         }
 
+                        if var wgBuilder = moduleBuilder as? WireGuardModule.Builder {
+                            wgBuilder.configurationBuilder = WireGuard.Configuration.Builder(privateKey: "")
+                            moduleBuilder = wgBuilder
+                        }
+
                         let module = try moduleBuilder.tryBuild()
                         builder.modules.append(module)
                     }

--- a/Passepartout/App/Context/ProfileManager+Testing.swift
+++ b/Passepartout/App/Context/ProfileManager+Testing.swift
@@ -52,9 +52,6 @@ extension ProfileManager {
 
                         if parameters.name == "Hide.me" {
                             if var ovpnBuilder = moduleBuilder as? OpenVPNModule.Builder {
-#if !os(tvOS)
-                                ovpnBuilder.isInteractive = true
-#endif
                                 ovpnBuilder.providerEntity = mockHideMeEntity
                                 moduleBuilder = ovpnBuilder
                             } else if var onDemandBuilder = moduleBuilder as? OnDemandModule.Builder {

--- a/Passepartout/UITests/Extensions/XCUIElement+Extensions.swift
+++ b/Passepartout/UITests/Extensions/XCUIElement+Extensions.swift
@@ -48,6 +48,8 @@ private extension XCUIElement {
             return buttons
         case .text:
             return staticTexts
+        case .toggle:
+            return toggles
         }
 #else
         switch elementType {
@@ -59,6 +61,8 @@ private extension XCUIElement {
             return menuItems
         case .text:
             return staticTexts
+        case .toggle:
+            return checkBoxes
         }
 #endif
     }

--- a/Passepartout/UITests/Extensions/XCUIElement+Extensions.swift
+++ b/Passepartout/UITests/Extensions/XCUIElement+Extensions.swift
@@ -49,7 +49,7 @@ private extension XCUIElement {
         case .text:
             return staticTexts
         case .toggle:
-            return toggles
+            return switches
         }
 #else
         switch elementType {

--- a/Passepartout/UITests/Main/MainFlowTests.swift
+++ b/Passepartout/UITests/Main/MainFlowTests.swift
@@ -58,14 +58,12 @@ final class MainFlowTests: XCTestCase {
             .leaveModule()
     }
 
-    // FIXME: ###, ui tests
-//#if os(iOS)
-//    func testDiscloseProviderCountry() {
-//        AppScreen(app: app)
-//            .waitForProfiles()
-//            .editProfile(at: 2)
-//            .connectToProfile()
-//            .discloseCountry(at: 2)
-//    }
-//#endif
+#if os(iOS)
+    func testDiscloseProviderCountry() {
+        AppScreen(app: app)
+            .waitForProfiles()
+            .editProfile(at: 2)
+            .editProviderServer()
+    }
+#endif
 }

--- a/Passepartout/UITests/Main/MainFlowTests.swift
+++ b/Passepartout/UITests/Main/MainFlowTests.swift
@@ -47,33 +47,25 @@ final class MainFlowTests: XCTestCase {
     func testEditProfile() {
         AppScreen(app: app)
             .waitForProfiles()
-            .openProfileMenu(at: 2)
-            .editProfile()
+            .editProfile(at: 2)
     }
 
     func testEditProfileModule() {
         AppScreen(app: app)
             .waitForProfiles()
-            .openProfileMenu(at: 2)
-            .editProfile()
+            .editProfile(at: 2)
             .enterModule(at: 1)
             .leaveModule()
     }
 
-    func testConnectToProviderServer() {
-        AppScreen(app: app)
-            .waitForProfiles()
-            .openProfileMenu(at: 2)
-            .connectToProfile()
-    }
-
-#if os(iOS)
-    func testDiscloseProviderCountry() {
-        AppScreen(app: app)
-            .waitForProfiles()
-            .openProfileMenu(at: 2)
-            .connectToProfile()
-            .discloseCountry(at: 2)
-    }
-#endif
+    // FIXME: ###, ui tests
+//#if os(iOS)
+//    func testDiscloseProviderCountry() {
+//        AppScreen(app: app)
+//            .waitForProfiles()
+//            .editProfile(at: 2)
+//            .connectToProfile()
+//            .discloseCountry(at: 2)
+//    }
+//#endif
 }

--- a/Passepartout/UITests/Main/MainScreenshotTests.swift
+++ b/Passepartout/UITests/Main/MainScreenshotTests.swift
@@ -51,8 +51,7 @@ final class MainScreenshotTests: XCTestCase, XCUIApplicationProviding {
             .enableProfile(at: 0)
 
         let profile = root
-            .openProfileMenu(at: 2)
-            .editProfile()
+            .editProfile(at: 2)
 
         await pause()
         try snapshot("03", "ProfileEditor", target: .sheet)
@@ -77,12 +76,13 @@ final class MainScreenshotTests: XCTestCase, XCUIApplicationProviding {
         await pause()
         try snapshot("01", "Connected")
 
-        app
-            .openProfileMenu(at: 2)
-            .connectToProfile()
-#if os(iOS)
-            .discloseCountry(at: 2)
-#endif
+        // FIXME: ###, ui tests
+//        app
+//            .editProfile(at: 2)
+//            .connectToProfile()
+//#if os(iOS)
+//            .discloseCountry(at: 2)
+//#endif
 
         await pause()
         try snapshot("05", "ProviderServers", target: .sheet)

--- a/Passepartout/UITests/Main/MainScreenshotTests.swift
+++ b/Passepartout/UITests/Main/MainScreenshotTests.swift
@@ -48,7 +48,7 @@ final class MainScreenshotTests: XCTestCase, XCUIApplicationProviding {
     func testTakeScreenshots() async throws {
         let root = AppScreen(app: app)
             .waitForProfiles()
-            .enableProfile(at: 0)
+            .enableProfile(at: 1)
 
         let profile = root
             .editProfile(at: 2)

--- a/Passepartout/UITests/Main/MainScreenshotTests.swift
+++ b/Passepartout/UITests/Main/MainScreenshotTests.swift
@@ -76,13 +76,12 @@ final class MainScreenshotTests: XCTestCase, XCUIApplicationProviding {
         await pause()
         try snapshot("01", "Connected")
 
-        // FIXME: ###, ui tests
-//        app
-//            .editProfile(at: 2)
-//            .connectToProfile()
-//#if os(iOS)
-//            .discloseCountry(at: 2)
-//#endif
+        app
+            .editProfile(at: 2)
+            .editProviderServer()
+#if os(iOS)
+            .discloseCountry(at: 2)
+#endif
 
         await pause()
         try snapshot("05", "ProviderServers", target: .sheet)

--- a/Passepartout/UITests/Main/Screens/AppScreen.swift
+++ b/Passepartout/UITests/Main/Screens/AppScreen.swift
@@ -45,9 +45,9 @@ struct AppScreen {
     }
 
     @discardableResult
-    func openProfileMenu(at index: Int) -> ProfileMenuScreen {
-        let profileMenu = app.get(.App.profileMenu, at: index)
+    func editProfile(at index: Int) -> ProfileEditorScreen {
+        let profileMenu = app.get(.App.profileEdit, at: index)
         profileMenu.tap()
-        return ProfileMenuScreen(app: app)
+        return ProfileEditorScreen(app: app)
     }
 }

--- a/Passepartout/UITests/Main/Screens/AppScreen.swift
+++ b/Passepartout/UITests/Main/Screens/AppScreen.swift
@@ -33,7 +33,7 @@ struct AppScreen {
 
     @discardableResult
     func waitForProfiles() -> Self {
-        app.get(.App.installedProfile)
+        app.get(.App.profilesHeader)
         return self
     }
 

--- a/Passepartout/UITests/Main/Screens/ProfileEditorScreen.swift
+++ b/Passepartout/UITests/Main/Screens/ProfileEditorScreen.swift
@@ -49,6 +49,13 @@ struct ProfileEditorScreen {
     }
 
     @discardableResult
+    func editProviderServer() -> Self {
+        let providerServerLink = app.get(.Profile.providerServerLink)
+        providerServerLink.tap()
+        return self
+    }
+
+    @discardableResult
     func closeProfile() -> AppScreen {
         let cancelButton = app.get(.Profile.cancel)
         cancelButton.tap()

--- a/Passepartout/UITests/Main/Screens/ProfileEditorScreen.swift
+++ b/Passepartout/UITests/Main/Screens/ProfileEditorScreen.swift
@@ -49,10 +49,10 @@ struct ProfileEditorScreen {
     }
 
     @discardableResult
-    func editProviderServer() -> Self {
+    func editProviderServer() -> ProviderServersScreen {
         let providerServerLink = app.get(.Profile.providerServerLink)
         providerServerLink.tap()
-        return self
+        return ProviderServersScreen(app: app)
     }
 
     @discardableResult

--- a/Passepartout/UITests/TV/Screens/AppScreen.swift
+++ b/Passepartout/UITests/TV/Screens/AppScreen.swift
@@ -35,7 +35,7 @@ struct AppScreen {
 
     @discardableResult
     func waitForProfiles() -> Self {
-        app.get(.App.installedProfile)
+        app.get(.App.profilesHeader)
         return self
     }
 


### PR DESCRIPTION
Outdated after reworking the UI. Some fixes were also needed because:

- [WireGuardModule requires a configuration](https://github.com/passepartoutvpn/passepartout/pull/1164)
- [OpenVPNModule is interactive when no credentials are set](https://github.com/passepartoutvpn/passepartout/pull/1104)
- Mock profile had a wrong category ("" → "default")