### PR TITLE
Auto-enable in-app purchases on paywall

### DIFF
--- a/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
@@ -42,19 +42,19 @@ public final class IAPManager: ObservableObject {
 
     private let productsAtBuild: BuildProducts<AppProduct>?
 
-    private(set) var userLevel: AppUserLevel
-
-    public private(set) var purchasedAppBuild: Int?
-
+    @Published
     public var isEnabled = true {
         didSet {
-            pp_log(.App.iap, .info, "IAPManager.isEnabled -> \(isEnabled)")
             pendingReceiptTask?.cancel()
             Task {
                 await reloadReceipt()
             }
         }
     }
+
+    private(set) var userLevel: AppUserLevel
+
+    public private(set) var purchasedAppBuild: Int?
 
     public private(set) var purchasedProducts: Set<AppProduct>
 

--- a/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
@@ -91,6 +91,14 @@ extension IAPManager {
         pendingReceiptTask != nil
     }
 
+    public func enable() async {
+        guard !isEnabled else {
+            return
+        }
+        isEnabled = true
+        await reloadReceipt()
+    }
+
     public func purchasableProducts(for products: [AppProduct]) async throws -> [InAppProduct] {
         guard isEnabled else {
             return []

--- a/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
@@ -46,9 +46,6 @@ public final class IAPManager: ObservableObject {
     public var isEnabled = true {
         didSet {
             pendingReceiptTask?.cancel()
-            Task {
-                await reloadReceipt()
-            }
         }
     }
 

--- a/Packages/App/Sources/UILibrary/Business/AppContext.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppContext.swift
@@ -109,10 +109,14 @@ private extension AppContext {
 
         iapManager
             .$isEnabled
+            .dropFirst()
             .removeDuplicates()
-            .sink {
+            .sink { [weak self] in
                 pp_log(.App.iap, .info, "IAPManager.isEnabled -> \($0)")
                 UserDefaults.appGroup.set(!$0, forKey: AppPreference.skipsPurchases.key)
+                Task {
+                    await self?.iapManager.reloadReceipt()
+                }
             }
             .store(in: &subscriptions)
 

--- a/Packages/App/Sources/UILibrary/Business/AppContext.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppContext.swift
@@ -107,6 +107,15 @@ private extension AppContext {
             await iapManager.reloadReceipt()
         }
 
+        iapManager
+            .$isEnabled
+            .removeDuplicates()
+            .sink {
+                pp_log(.App.iap, .info, "IAPManager.isEnabled -> \($0)")
+                UserDefaults.appGroup.set(!$0, forKey: AppPreference.skipsPurchases.key)
+            }
+            .store(in: &subscriptions)
+
         pp_log(.App.profiles, .info, "\tObserve eligible features...")
         iapManager
             .$eligibleFeatures

--- a/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesGroup.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesGroup.swift
@@ -49,9 +49,6 @@ public struct PreferencesGroup: View {
     @AppStorage(AppPreference.dnsFallsBack.key, store: .appGroup)
     private var dnsFallsBack = true
 
-    @AppStorage(AppPreference.skipsPurchases.key, store: .appGroup)
-    private var skipsPurchases = false
-
     private let profileManager: ProfileManager
 
     @State
@@ -122,7 +119,7 @@ private extension PreferencesGroup {
     }
 
     var enablesPurchasesToggle: some View {
-        Toggle(Strings.Views.Preferences.enablesIap, isOn: enablesPurchasesBinding)
+        Toggle(Strings.Views.Preferences.enablesIap, isOn: $iapManager.isEnabled)
             .themeSectionWithSingleRow(footer: Strings.Views.Preferences.EnablesIap.footer)
     }
 
@@ -152,17 +149,6 @@ private extension PreferencesGroup {
             above: true
         )
         .disabled(isErasingiCloud)
-    }
-}
-
-private extension PreferencesGroup {
-    var enablesPurchasesBinding: Binding<Bool> {
-        Binding {
-            !skipsPurchases
-        } set: {
-            skipsPurchases = !$0
-            iapManager.isEnabled = $0
-        }
     }
 }
 

--- a/Packages/App/Sources/UILibrary/Views/UI/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/PaywallModifier.swift
@@ -81,6 +81,7 @@ public struct PaywallModifier: ViewModifier {
                 guard let reason = $0 else {
                     return
                 }
+                iapManager.isEnabled = true
                 if reason.needsConfirmation {
                     isConfirming = true
                 } else {

--- a/Packages/App/Sources/UILibrary/Views/UI/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/PaywallModifier.swift
@@ -82,7 +82,14 @@ public struct PaywallModifier: ViewModifier {
                     return
                 }
                 Task {
-                    await iapManager.enable()
+                    if !iapManager.isEnabled {
+                        pp_log(.App.iap, .info, "In-app purchases are disabled, enabling...")
+                        await iapManager.enable()
+                        guard !iapManager.isEligible(for: reason.requiredFeatures) else {
+                            pp_log(.App.iap, .info, "Skipping paywall because eligible for features: \(reason.requiredFeatures)")
+                            return
+                        }
+                    }
                     if reason.needsConfirmation {
                         isConfirming = true
                     } else {

--- a/Packages/App/Sources/UILibrary/Views/UI/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/PaywallModifier.swift
@@ -81,15 +81,17 @@ public struct PaywallModifier: ViewModifier {
                 guard let reason = $0 else {
                     return
                 }
-                iapManager.isEnabled = true
-                if reason.needsConfirmation {
-                    isConfirming = true
-                } else {
-                    guard !iapManager.isBeta else {
-                        assertionFailure("Purchasing in beta?")
-                        return
+                Task {
+                    await iapManager.enable()
+                    if reason.needsConfirmation {
+                        isConfirming = true
+                    } else {
+                        guard !iapManager.isBeta else {
+                            assertionFailure("Purchasing in beta?")
+                            return
+                        }
+                        isPurchasing = true
                     }
-                    isPurchasing = true
                 }
             }
     }

--- a/Packages/App/Sources/UILibrary/Views/UI/PurchaseRequiredView.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/PurchaseRequiredView.swift
@@ -43,7 +43,7 @@ public struct PurchaseRequiredView<Content>: View where Content: View {
     public var body: some View {
         content()
             .opaque(force || !isEligible)
-            .if(iapManager.isEnabled && !iapManager.isBeta)
+            .if(!iapManager.isBeta)
     }
 }
 


### PR DESCRIPTION
Act safer in case the user accidentally disables IAPs.