### PR TITLE
Relist "Forever" purchase

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -34,6 +34,9 @@ import UIAccessibility
 struct ModuleListView: View, Routable {
     static let generalModuleId = UUID()
 
+    @EnvironmentObject
+    private var iapManager: IAPManager
+
     @Environment(\.isUITesting)
     private var isUITesting
 
@@ -59,7 +62,8 @@ struct ModuleListView: View, Routable {
                         Text(Strings.Global.Nouns.general)
                         PurchaseRequiredView(
                             requiring: requiredGeneralFeatures,
-                            reason: $paywallReason
+                            reason: $paywallReason,
+                            suggesting: suggestedGeneralProducts
                         )
                     }
                 }
@@ -133,6 +137,12 @@ private extension ModuleListView {
             features.insert(.sharing)
         }
         return features
+    }
+
+    var suggestedGeneralProducts: Set<AppProduct> {
+        var products = iapManager.suggestedProducts()
+        products.insert(.Features.appleTV)
+        return products
     }
 
     func moveModules(from offsets: IndexSet, to newOffset: Int) {

--- a/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
@@ -86,6 +86,10 @@ extension AppProduct.Full {
 
         public static let yearly = AppProduct(featureId: "full.yearly")
     }
+
+    public enum OneTime {
+        public static let lifetime = AppProduct(featureId: "full.lifetime")
+    }
 }
 
 extension AppProduct {
@@ -119,12 +123,4 @@ extension AppProduct.Features {
     public static let networkSettings = AppProduct(featureId: "network_settings")
 
     public static let trustedNetworks = AppProduct(featureId: "trusted_networks")
-}
-
-extension AppProduct.Full {
-    public enum OneTime {
-
-        @available(*, deprecated)
-        public static let lifetime = AppProduct(featureId: "full.lifetime")
-    }
 }

--- a/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
@@ -43,11 +43,11 @@ extension AppProduct {
         ]
     }
 
-    public enum Full {
+    public enum Complete {
         static let all: [AppProduct] = [
-            .Full.OneTime.lifetime,
-            .Full.Recurring.monthly,
-            .Full.Recurring.yearly
+            .Complete.OneTime.lifetime,
+            .Complete.Recurring.monthly,
+            .Complete.Recurring.yearly
         ]
     }
 
@@ -80,7 +80,7 @@ extension AppProduct.Features {
     public static let appleTV = AppProduct(featureId: "appletv")
 }
 
-extension AppProduct.Full {
+extension AppProduct.Complete {
     public enum Recurring {
         public static let monthly = AppProduct(featureId: "full.monthly")
 
@@ -95,9 +95,9 @@ extension AppProduct.Full {
 extension AppProduct {
     public var isComplete: Bool {
         switch self {
-        case .Full.Recurring.yearly,
-                .Full.Recurring.monthly,
-                .Full.OneTime.lifetime:
+        case .Complete.Recurring.yearly,
+                .Complete.Recurring.monthly,
+                .Complete.OneTime.lifetime:
             return true
         default:
             return false
@@ -106,7 +106,7 @@ extension AppProduct {
 
     public var isRecurring: Bool {
         switch self {
-        case .Full.Recurring.monthly, .Full.Recurring.yearly:
+        case .Complete.Recurring.monthly, .Complete.Recurring.yearly:
             return true
         default:
             return false

--- a/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppProduct+Features.swift
@@ -93,7 +93,7 @@ extension AppProduct.Full {
 }
 
 extension AppProduct {
-    public var isFullVersion: Bool {
+    public var isComplete: Bool {
         switch self {
         case .Full.Recurring.yearly,
                 .Full.Recurring.monthly,

--- a/Packages/App/Sources/CommonIAP/Domain/AppProduct.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppProduct.swift
@@ -39,7 +39,7 @@ public struct AppProduct: RawRepresentable, Hashable, Sendable {
 
 extension AppProduct {
     public static var all: [Self] {
-        Features.all + Essentials.all + Full.all + Donations.all
+        Features.all + Essentials.all + Complete.all + Donations.all
     }
 }
 

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -70,10 +70,10 @@ extension AppProduct: AppFeatureProviding {
 #endif
             return eligible
 
-        // MARK: Discontinued
-
         case .Complete.OneTime.lifetime, .Complete.Recurring.monthly, .Complete.Recurring.yearly:
             return AppFeature.allCases
+
+        // MARK: Discontinued
 
         case .Features.allProviders:
             return [.providers]

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -72,7 +72,7 @@ extension AppProduct: AppFeatureProviding {
 
         // MARK: Discontinued
 
-        case .Full.OneTime.lifetime, .Full.Recurring.monthly, .Full.Recurring.yearly:
+        case .Complete.OneTime.lifetime, .Complete.Recurring.monthly, .Complete.Recurring.yearly:
             return AppFeature.allCases
 
         case .Features.allProviders:

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -31,9 +31,9 @@ import PassepartoutKit
 extension IAPManager {
     public func suggestedProducts() -> Set<AppProduct> {
 #if os(iOS)
-        suggestedProducts(for: .iOS, withRecurring: true)
+        suggestedProducts(for: .iOS, withComplete: true)
 #elseif os(macOS)
-        suggestedProducts(for: .macOS, withRecurring: true)
+        suggestedProducts(for: .macOS, withComplete: true)
 #elseif os(tvOS)
         fatalError("tvOS: Do not suggest products, paywall unsupported")
 #endif
@@ -50,7 +50,7 @@ extension IAPManager {
 
     func suggestedProducts(
         for platform: Platform,
-        withRecurring: Bool = false,
+        withComplete: Bool = false,
         asserting: Bool = false
     ) -> Set<AppProduct> {
         guard !purchasedProducts.contains(.Essentials.iOS_macOS) else {
@@ -92,9 +92,10 @@ extension IAPManager {
             suggested.insert(.Essentials.macOS)
         }
 
-        if withRecurring && purchasedProducts.isEmpty {
+        if withComplete && purchasedProducts.isEmpty {
             suggested.insert(.Full.Recurring.yearly)
             suggested.insert(.Full.Recurring.monthly)
+            suggested.insert(.Full.OneTime.lifetime)
         }
 
         return suggested

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -59,9 +59,9 @@ extension IAPManager {
             }
             return []
         }
-        guard !purchasedProducts.contains(where: \.isFullVersion) else {
+        guard !purchasedProducts.contains(where: \.isComplete) else {
             if asserting {
-                assertionFailure("Suggesting 'Essentials' to full version purchaser?")
+                assertionFailure("Suggesting 'Essentials' to complete version purchaser?")
             }
             return []
         }

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -93,9 +93,9 @@ extension IAPManager {
         }
 
         if withComplete && purchasedProducts.isEmpty {
-            suggested.insert(.Full.Recurring.yearly)
-            suggested.insert(.Full.Recurring.monthly)
-            suggested.insert(.Full.OneTime.lifetime)
+            suggested.insert(.Complete.Recurring.yearly)
+            suggested.insert(.Complete.Recurring.monthly)
+            suggested.insert(.Complete.OneTime.lifetime)
         }
 
         return suggested

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -54,7 +54,7 @@ struct PaywallView: View {
     private var products: [InAppProduct] = []
 
     @State
-    private var fullProducts: [InAppProduct] = []
+    private var completeProducts: [InAppProduct] = []
 
     @State
     private var purchasingIdentifier: String?
@@ -91,7 +91,7 @@ private extension PaywallView {
         Form {
             requiredFeaturesView
             productsView
-            fullProductsView
+            completeProductsView
             restoreView
             linksView
         }
@@ -138,8 +138,8 @@ private extension PaywallView {
             }
     }
 
-    var fullProductsView: some View {
-        fullProducts
+    var completeProductsView: some View {
+        completeProducts
             .nilIfEmpty
             .map { products in
                 ForEach(products, id: \.productIdentifier) {
@@ -221,7 +221,7 @@ private extension PaywallView {
             guard !rawProducts.isEmpty else {
                 throw AppError.emptyProducts
             }
-            let rawFullProducts = rawProducts.filter(\.isFullVersion)
+            let rawCompleteProducts = rawProducts.filter(\.isComplete)
 
             let allProducts = try await iapManager.purchasableProducts(for: rawProducts
                 .sorted {
@@ -229,13 +229,13 @@ private extension PaywallView {
                 }
             )
             var products: [InAppProduct] = []
-            var fullProducts: [InAppProduct] = []
+            var completeProducts: [InAppProduct] = []
             allProducts.forEach {
                 guard let raw = AppProduct(rawValue: $0.productIdentifier) else {
                     return
                 }
-                if rawFullProducts.contains(raw) {
-                    fullProducts.append($0)
+                if rawCompleteProducts.contains(raw) {
+                    completeProducts.append($0)
                 } else {
                     products.append($0)
                 }
@@ -247,7 +247,7 @@ private extension PaywallView {
             }
 
             self.products = products
-            self.fullProducts = fullProducts
+            self.completeProducts = completeProducts
         } catch {
             pp_log(.App.iap, .error, "Unable to load purchasable products: \(error)")
             onError(error, dismissing: true)

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -295,9 +295,9 @@ private extension AppProduct {
             return 1
         case .Essentials.macOS:
             return 2
-        case .Full.Recurring.yearly:
+        case .Complete.Recurring.yearly:
             return 3
-        case .Full.Recurring.monthly:
+        case .Complete.Recurring.monthly:
             return 4
         default:
             return .max

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -343,29 +343,31 @@ extension IAPManagerTests {
         XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
     }
 
-    func test_givenFree_whenWithRecurring_thenSuggestsEssentialsAndRecurring() async {
+    func test_givenFree_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, withRecurring: true), [
+        XCTAssertEqual(sut.suggestedProducts(for: .iOS, withComplete: true), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Full.Recurring.yearly,
-            .Full.Recurring.monthly
+            .Full.Recurring.monthly,
+            .Full.OneTime.lifetime
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, withRecurring: true), [
+        XCTAssertEqual(sut.suggestedProducts(for: .macOS, withComplete: true), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Full.Recurring.yearly,
-            .Full.Recurring.monthly
+            .Full.Recurring.monthly,
+            .Full.OneTime.lifetime
         ])
     }
 
-    func test_givenNonFree_whenWithRecurring_thenSuggestsEssentials() async {
+    func test_givenNonFree_whenWithComplete_thenSuggestsEssentials() async {
         let sut = await IAPManager(products: [.Features.trustedNetworks])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, withRecurring: true), [
+        XCTAssertEqual(sut.suggestedProducts(for: .iOS, withComplete: true), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, withRecurring: true), [
+        XCTAssertEqual(sut.suggestedProducts(for: .macOS, withComplete: true), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -326,19 +326,19 @@ extension IAPManagerTests {
     }
 
     func test_givenLifetime_thenSuggestsNothing() async {
-        let sut = await IAPManager(products: [.Full.OneTime.lifetime])
+        let sut = await IAPManager(products: [.Complete.OneTime.lifetime])
         XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
         XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
     }
 
     func test_givenRecurringMonthly_thenSuggestsNothing() async {
-        let sut = await IAPManager(products: [.Full.Recurring.monthly])
+        let sut = await IAPManager(products: [.Complete.Recurring.monthly])
         XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
         XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
     }
 
     func test_givenRecurringYearly_thenSuggestsNothing() async {
-        let sut = await IAPManager(products: [.Full.Recurring.yearly])
+        let sut = await IAPManager(products: [.Complete.Recurring.yearly])
         XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
         XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
     }
@@ -348,16 +348,16 @@ extension IAPManagerTests {
         XCTAssertEqual(sut.suggestedProducts(for: .iOS, withComplete: true), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
-            .Full.Recurring.yearly,
-            .Full.Recurring.monthly,
-            .Full.OneTime.lifetime
+            .Complete.Recurring.yearly,
+            .Complete.Recurring.monthly,
+            .Complete.OneTime.lifetime
         ])
         XCTAssertEqual(sut.suggestedProducts(for: .macOS, withComplete: true), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
-            .Full.Recurring.yearly,
-            .Full.Recurring.monthly,
-            .Full.OneTime.lifetime
+            .Complete.Recurring.yearly,
+            .Complete.Recurring.monthly,
+            .Complete.OneTime.lifetime
         ])
     }
 


### PR DESCRIPTION
Only subscriptions were being offered.

Also, fix "Apple TV" not properly suggested on macOS when iCloud is required.