### PR TITLE
WireGuard: Fix IPv6 endpoints not recognized

### DIFF
--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Endpoint+WireGuardKit.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/Mappers/Endpoint+WireGuardKit.swift
@@ -36,7 +36,14 @@ extension PassepartoutKit.Endpoint {
     }
 
     func toWireGuardEndpoint() throws -> WireGuardKit.Endpoint {
-        guard let wg = WireGuardKit.Endpoint(from: "\(address):\(port)") else {
+        let wgAddress: String
+        switch address {
+        case .ip(let raw, let family):
+            wgAddress = family == .v6 ? "[\(raw)]" : raw
+        case .hostname(let raw):
+            wgAddress = raw
+        }
+        guard let wg = WireGuardKit.Endpoint(from: "\(wgAddress):\(port)") else {
             throw PassepartoutError(.parsing)
         }
         return wg


### PR DESCRIPTION
https://www.reddit.com/r/passepartout/comments/1isjyri/no_wireguard_connection_via_ipv6_to_a_server/

v2 handled this correctly because it was using the WireGuardKit entities as is, whereas v3 uses its own entities, namely `WireGuard.RemoteInterface` and `Endpoint` in this case. The difference is that WireGuard requires that IPv6 addresses in endpoints be wrapped in square brackets in the configuration file.