### PR TITLE
Validate module builders in ProfileEditor

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -135,7 +135,7 @@ private extension ProfileCoordinator {
 
     // standard: verify and alert if purchase required
     func onCommitEditingStandard() async throws {
-        let profileToSave = try profileEditor.build()
+        let profileToSave = try profileEditor.build(with: registry)
 
         do {
             try iapManager.verify(profileToSave, extra: profileEditor.extraFeatures)
@@ -171,7 +171,7 @@ private extension ProfileCoordinator {
 
     // beta: skip verification
     func onCommitEditingBeta() async throws {
-        let profileToSave = try profileEditor.build()
+        let profileToSave = try profileEditor.build(with: registry)
         try await profileEditor.save(profileToSave, to: profileManager, preferencesManager: preferencesManager)
         onDismiss()
     }

--- a/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/StandardWireGuardParser+Validate.swift
+++ b/Packages/PassepartoutWireGuardGo/Sources/PassepartoutWireGuardGo/StandardWireGuardParser+Validate.swift
@@ -1,0 +1,90 @@
+//
+//  StandardWireGuardParser+Validate.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 2/25/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import PassepartoutKit
+internal import WireGuardKit
+
+extension StandardWireGuardParser: ModuleBuilderValidator {
+    public func validate(_ builder: any ModuleBuilder) throws {
+        guard let builder = builder as? WireGuardModule.Builder else {
+            throw PassepartoutError(.unknownModuleHandler)
+        }
+        guard let configurationBuilder = builder.configurationBuilder else {
+            // assume provider configurations to be valid
+            return
+        }
+        do {
+            let quickConfig = configurationBuilder.toQuickConfig()
+            _ = try TunnelConfiguration(fromWgQuickConfig: quickConfig)
+        } catch {
+            throw PassepartoutError(.parsing, error)
+        }
+    }
+}
+
+private extension WireGuard.Configuration.Builder {
+    func toQuickConfig() -> String {
+        var lines: [String] = []
+
+        lines.append("[Interface]")
+        lines.append("PrivateKey = \(interface.privateKey)")
+        if !interface.addresses.isEmpty {
+            lines.append("Address = \(interface.addresses.wgJoined)")
+        }
+        let dnsEntries = interface.dns.servers + (interface.dns.searchDomains ?? [])
+        if !dnsEntries.isEmpty {
+            lines.append("DNS = \(dnsEntries.wgJoined)")
+        }
+        if let mtu = interface.mtu {
+            lines.append("MTU = \(mtu)")
+        }
+
+        peers.forEach {
+            lines.append("[Peer]")
+            lines.append("PublicKey = \($0.publicKey)")
+            if let preSharedKey = $0.preSharedKey, !preSharedKey.isEmpty {
+                lines.append("PresharedKey = \(preSharedKey)")
+            }
+            if !$0.allowedIPs.isEmpty {
+                lines.append("AllowedIPs = \($0.allowedIPs.wgJoined)")
+            }
+            if let endpoint = $0.endpoint {
+                lines.append("Endpoint = \(endpoint)")
+            }
+            if let persistentKeepAlive = $0.keepAlive {
+                lines.append("PersistentKeepalive = \(persistentKeepAlive)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+private extension Collection where Element == String {
+    var wgJoined: String {
+        joined(separator: ",")
+    }
+}

--- a/Packages/PassepartoutWireGuardGo/Tests/PassepartoutWireGuardGoTests/StandardWireGuardParserTests.swift
+++ b/Packages/PassepartoutWireGuardGo/Tests/PassepartoutWireGuardGoTests/StandardWireGuardParserTests.swift
@@ -1,0 +1,218 @@
+//
+//  StandardWireGuardParserTests.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 2/25/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import PassepartoutKit
+@testable import PassepartoutWireGuardGo
+@testable internal import WireGuardKit
+import XCTest
+
+final class StandardWireGuardParserTests: XCTestCase {
+    private let parser = StandardWireGuardParser()
+
+    private let keyGenerator = StandardWireGuardKeyGenerator()
+
+    // MARK: - Interface
+
+    func test_givenParser_whenGoodBuilder_thenDoesNotThrow() {
+        var sut = newBuilder()
+        sut.interface.addresses = ["1.2.3.4"]
+
+        var dns = DNSModule.Builder()
+        dns.servers = ["1.2.3.4"]
+        dns.searchDomains = ["domain.local"]
+        sut.interface.dns = dns
+
+        let builder = WireGuardModule.Builder(configurationBuilder: sut)
+        XCTAssertNoThrow(try parser.validate(builder))
+    }
+
+    func test_givenParser_whenBadPrivateKey_thenThrows() {
+        let sut = WireGuard.Configuration.Builder(privateKey: "")
+        do {
+            try assertValidationFailure(sut)
+        } catch {
+            assertParseError(error) {
+                guard case .interfaceHasInvalidPrivateKey = $0 else {
+                    XCTFail($0.localizedDescription)
+                    return
+                }
+            }
+        }
+    }
+
+    func test_givenParser_whenBadAddresses_thenThrows() {
+        var sut = newBuilder()
+        sut.interface.addresses = ["dsfds"]
+        do {
+            try assertValidationFailure(sut)
+        } catch {
+            assertParseError(error) {
+                guard case .interfaceHasInvalidAddress = $0 else {
+                    XCTFail($0.localizedDescription)
+                    return
+                }
+            }
+        }
+    }
+
+    // parser is too tolerant, never fails
+//    func test_givenParser_whenBadDNS_thenThrows() {
+//        var sut = newBuilder()
+//        sut.interface.addresses = ["1.2.3.4"]
+//
+//        var dns = DNSModule.Builder()
+//        dns.servers = ["1.a.2.$%3"]
+//        dns.searchDomains = ["-invalid.example.com"]
+//        sut.interface.dns = dns
+//
+//        do {
+//            try assertValidationFailure(sut)
+//        } catch {
+//            assertParseError(error) {
+//                guard case .interfaceHasInvalidDNS = $0 else {
+//                    XCTFail($0.localizedDescription)
+//                    return
+//                }
+//            }
+//        }
+//    }
+
+    // MARK: - Peers
+
+    func test_givenParser_whenBadPeerPublicKey_thenThrows() {
+        var sut = newBuilder(withInterface: true)
+
+        let peer = WireGuard.RemoteInterface.Builder(publicKey: "")
+        sut.peers = [peer]
+
+        do {
+            try assertValidationFailure(sut)
+        } catch {
+            assertParseError(error) {
+                guard case .peerHasInvalidPublicKey = $0 else {
+                    XCTFail($0.localizedDescription)
+                    return
+                }
+            }
+        }
+    }
+
+    func test_givenParser_whenBadPeerPresharedKey_thenThrows() {
+        var sut = newBuilder(withInterface: true, withPeer: true)
+        var peer = sut.peers[0]
+        peer.preSharedKey = "fdsfokn.,x"
+        sut.peers = [peer]
+
+        do {
+            try assertValidationFailure(sut)
+        } catch {
+            assertParseError(error) {
+                guard case .peerHasInvalidPreSharedKey = $0 else {
+                    XCTFail($0.localizedDescription)
+                    return
+                }
+            }
+        }
+    }
+
+    func test_givenParser_whenBadPeerEndpoint_thenThrows() {
+        var sut = newBuilder(withInterface: true, withPeer: true)
+        var peer = sut.peers[0]
+        peer.endpoint = "fdsfokn.,x"
+        sut.peers = [peer]
+
+        do {
+            try assertValidationFailure(sut)
+        } catch {
+            assertParseError(error) {
+                guard case .peerHasInvalidEndpoint = $0 else {
+                    XCTFail($0.localizedDescription)
+                    return
+                }
+            }
+        }
+    }
+
+    func test_givenParser_whenBadPeerAllowedIPs_thenThrows() {
+        var sut = newBuilder(withInterface: true, withPeer: true)
+        var peer = sut.peers[0]
+        peer.allowedIPs = ["fdsfokn.,x"]
+        sut.peers = [peer]
+
+        do {
+            try assertValidationFailure(sut)
+        } catch {
+            assertParseError(error) {
+                guard case .peerHasInvalidAllowedIP = $0 else {
+                    XCTFail($0.localizedDescription)
+                    return
+                }
+            }
+        }
+    }
+}
+
+private extension StandardWireGuardParserTests {
+    func newBuilder(withInterface: Bool = false, withPeer: Bool = false) -> WireGuard.Configuration.Builder {
+        var builder = WireGuard.Configuration.Builder(keyGenerator: keyGenerator)
+        if withInterface {
+            builder.interface.addresses = ["1.2.3.4"]
+            var dns = DNSModule.Builder()
+            dns.servers = ["1.2.3.4"]
+            dns.searchDomains = ["domain.local"]
+            builder.interface.dns = dns
+        }
+        if withPeer {
+            let peerPrivateKey = keyGenerator.newPrivateKey()
+            do {
+                let publicKey = try keyGenerator.publicKey(for: peerPrivateKey)
+                builder.peers = [WireGuard.RemoteInterface.Builder(publicKey: publicKey)]
+            } catch {
+                XCTFail(error.localizedDescription)
+                return builder
+            }
+        }
+        return builder
+    }
+
+    func assertValidationFailure(_ wgBuilder: WireGuard.Configuration.Builder) throws {
+        let builder = WireGuardModule.Builder(configurationBuilder: wgBuilder)
+        try parser.validate(builder)
+        XCTFail("Must fail")
+    }
+
+    func assertParseError(_ error: Error, _ block: (TunnelConfiguration.ParseError) -> Void) {
+        NSLog("Thrown: \(error.localizedDescription)")
+        guard let ppError = error as? PassepartoutError else {
+            XCTFail("Not a PassepartoutError")
+            return
+        }
+        guard let parseError = ppError.reason as? TunnelConfiguration.ParseError else {
+            XCTFail("Not a TunnelConfiguration.ParseError")
+            return
+        }
+        block(parseError)
+    }
+}

--- a/Passepartout/Shared/Dependencies+PassepartoutKit.swift
+++ b/Passepartout/Shared/Dependencies+PassepartoutKit.swift
@@ -75,6 +75,7 @@ private extension Dependencies {
             WireGuardModule.Implementation(
                 keyGenerator: StandardWireGuardKeyGenerator(),
                 importer: StandardWireGuardParser(),
+                validator: StandardWireGuardParser(),
                 connectionBlock: {
                     try WireGuardConnection(
                         parameters: $0,


### PR DESCRIPTION
Validate module builders if the implementation supports it. Start with WireGuard.

Preparation for [editing of WireGuard configurations](https://github.com/passepartoutvpn/passepartout/pull/1197).