### PR TITLE
Use a single navigation destination for ProfileEditor

### DIFF
--- a/Packages/App/Sources/AppUIMain/Extensions/ProfileEditor+Destination.swift
+++ b/Packages/App/Sources/AppUIMain/Extensions/ProfileEditor+Destination.swift
@@ -1,0 +1,57 @@
+//
+//  ProfileEditor+Destination.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 2/12/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import PassepartoutKit
+import SwiftUI
+
+extension View {
+    public func navigationDestination(for editor: ProfileEditor, path: Binding<NavigationPath>) -> some View {
+        navigationDestination(for: ProfileRoute.self) { route in
+            editor.destinationHandler(for: route.wrapped)
+                .map { handler in
+                    AnyView(handler.moduleDestination(
+                        for: route.wrapped,
+                        with: .init(
+                            editor: editor,
+                            module: handler,
+                            impl: nil
+                        ),
+                        path: path
+                    ))
+                }
+        }
+    }
+}
+
+private extension ProfileEditor {
+    func destinationHandler(for route: AnyHashable) -> (any ModuleBuilder & ModuleDestinationProviding)? {
+        modules.first {
+            guard let handler = $0 as? any ModuleDestinationProviding else {
+                return false
+            }
+            return handler.handlesRoute(route)
+        } as? any ModuleBuilder & ModuleDestinationProviding
+    }
+}

--- a/Packages/App/Sources/AppUIMain/Extensions/ProfileEditor+Destination.swift
+++ b/Packages/App/Sources/AppUIMain/Extensions/ProfileEditor+Destination.swift
@@ -35,8 +35,7 @@ extension View {
                         for: route.wrapped,
                         with: .init(
                             editor: editor,
-                            module: handler,
-                            impl: nil
+                            module: handler
                         ),
                         path: path
                     ))

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+Destination.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+Destination.swift
@@ -112,7 +112,7 @@ private struct DestinationView: View {
                 OpenVPNView.RemotesView(
                     endpoints: endpoints,
                     excludedEndpoints: excludedEndpoints,
-                    remotesRoute: draft.wrappedValue.providerSelection == nil ? OpenVPNView.Subroute.editRemotes : nil
+                    remotesRoute: draft.wrappedValue.providerSelection == nil ? ProfileRoute(OpenVPNView.Subroute.editRemotes) : nil
                 )
 
             case .editRemotes:

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+Extensions.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+Extensions.swift
@@ -47,13 +47,13 @@ extension OpenVPNModule.Builder: ModuleShortcutsProviding {
     public func moduleShortcutsView(editor: ProfileEditor, path: Binding<NavigationPath>) -> some View {
         if let providerSelection {
 //            ProviderNameRow(id: providerSelection.id)
-            NavigationLink(value: OpenVPNView.Subroute.providerServer) {
+            NavigationLink(value: ProfileRoute(OpenVPNView.Subroute.providerServer)) {
                 ProviderServerRow(selectedEntity: providerSelection.entity)
             }
             .uiAccessibility(.Profile.providerServerLink)
         }
         if providerSelection != nil || configurationBuilder?.authUserPass == true {
-            NavigationLink(value: OpenVPNView.Subroute.credentials) {
+            NavigationLink(value: ProfileRoute(OpenVPNView.Subroute.credentials)) {
                 Text(Strings.Modules.Openvpn.credentials)
             }
         }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Configuration.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Configuration.swift
@@ -62,10 +62,6 @@ extension OpenVPNView {
     }
 }
 
-// MARK: - Editable
-
-
-
 // MARK: - Constant
 
 private extension OpenVPNView.ConfigurationView {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView.swift
@@ -92,7 +92,7 @@ private extension OpenVPNView {
             ConfigurationView(
                 isServerPushed: isServerPushed,
                 configuration: configuration,
-                credentialsRoute: Subroute.credentials
+                credentialsRoute: ProfileRoute(Subroute.credentials)
             )
         } else {
             emptyConfigurationView
@@ -111,11 +111,11 @@ private extension OpenVPNView {
     }
 
     func remotesLink(with endpoints: [ExtendedEndpoint]) -> some View {
-        NavigationLink(Strings.Modules.Openvpn.remotes, value: Subroute.remotes(endpoints))
+        NavigationLink(Strings.Modules.Openvpn.remotes, value: ProfileRoute(Subroute.remotes(endpoints)))
     }
 
     func providerConfigurationLink(with configuration: OpenVPN.Configuration) -> some View {
-        NavigationLink(Strings.Global.Nouns.configuration, value: Subroute.providerConfiguration(configuration))
+        NavigationLink(Strings.Global.Nouns.configuration, value: ProfileRoute(Subroute.providerConfiguration(configuration)))
     }
 
     var importButton: some View {
@@ -129,7 +129,7 @@ private extension OpenVPNView {
             providerId: providerId,
             providerPreferences: nil,
             selectedEntity: providerEntity,
-            entityDestination: Subroute.providerServer,
+            entityDestination: ProfileRoute(Subroute.providerServer),
             paywallReason: $paywallReason,
             providerRows: {
                 moduleGroup(for: providerAccountRows)
@@ -138,7 +138,7 @@ private extension OpenVPNView {
     }
 
     var providerAccountRows: [ModuleRow]? {
-        [.push(caption: Strings.Modules.Openvpn.credentials, route: HashableRoute(Subroute.credentials))]
+        [.push(caption: Strings.Modules.Openvpn.credentials, route: HashableRoute(ProfileRoute(Subroute.credentials)))]
     }
 }
 

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileRoute.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileRoute.swift
@@ -27,4 +27,8 @@ import Foundation
 
 struct ProfileRoute: Hashable {
     let wrapped: AnyHashable
+
+    init(_ wrapped: AnyHashable) {
+        self.wrapped = wrapped
+    }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileRoute.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileRoute.swift
@@ -1,5 +1,5 @@
 //
-//  View+Modifiers.swift
+//  ProfileRoute.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 2/12/25.
@@ -23,24 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import SwiftUI
+import Foundation
 
-extension View {
-    public func modifiers(_ modifiers: [any ViewModifier]) -> some View {
-        modifiers.reduce(into: AnyView(self)) { view, modifier in
-            view = AnyView(view.modifier(AnyViewModifier(modifier)))
-        }
-    }
-}
-
-private struct AnyViewModifier: ViewModifier {
-    let apply: (AnyView) -> AnyView
-
-    init<M: ViewModifier>(_ modifier: M) {
-        self.apply = { AnyView($0.modifier(modifier)) }
-    }
-
-    func body(content: Content) -> some View {
-        apply(AnyView(content))
-    }
+struct ProfileRoute: Hashable {
+    let wrapped: AnyHashable
 }

--- a/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -73,7 +73,7 @@ struct ProfileEditView: View, Routable {
         .navigationTitle(Strings.Global.Nouns.profile)
         .navigationBarBackButtonHidden(true)
         .navigationDestination(for: NavigationRoute.self, destination: pushDestination)
-        .navigationDestinations(for: profileEditor, path: $path)
+        .navigationDestination(for: profileEditor, path: $path)
         .onLoad {
             if let initialModuleId {
                 push(.moduleDetail(moduleId: initialModuleId))

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
@@ -69,11 +69,11 @@ struct ProfileSplitView: View, Routable {
                 switch selectedModuleId {
                 case ModuleListView.generalModuleId:
                     detailView(for: .general)
-                        .navigationDestinations(for: profileEditor, path: $detailPath)
+                        .navigationDestination(for: profileEditor, path: $detailPath)
 
                 default:
                     detailView(for: .module(id: selectedModuleId))
-                        .navigationDestinations(for: profileEditor, path: $detailPath)
+                        .navigationDestination(for: profileEditor, path: $detailPath)
                 }
             }
             .themeNavigationStack(path: $detailPath)

--- a/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
@@ -48,7 +48,7 @@ extension AppProduct {
         static let all: [AppProduct] = [
             .Full.OneTime.lifetime,
             .Full.Recurring.monthly,
-            .Full.Recurring.yearly,
+            .Full.Recurring.yearly
         ]
     }
 

--- a/Packages/App/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
@@ -44,32 +44,6 @@ extension ProfileEditor {
     }
 }
 
-// MARK: - Destination
-
-extension View {
-    public func navigationDestinations(for editor: ProfileEditor, path: Binding<NavigationPath>) -> some View {
-        modifiers(editor.moduleDestinationModifiers(path: path))
-    }
-}
-
-private extension ProfileEditor {
-    func moduleDestinationModifiers(path: Binding<NavigationPath>) -> [any ViewModifier] {
-        modules.compactMap {
-            guard let provider = $0 as? any ModuleDestinationProviding else {
-                return nil
-            }
-            return provider.moduleDestination(
-                with: .init(
-                    editor: self,
-                    module: $0,
-                    impl: nil
-                ),
-                path: path
-            )
-        }
-    }
-}
-
 // MARK: - Shortcuts
 
 extension ProfileEditor {

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleDestinationProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleDestinationProviding.swift
@@ -45,16 +45,12 @@ public struct ModuleDestinationParameters {
 
     public let module: any ModuleBuilder
 
-    public let impl: (any ModuleImplementation)?
-
     @MainActor
     public init(
         editor: ProfileEditor,
-        module: any ModuleBuilder,
-        impl: (any ModuleImplementation)?
+        module: any ModuleBuilder
     ) {
         self.editor = editor
         self.module = module
-        self.impl = impl
     }
 }

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleDestinationProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleDestinationProviding.swift
@@ -28,10 +28,16 @@ import PassepartoutKit
 import SwiftUI
 
 public protocol ModuleDestinationProviding {
-    associatedtype Destination: ViewModifier
+    associatedtype Destination: View
+
+    func handlesRoute(_ route: AnyHashable) -> Bool
 
     @MainActor
-    func moduleDestination(with parameters: ModuleDestinationParameters, path: Binding<NavigationPath>) -> Destination
+    func moduleDestination(
+        for route: AnyHashable,
+        with parameters: ModuleDestinationParameters,
+        path: Binding<NavigationPath>
+    ) -> Destination
 }
 
 public struct ModuleDestinationParameters {


### PR DESCRIPTION
The recursive modifiers are overkill. Instead:

- Wrap module routes into a static route type (ProfileRoute)
- Iterate over ModuleDestinationProviding looking for the module that handles the route
- Return destination views from that module

This way, only `navigationDestination(for: ProfileRoute.self)` is needed on the parent.