### PR TITLE
Inject APIMapper in APIManager only

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Providers/APIContentModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/APIContentModifier.swift
@@ -37,8 +37,6 @@ struct APIContentModifier<Template, ProviderRows>: ViewModifier where Template: 
     @EnvironmentObject
     private var preferencesManager: PreferencesManager
 
-    let apis: [APIMapper]
-
     @Binding
     var providerId: ProviderID?
 
@@ -88,7 +86,7 @@ private extension APIContentModifier {
         if let providerId {
             Group {
                 providerRows
-                RefreshInfrastructureButton(apis: apis, providerId: providerId)
+                RefreshInfrastructureButton(providerId: providerId)
             }
             .themeSection(footer: lastUpdatedString)
         }
@@ -108,7 +106,7 @@ private extension APIContentModifier {
                             .themeSubtitle()
                     }
                     Spacer()
-                    RefreshInfrastructureButton(apis: apis, providerId: providerId)
+                    RefreshInfrastructureButton(providerId: providerId)
                 }
             }
         }
@@ -162,7 +160,7 @@ private extension APIContentModifier {
     @discardableResult
     func refreshIndex() async -> Bool {
         do {
-            try await apiManager.fetchIndex(from: apis)
+            try await apiManager.fetchIndex()
             return true
         } catch {
             pp_log(.app, .error, "Unable to fetch index: \(error)")
@@ -173,7 +171,7 @@ private extension APIContentModifier {
     @discardableResult
     func refreshInfrastructure(for providerId: ProviderID) async -> Bool {
         do {
-            try await apiManager.fetchInfrastructure(from: apis, for: providerId)
+            try await apiManager.fetchInfrastructure(for: providerId)
             return true
         } catch {
             pp_log(.app, .error, "Unable to refresh infrastructure: \(error)")
@@ -218,7 +216,6 @@ private extension APIContentModifier {
     List {
         EmptyView()
             .modifier(APIContentModifier(
-                apis: [API.bundled],
                 providerId: .constant(.hideme),
                 providerPreferences: nil,
                 templateType: OpenVPNProviderTemplate.self,

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderContentModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderContentModifier.swift
@@ -29,7 +29,6 @@ import PassepartoutKit
 import SwiftUI
 
 struct ProviderContentModifier<Template, ProviderRows>: ViewModifier where Template: IdentifiableConfiguration, ProviderRows: View {
-    var apis: [APIMapper] = API.shared
 
     @Binding
     var providerId: ProviderID?
@@ -51,7 +50,6 @@ struct ProviderContentModifier<Template, ProviderRows>: ViewModifier where Templ
         debugChanges()
         return content
             .modifier(APIContentModifier(
-                apis: apis,
                 providerId: $providerId,
                 providerPreferences: providerPreferences,
                 templateType: Template.self,
@@ -88,7 +86,6 @@ private extension ProviderContentModifier {
         List {
             EmptyView()
                 .modifier(ProviderContentModifier(
-                    apis: [API.bundled],
                     providerId: .constant(.hideme),
                     providerPreferences: nil,
                     selectedEntity: .constant(nil as ProviderEntity<OpenVPNProviderTemplate>?),

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
@@ -29,8 +29,6 @@ import PassepartoutKit
 import SwiftUI
 
 struct ProviderFiltersView: View {
-    let apis: [APIMapper]
-
     let providerId: ProviderID
 
     @ObservedObject
@@ -50,7 +48,7 @@ struct ProviderFiltersView: View {
                 HStack {
                     favoritesToggle
                     Spacer()
-                    RefreshInfrastructureButton(apis: apis, providerId: providerId)
+                    RefreshInfrastructureButton(providerId: providerId)
                     clearFiltersButton
                 }
 #endif
@@ -116,7 +114,6 @@ private extension ProviderFiltersView {
 #Preview {
     NavigationStack {
         ProviderFiltersView(
-            apis: [API.bundled],
             providerId: .mullvad,
             model: .init()
         )

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
@@ -37,8 +37,6 @@ struct ProviderServerView<Template>: View where Template: IdentifiableConfigurat
     @EnvironmentObject
     private var preferencesManager: PreferencesManager
 
-    var apis: [APIMapper] = API.shared
-
     let moduleId: UUID
 
     let providerId: ProviderID
@@ -91,7 +89,6 @@ struct ProviderServerView<Template>: View where Template: IdentifiableConfigurat
 extension ProviderServerView {
     func contentView() -> some View {
         ContentView(
-            apis: apis,
             providerId: providerId,
             servers: filteredServers,
             selectedServer: selectedEntity?.server,
@@ -111,7 +108,6 @@ extension ProviderServerView {
 
     func filtersView() -> some View {
         ProviderFiltersView(
-            apis: apis,
             providerId: providerId,
             model: filtersViewModel
         )
@@ -155,10 +151,7 @@ private extension ProviderServerView {
             pp_log(.app, .error, "Unable to load preferences for provider \(providerId): \(error)")
         }
         do {
-            let repository = try await apiManager.providerRepository(
-                from: apis,
-                for: providerId
-            )
+            let repository = try await apiManager.providerRepository(for: providerId)
             try await providerManager.setRepository(repository)
             filtersViewModel.load(options: providerManager.options, initialFilters: initialFilters)
             await reloadServers(filters: filtersViewModel.filters)
@@ -232,7 +225,6 @@ private extension ProviderServerView {
 #Preview {
     NavigationStack {
         ProviderServerView(
-            apis: [API.bundled],
             moduleId: UUID(),
             providerId: .protonvpn,
             selectedEntity: nil as ProviderEntity<OpenVPNProviderTemplate>?,

--- a/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
@@ -33,8 +33,6 @@ import UIAccessibility
 
 extension ProviderServerView {
     struct ContentView: View {
-        let apis: [APIMapper]
-
         let providerId: ProviderID
 
         let servers: [ProviderServer]
@@ -73,7 +71,7 @@ private extension ProviderServerView.ContentView {
         List {
             Section {
                 Toggle(Strings.Views.Providers.onlyFavorites, isOn: $filtersViewModel.onlyShowsFavorites)
-                RefreshInfrastructureButton(apis: apis, providerId: providerId)
+                RefreshInfrastructureButton(providerId: providerId)
             }
             Group {
                 if isFiltering || !servers.isEmpty {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
@@ -36,8 +36,6 @@ extension ProviderServerView {
         @EnvironmentObject
         private var theme: Theme
 
-        let apis: [APIMapper]
-
         let providerId: ProviderID
 
         let servers: [ProviderServer]

--- a/Packages/App/Sources/UILibrary/Business/AppContext.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppContext.swift
@@ -137,7 +137,7 @@ private extension AppContext {
 
         do {
             pp_log(.app, .info, "\tFetch providers index...")
-            try await apiManager.fetchIndex(from: API.shared)
+            try await apiManager.fetchIndex()
         } catch {
             pp_log(.app, .error, "\tUnable to fetch providers index: \(error)")
         }

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -55,6 +55,7 @@ extension AppContext {
             interval: Constants.shared.tunnel.refreshInterval
         )
         let apiManager = APIManager(
+            from: [API.bundled],
             repository: InMemoryAPIRepository()
         )
         let migrationManager = MigrationManager()

--- a/Packages/App/Sources/UILibrary/Views/UI/RefreshInfrastructureButton.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/RefreshInfrastructureButton.swift
@@ -31,14 +31,11 @@ public struct RefreshInfrastructureButton<Label>: View where Label: View {
     @EnvironmentObject
     private var apiManager: APIManager
 
-    private let apis: [APIMapper]
-
     private let providerId: ProviderID
 
     private let label: () -> Label
 
-    public init(apis: [APIMapper], providerId: ProviderID, label: @escaping () -> Label) {
-        self.apis = apis
+    public init(providerId: ProviderID, label: @escaping () -> Label) {
         self.providerId = providerId
         self.label = label
     }
@@ -46,7 +43,7 @@ public struct RefreshInfrastructureButton<Label>: View where Label: View {
     public var body: some View {
         Button {
             Task {
-                try await apiManager.fetchInfrastructure(from: apis, for: providerId)
+                try await apiManager.fetchInfrastructure(for: providerId)
             }
         } label: {
             label()
@@ -55,8 +52,7 @@ public struct RefreshInfrastructureButton<Label>: View where Label: View {
 }
 
 extension RefreshInfrastructureButton where Label == RefreshInfrastructureButtonProgressView {
-    public init(apis: [APIMapper], providerId: ProviderID) {
-        self.apis = apis
+    public init(providerId: ProviderID) {
         self.providerId = providerId
         label = {
             RefreshInfrastructureButtonProgressView()

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -123,7 +123,7 @@ extension AppContext {
 
         let apiManager: APIManager = {
             let repository = AppData.cdAPIRepositoryV3(context: localStore.backgroundContext())
-            return APIManager(repository: repository)
+            return APIManager(from: API.shared, repository: repository)
         }()
 
         let migrationManager: MigrationManager = {

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -58,6 +58,7 @@ extension AppContext {
             interval: Constants.shared.tunnel.refreshInterval
         )
         let apiManager = APIManager(
+            from: [API.bundled],
             repository: InMemoryAPIRepository()
         )
         let migrationManager = MigrationManager()


### PR DESCRIPTION
Drop all scattered occurrences from views. Define mappers once in APIManager.