### PR TITLE
OpenVPN: Do not route DNS implicitly through the VPN

### DIFF
--- a/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
+++ b/Packages/PassepartoutOpenVPNOpenSSL/Sources/PassepartoutOpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
@@ -206,19 +206,6 @@ private extension NetworkSettingsBuilder {
             return ipv4Route
         }
 
-        if !isIPv4Gateway {
-            try? allDNSServers.forEach {
-                switch Address(rawValue: $0) {
-                case .ip(let addr, let family):
-                    if family == .v4 {
-                        routes.append(.init(try Subnet(addr, 32), nil))
-                    }
-                default:
-                    break
-                }
-            }
-        }
-
         return ipv4.including(routes: routes)
     }
 
@@ -242,19 +229,6 @@ private extension NetworkSettingsBuilder {
                 pp_log(.openvpn, .info, "\tIPv6: Add route \(route.destination?.description ?? "default") -> \(route.gateway?.description ?? "*")")
             }
             return ipv6Route
-        }
-
-        if !isIPv6Gateway {
-            try? allDNSServers.forEach {
-                switch Address(rawValue: $0) {
-                case .ip(let addr, let family):
-                    if family == .v6 {
-                        routes.append(.init(try Subnet(addr, 128), nil))
-                    }
-                default:
-                    break
-                }
-            }
         }
 
         return ipv6.including(routes: routes)


### PR DESCRIPTION
OpenVPN adds routes to the DNS servers when the VPN is not the default gateway (split setup). This is [an ancient drag from TunnelKit](https://github.com/passepartoutvpn/tunnelkit/commit/f799f47c256027130e348095b15fca10c8d2387b) that looks redundant for private DNS inside the VPN (the server already pushes the routes to reach the DNS server network) and breaking for public DNS (the VPN may have no Internet access).

There may or may not have been a reason to do that (2019), but it's time to reconsider the decision. Perhaps this was done in TunnelKit when routing was not working properly yet, and this code became redundant later.

Test in split setups before merging.

Final considerations:

- If it's the server pushing the DNS servers, be they public or private, the server is responsible for making them reachable from the client.
- If it's the client overriding the DNS settings via a module, an option should be offered to decide whether to route DNS inside or outside of the VPN (in case a VPN module is present in the profile).