### PR TITLE
Retry in-app verification 3 times before failing

### DIFF
--- a/Packages/App/Sources/CommonLibrary/Domain/Constants.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/Constants.swift
@@ -103,6 +103,10 @@ public struct Constants: Decodable, Sendable {
                 public let delay: TimeInterval
 
                 public let interval: TimeInterval
+
+                public let attempts: Int
+
+                public let retryInterval: TimeInterval
             }
 
             public let production: Parameters

--- a/Packages/App/Sources/CommonLibrary/Resources/Constants.json
+++ b/Packages/App/Sources/CommonLibrary/Resources/Constants.json
@@ -34,11 +34,15 @@
         "verification": {
             "production": {
                 "delay": 120.0,
-                "interval": 3600.0
+                "interval": 3600.0,
+                "attempts": 3,
+                "retryInterval": 20.0
             },
             "beta": {
                 "delay": 600.0,
-                "interval": 600.0
+                "interval": 600.0,
+                "attempts": 3,
+                "retryInterval": 10.0
             }
         }
     },

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -156,6 +156,9 @@ private extension PacketTunnelProvider {
 
             pp_log(.app, .info, "Will verify profile again in \(params.interval) seconds...")
             try? await Task.sleep(interval: params.interval)
+
+            // reset attempts for next verification
+            attempts = params.attempts
         }
     }
 }

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -81,7 +81,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
                 await verifyEligibility(
                     of: fwd.profile,
                     environment: environment,
-                    interval: params.interval
+                    params: params
                 )
             }
         } catch {
@@ -118,13 +118,32 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 // MARK: - Eligibility
 
 private extension PacketTunnelProvider {
-    func verifyEligibility(of profile: Profile, environment: TunnelEnvironment, interval: TimeInterval) async {
+
+    @MainActor
+    func verifyEligibility(
+        of profile: Profile,
+        environment: TunnelEnvironment,
+        params: Constants.Tunnel.Verification.Parameters
+    ) async {
+        var attempts = params.attempts
+
         while true {
             do {
                 pp_log(.app, .info, "Verify profile, requires: \(profile.features)")
                 await context.iapManager.reloadReceipt()
-                try await context.iapManager.verify(profile)
+                try context.iapManager.verify(profile)
             } catch {
+
+                // mitigate the StoreKit inability to report errors, sometimes it
+                // would just return empty products, e.g. on network failure. in those
+                // cases, retry a few times before failing
+                if attempts > 0 {
+                    attempts -= 1
+                    pp_log(.app, .error, "Verification failed for profile \(profile.id), next attempt in \(params.retryInterval) seconds... (remaining: \(attempts), products: \(context.iapManager.purchasedProducts))")
+                    try? await Task.sleep(interval: params.retryInterval)
+                    continue
+                }
+
                 let error = PassepartoutError(.App.ineligibleProfile)
                 environment.setEnvironmentValue(error.code, forKey: TunnelEnvironmentKeys.lastErrorCode)
                 pp_log(.app, .fault, "Verification failed for profile \(profile.id), shutting down: \(error)")
@@ -135,8 +154,8 @@ private extension PacketTunnelProvider {
                 return
             }
 
-            pp_log(.app, .info, "Will verify profile again in \(interval) seconds...")
-            try? await Task.sleep(interval: interval)
+            pp_log(.app, .info, "Will verify profile again in \(params.interval) seconds...")
+            try? await Task.sleep(interval: params.interval)
         }
     }
 }


### PR DESCRIPTION
Reported by e-mail, "Purchase required" despite being a paying user:

> It started the other day after my phone’s battery died.  I was having all sorts of connectivity problems after it restarted and finally realized the VPN wasn’t activating, but was routing traffic so nothing worked.

StoreKit is unable to report failures and may occasionally return empty products e.g. on network failure. There's no way of telling paying from non-paying users in that case. Considering that `currentEntitlements` may return the correct products after a delay, the PR mitigates the broken behavior by retrying a few times before failing.

Candidate for a FAQ entry.