### PR TITLE
Optimize module editing with ModuleDraft

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Modules/DNSView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/DNSView.swift
@@ -33,14 +33,11 @@ struct DNSView: View, ModuleDraftEditing {
     @EnvironmentObject
     private var theme: Theme
 
-    let module: DNSModule.Builder
-
     @ObservedObject
-    var editor: ProfileEditor
+    var draft: ModuleDraft<DNSModule.Builder>
 
-    init(module: DNSModule.Builder, parameters: ModuleViewParameters) {
-        self.module = module
-        editor = parameters.editor
+    init(draft: ModuleDraft<DNSModule.Builder>, parameters: ModuleViewParameters) {
+        self.draft = draft
     }
 
     var body: some View {
@@ -56,7 +53,7 @@ struct DNSView: View, ModuleDraftEditing {
             .labelsHidden()
         }
         .themeManualInput()
-        .moduleView(editor: editor, draft: draft.wrappedValue)
+        .moduleView(draft: draft)
     }
 }
 
@@ -69,21 +66,21 @@ private extension DNSView {
 
     var protocolSection: some View {
         Section {
-            Picker(Strings.Global.Nouns.protocol, selection: draft.protocolType) {
+            Picker(Strings.Global.Nouns.protocol, selection: $draft.module.protocolType) {
                 ForEach(Self.allProtocols, id: \.self) {
                     Text($0.localizedDescription)
                 }
             }
-            switch draft.wrappedValue.protocolType {
+            switch draft.module.protocolType {
             case .cleartext:
                 EmptyView()
 
             case .https:
-                ThemeTextField(Strings.Unlocalized.url, text: draft.dohURL, placeholder: Strings.Unlocalized.Placeholders.dohURL)
+                ThemeTextField(Strings.Unlocalized.url, text: $draft.module.dohURL, placeholder: Strings.Unlocalized.Placeholders.dohURL)
                     .labelsHidden()
 
             case .tls:
-                ThemeTextField(Strings.Global.Nouns.hostname, text: draft.dotHostname, placeholder: Strings.Unlocalized.Placeholders.dotHostname)
+                ThemeTextField(Strings.Global.Nouns.hostname, text: $draft.module.dotHostname, placeholder: Strings.Unlocalized.Placeholders.dotHostname)
                     .labelsHidden()
 
             @unknown default:
@@ -94,7 +91,7 @@ private extension DNSView {
 
     var routingSection: some View {
         Group {
-            Picker(Strings.Modules.Dns.routeThroughVpn, selection: draft.routesThroughVPN) {
+            Picker(Strings.Modules.Dns.routeThroughVpn, selection: $draft.module.routesThroughVPN) {
                 Text(Strings.Global.Nouns.default)
                     .tag(nil as Bool?)
                 Text(Strings.Global.Nouns.yes)
@@ -109,7 +106,7 @@ private extension DNSView {
 
     var domainSection: some View {
         Group {
-            ThemeTextField(Strings.Global.Nouns.domain, text: draft.domainName ?? "", placeholder: Strings.Unlocalized.Placeholders.hostname)
+            ThemeTextField(Strings.Global.Nouns.domain, text: $draft.module.domainName ?? "", placeholder: Strings.Unlocalized.Placeholders.hostname)
         }
         .themeSection(header: Strings.Global.Nouns.domain)
     }
@@ -118,7 +115,7 @@ private extension DNSView {
         theme.listSection(
             Strings.Entities.Dns.servers,
             addTitle: Strings.Modules.Dns.Servers.add,
-            originalItems: draft.servers,
+            originalItems: $draft.module.servers,
             itemLabel: {
                 if $0 {
                     Text($1.wrappedValue)
@@ -133,7 +130,7 @@ private extension DNSView {
         theme.listSection(
             Strings.Entities.Dns.searchDomains,
             addTitle: Strings.Modules.Dns.SearchDomains.add,
-            originalItems: draft.searchDomains ?? [],
+            originalItems: $draft.module.searchDomains ?? [],
             itemLabel: {
                 if $0 {
                     Text($1.wrappedValue)

--- a/Packages/App/Sources/AppUIMain/Views/Modules/HTTPProxyView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/HTTPProxyView.swift
@@ -32,14 +32,11 @@ struct HTTPProxyView: View, ModuleDraftEditing {
     @EnvironmentObject
     private var theme: Theme
 
-    let module: HTTPProxyModule.Builder
-
     @ObservedObject
-    var editor: ProfileEditor
+    var draft: ModuleDraft<HTTPProxyModule.Builder>
 
-    init(module: HTTPProxyModule.Builder, parameters: ModuleViewParameters) {
-        self.module = module
-        editor = parameters.editor
+    init(draft: ModuleDraft<HTTPProxyModule.Builder>, parameters: ModuleViewParameters) {
+        self.draft = draft
     }
 
     var body: some View {
@@ -51,30 +48,30 @@ struct HTTPProxyView: View, ModuleDraftEditing {
         }
         .labelsHidden()
         .themeManualInput()
-        .moduleView(editor: editor, draft: draft.wrappedValue)
+        .moduleView(draft: draft)
     }
 }
 
 private extension HTTPProxyView {
     var httpSection: some View {
         Group {
-            ThemeTextField(Strings.Global.Nouns.address, text: draft.address, placeholder: Strings.Unlocalized.Placeholders.proxyIPv4Address)
-            ThemeTextField(Strings.Global.Nouns.port, text: draft.port.toString(omittingZero: true), placeholder: Strings.Unlocalized.Placeholders.proxyPort)
+            ThemeTextField(Strings.Global.Nouns.address, text: $draft.module.address, placeholder: Strings.Unlocalized.Placeholders.proxyIPv4Address)
+            ThemeTextField(Strings.Global.Nouns.port, text: $draft.module.port.toString(omittingZero: true), placeholder: Strings.Unlocalized.Placeholders.proxyPort)
         }
         .themeSection(header: Strings.Unlocalized.http)
     }
 
     var httpsSection: some View {
         Group {
-            ThemeTextField(Strings.Global.Nouns.address, text: draft.secureAddress, placeholder: Strings.Unlocalized.Placeholders.proxyIPv4Address)
-            ThemeTextField(Strings.Global.Nouns.port, text: draft.securePort.toString(omittingZero: true), placeholder: Strings.Unlocalized.Placeholders.proxyPort)
+            ThemeTextField(Strings.Global.Nouns.address, text: $draft.module.secureAddress, placeholder: Strings.Unlocalized.Placeholders.proxyIPv4Address)
+            ThemeTextField(Strings.Global.Nouns.port, text: $draft.module.securePort.toString(omittingZero: true), placeholder: Strings.Unlocalized.Placeholders.proxyPort)
         }
         .themeSection(header: Strings.Unlocalized.https)
     }
 
     var pacSection: some View {
         Group {
-            ThemeTextField(Strings.Unlocalized.url, text: draft.pacURLString, placeholder: Strings.Unlocalized.Placeholders.pacURL)
+            ThemeTextField(Strings.Unlocalized.url, text: $draft.module.pacURLString, placeholder: Strings.Unlocalized.Placeholders.pacURL)
         }
         .themeSection(header: Strings.Unlocalized.pac)
     }
@@ -84,7 +81,7 @@ private extension HTTPProxyView {
         theme.listSection(
             Strings.Entities.HttpProxy.bypassDomains,
             addTitle: Strings.Modules.HttpProxy.BypassDomains.add,
-            originalItems: draft.bypassDomains,
+            originalItems: $draft.module.bypassDomains,
             itemLabel: {
                 if $0 {
                     Text($1.wrappedValue)

--- a/Packages/App/Sources/AppUIMain/Views/Modules/IPView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/IPView.swift
@@ -28,17 +28,15 @@ import PassepartoutKit
 import SwiftUI
 
 struct IPView: View, ModuleDraftEditing {
-    let module: IPModule.Builder
 
     @ObservedObject
-    var editor: ProfileEditor
+    var draft: ModuleDraft<IPModule.Builder>
 
     @State
     private var routePresentation: RoutePresentation?
 
-    init(module: IPModule.Builder, parameters: ModuleViewParameters) {
-        self.module = module
-        editor = parameters.editor
+    init(draft: ModuleDraft<IPModule.Builder>, parameters: ModuleViewParameters) {
+        self.draft = draft
     }
 
     var body: some View {
@@ -47,7 +45,7 @@ struct IPView: View, ModuleDraftEditing {
             ipSections(for: .v6)
             interfaceSection
         }
-        .moduleView(editor: editor, draft: draft.wrappedValue)
+        .moduleView(draft: draft)
         .themeModal(item: $routePresentation, content: routeModal)
     }
 }
@@ -135,9 +133,9 @@ private extension IPView {
             ThemeTextField(
                 Strings.Unlocalized.mtu,
                 text: Binding {
-                    draft.wrappedValue.mtu?.description ?? ""
+                    draft.module.mtu?.description ?? ""
                 } set: {
-                    draft.wrappedValue.mtu = Int($0)
+                    draft.module.mtu = Int($0)
                 },
                 placeholder: Strings.Unlocalized.Placeholders.mtu
             )
@@ -150,18 +148,10 @@ private extension IPView {
     func binding(forSettingsIn family: Address.Family) -> Binding<IPSettings> {
         switch family {
         case .v4:
-            return Binding {
-                draft.wrappedValue.ipv4 ?? IPSettings(subnet: nil)
-            } set: {
-                draft.wrappedValue.ipv4 = $0
-            }
+            return $draft.module.ipv4 ?? IPSettings(subnet: nil)
 
         case .v6:
-            return Binding {
-                draft.wrappedValue.ipv6 ?? IPSettings(subnet: nil)
-            } set: {
-                draft.wrappedValue.ipv6 = $0
-            }
+            return $draft.module.ipv6 ?? IPSettings(subnet: nil)
         }
     }
 
@@ -178,31 +168,31 @@ private extension IPView {
                 case .included(let family):
                     switch family {
                     case .v4:
-                        if draft.wrappedValue.ipv4 == nil {
-                            draft.wrappedValue.ipv4 = IPSettings(subnet: nil)
+                        if draft.module.ipv4 == nil {
+                            draft.module.ipv4 = IPSettings(subnet: nil)
                         }
-                        draft.wrappedValue.ipv4?.include(route)
+                        draft.module.ipv4?.include(route)
 
                     case .v6:
-                        if draft.wrappedValue.ipv6 == nil {
-                            draft.wrappedValue.ipv6 = IPSettings(subnet: nil)
+                        if draft.module.ipv6 == nil {
+                            draft.module.ipv6 = IPSettings(subnet: nil)
                         }
-                        draft.wrappedValue.ipv6?.include(route)
+                        draft.module.ipv6?.include(route)
                     }
 
                 case .excluded(let family):
                     switch family {
                     case .v4:
-                        if draft.wrappedValue.ipv4 == nil {
-                            draft.wrappedValue.ipv4 = IPSettings(subnet: nil)
+                        if draft.module.ipv4 == nil {
+                            draft.module.ipv4 = IPSettings(subnet: nil)
                         }
-                        draft.wrappedValue.ipv4?.exclude(route)
+                        draft.module.ipv4?.exclude(route)
 
                     case .v6:
-                        if draft.wrappedValue.ipv6 == nil {
-                            draft.wrappedValue.ipv6 = IPSettings(subnet: nil)
+                        if draft.module.ipv6 == nil {
+                            draft.module.ipv6 = IPSettings(subnet: nil)
                         }
-                        draft.wrappedValue.ipv6?.exclude(route)
+                        draft.module.ipv6?.exclude(route)
                     }
                 }
             }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Import.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Import.swift
@@ -31,8 +31,8 @@ import SwiftUI
 extension OpenVPNView {
     struct ImportModifier: ViewModifier {
 
-        @Binding
-        var draft: OpenVPNModule.Builder
+        @ObservedObject
+        var draft: ModuleDraft<OpenVPNModule.Builder>
 
         let impl: OpenVPNModule.Implementation?
 
@@ -59,7 +59,7 @@ extension OpenVPNView {
                     onCompletion: importConfiguration
                 )
                 .alert(
-                    draft.moduleType.localizedDescription,
+                    draft.module.moduleType.localizedDescription,
                     isPresented: $requiresPassphrase,
                     presenting: importURL,
                     actions: { url in
@@ -123,10 +123,10 @@ private extension OpenVPNView.ImportModifier {
             guard let module = parsed as? OpenVPNModule else {
                 throw PassepartoutError(.parsing)
             }
-            draft.configurationBuilder = module.configuration?.builder()
+            draft.module.configurationBuilder = module.configuration?.builder()
         } catch {
             pp_log(.app, .error, "Unable to import OpenVPN configuration: \(error)")
-            errorHandler.handle(error, title: draft.moduleType.localizedDescription)
+            errorHandler.handle(error, title: draft.module.moduleType.localizedDescription)
         }
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView.swift
@@ -51,15 +51,14 @@ struct OpenVPNView: View, ModuleDraftEditing {
     @StateObject
     private var errorHandler: ErrorHandler = .default()
 
-    // FIXME: ###, restore
-//    init(serverConfiguration: OpenVPN.Configuration) {
-//        module = OpenVPNModule.Builder(configurationBuilder: serverConfiguration.builder())
-//        editor = ProfileEditor(modules: [module])
-//        impl = nil
-//        isServerPushed = true
-//        providerConfiguration = nil
-//        assert(module.configurationBuilder != nil, "isServerPushed must imply module.configurationBuilder != nil")
-//    }
+    init(serverConfiguration: OpenVPN.Configuration) {
+        let module = OpenVPNModule.Builder(configurationBuilder: serverConfiguration.builder())
+        draft = ModuleDraft(module: module)
+        impl = nil
+        isServerPushed = true
+        providerConfiguration = nil
+        assert(module.configurationBuilder != nil, "isServerPushed must imply module.configurationBuilder != nil")
+    }
 
     init(draft: ModuleDraft<OpenVPNModule.Builder>, parameters: ModuleViewParameters) {
         self.draft = draft

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/DNSModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/DNSModule+UI.swift
@@ -30,6 +30,6 @@ import UILibrary
 
 extension DNSModule.Builder: ModuleViewProviding {
     public func moduleView(with parameters: ModuleViewParameters) -> some View {
-        DNSView(module: self, parameters: parameters)
+        DNSView(draft: parameters.editor[self], parameters: parameters)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/HTTPProxyModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/HTTPProxyModule+UI.swift
@@ -30,6 +30,6 @@ import UILibrary
 
 extension HTTPProxyModule.Builder: ModuleViewProviding {
     public func moduleView(with parameters: ModuleViewParameters) -> some View {
-        HTTPProxyView(module: self, parameters: parameters)
+        HTTPProxyView(draft: parameters.editor[self], parameters: parameters)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/IPModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/IPModule+UI.swift
@@ -30,6 +30,6 @@ import UILibrary
 
 extension IPModule.Builder: ModuleViewProviding {
     public func moduleView(with parameters: ModuleViewParameters) -> some View {
-        IPView(module: self, parameters: parameters)
+        IPView(draft: parameters.editor[self], parameters: parameters)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/OnDemandModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/OnDemandModule+UI.swift
@@ -29,6 +29,6 @@ import UILibrary
 
 extension OnDemandModule.Builder: ModuleViewProviding {
     public func moduleView(with parameters: ModuleViewParameters) -> some View {
-        OnDemandView(module: self, parameters: parameters)
+        OnDemandView(draft: parameters.editor[self], parameters: parameters)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardModule+UI.swift
@@ -29,7 +29,7 @@ import SwiftUI
 
 extension WireGuardModule.Builder: ModuleViewProviding {
     public func moduleView(with parameters: ModuleViewParameters) -> some View {
-        WireGuardView(module: self, parameters: parameters)
+        WireGuardView(draft: parameters.editor[self], parameters: parameters)
     }
 }
 

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ModuleViewModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ModuleViewModifier.swift
@@ -33,9 +33,7 @@ struct ModuleViewModifier<T>: ViewModifier where T: ModuleBuilder & Equatable {
     private var isUITesting
 
     @ObservedObject
-    var editor: ProfileEditor
-
-    let draft: T
+    var draft: ModuleDraft<T>
 
     let withUUID: Bool
 
@@ -45,19 +43,19 @@ struct ModuleViewModifier<T>: ViewModifier where T: ModuleBuilder & Equatable {
 #if DEBUG
             if !isUITesting && withUUID {
                 Section {
-                    UUIDText(uuid: draft.id)
+                    UUIDText(uuid: draft.module.id)
                 }
             }
 #endif
         }
         .themeForm()
         .themeManualInput()
-        .themeAnimation(on: draft, category: .modules)
+        .themeAnimation(on: draft.module, category: .modules)
     }
 }
 
 extension View {
-    func moduleView<T>(editor: ProfileEditor, draft: T, withUUID: Bool = true) -> some View where T: ModuleBuilder & Equatable {
-        modifier(ModuleViewModifier(editor: editor, draft: draft, withUUID: withUUID))
+    func moduleView<T>(draft: ModuleDraft<T>, withUUID: Bool = true) -> some View where T: ModuleBuilder & Equatable {
+        modifier(ModuleViewModifier(draft: draft, withUUID: withUUID))
     }
 }

--- a/Packages/App/Sources/UILibrary/Business/ModuleDraft.swift
+++ b/Packages/App/Sources/UILibrary/Business/ModuleDraft.swift
@@ -30,6 +30,8 @@ import PassepartoutKit
 public final class ModuleDraft<T>: ObservableObject where T: ModuleBuilder {
     private weak var editor: ProfileEditor?
 
+    private let staticEditor: ProfileEditor?
+
     private let moduleId: UUID
 
     public var module: T {
@@ -48,8 +50,15 @@ public final class ModuleDraft<T>: ObservableObject where T: ModuleBuilder {
         }
     }
 
+    public init(module: T) {
+        staticEditor = ProfileEditor(modules: [module])
+        editor = staticEditor
+        moduleId = module.id
+    }
+
     init(editor: ProfileEditor, module: T) {
         self.editor = editor
+        staticEditor = nil
         moduleId = module.id
     }
 }

--- a/Packages/App/Sources/UILibrary/Extensions/ModuleDraftEditing+UI.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/ModuleDraftEditing+UI.swift
@@ -27,13 +27,6 @@ import PassepartoutKit
 import SwiftUI
 
 @MainActor
-extension ModuleDraftEditing {
-    public var draft: ModuleDraft<Draft> {
-        editor[module]
-    }
-}
-
-@MainActor
 extension ModuleDraftEditing where Draft: MutableProviderSelecting {
     public var providerId: Binding<ProviderID?> {
         Binding {

--- a/Packages/App/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
@@ -29,18 +29,8 @@ import PassepartoutKit
 import SwiftUI
 
 extension ProfileEditor {
-    public subscript<T>(module: T) -> Binding<T> where T: ModuleBuilder {
-        Binding { [weak self] in
-            guard let foundModule = self?.module(withId: module.id) else {
-                fatalError("Module not found in editor: \(module.id)")
-            }
-            guard let matchingModule = foundModule as? T else {
-                fatalError("Type mismatch when binding to editor module: \(type(of: foundModule)) != \(type(of: module))")
-            }
-            return matchingModule
-        } set: { [weak self] in
-            self?.saveModule($0, activating: false)
-        }
+    public subscript<T>(module: T) -> ModuleDraft<T> where T: ModuleBuilder {
+        ModuleDraft(editor: self, module: module)
     }
 }
 

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleDraftEditing.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleDraftEditing.swift
@@ -26,10 +26,9 @@
 import PassepartoutKit
 import SwiftUI
 
+@MainActor
 public protocol ModuleDraftEditing {
     associatedtype Draft: ModuleBuilder
 
-    var editor: ProfileEditor { get }
-
-    var module: Draft { get }
+    var draft: ModuleDraft<Draft> { get }
 }

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleViewProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleViewProviding.swift
@@ -35,6 +35,8 @@ public protocol ModuleViewProviding {
 }
 
 public struct ModuleViewParameters {
+
+    // FIXME: ###, drop this, only impl
     public let editor: ProfileEditor
 
     public let impl: (any ModuleImplementation)?

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleViewProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleViewProviding.swift
@@ -35,8 +35,6 @@ public protocol ModuleViewProviding {
 }
 
 public struct ModuleViewParameters {
-
-    // FIXME: ###, drop this, only impl
     public let editor: ProfileEditor
 
     public let impl: (any ModuleImplementation)?

--- a/Packages/App/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
@@ -28,13 +28,8 @@ import SwiftUI
 
 extension OpenVPNModule.Builder: InteractiveViewProviding {
     public func interactiveView(with editor: ProfileEditor, onSubmit: @escaping () -> Void) -> some View {
-        let draft = editor[self]
-
-        return OpenVPNCredentialsView(
-            profileEditor: editor,
-            providerId: draft.wrappedValue.providerId,
-            isInteractive: draft.isInteractive,
-            credentials: draft.credentials,
+        OpenVPNCredentialsView(
+            draft: editor[self],
             isAuthenticating: true,
             onSubmit: onSubmit
         )


### PR DESCRIPTION
Do not create zillions of bindings to ProfileEditor. Instead, feed module views with a statically created ModuleDraft (ObservableObject). More solid access and modification.

Fixes #1236 