### PR TITLE
macOS: Fix missing icon in menu bar

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
@@ -49,7 +49,7 @@ public struct AppMenu: View {
     public var body: some View {
         versionItem
         Divider()
-        showToggle
+        showButton
         loginToggle
         keepToggle
         Divider()
@@ -73,9 +73,18 @@ private extension AppMenu {
         Text(BundleConfiguration.mainVersionString)
     }
 
-    var showToggle: some View {
+    var showButton: some View {
         Button(Strings.Global.Actions.show) {
-            settings.isVisible = true
+            Task {
+                let url = Bundle.main.bundleURL
+                let config = NSWorkspace.OpenConfiguration()
+                config.createsNewApplicationInstance = false
+                do {
+                    try await NSWorkspace.shared.openApplication(at: url, configuration: config)
+                } catch {
+                    pp_log(.app, .error, "Unable to reopen app: \(error)")
+                }
+            }
         }
     }
 

--- a/Packages/App/Sources/CommonUtils/Views/AppWindow.swift
+++ b/Packages/App/Sources/CommonUtils/Views/AppWindow.swift
@@ -33,15 +33,15 @@ public final class AppWindow {
 
     public var isVisible: Bool {
         get {
-            NSApp.activationPolicy() == .regular && window.isVisible
+            NSApp.activationPolicy() == .regular && window?.isVisible == true
         }
         set {
             NSApp.setActivationPolicy(newValue ? .regular : .accessory)
             if newValue {
                 NSApp.activate(ignoringOtherApps: true)
-                window.makeKeyAndOrderFront(self)
+                window?.makeKeyAndOrderFront(self)
             } else {
-                window.close()
+                window?.close()
             }
         }
     }
@@ -51,11 +51,14 @@ public final class AppWindow {
 }
 
 private extension AppWindow {
-    var window: NSWindow {
-        guard let window = NSApp.windows.first else {
-            fatalError("No Mac window?")
-        }
-        return window
+    var window: NSWindow? {
+        NSApp.windows.first(where: \.isWindow)
+    }
+}
+
+private extension NSWindow {
+    var isWindow: Bool {
+        !className.contains("NSStatusBar")
     }
 }
 

--- a/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
+++ b/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
@@ -48,8 +48,8 @@ public final class MacSettingsModel: ObservableObject {
             appWindow.isVisible
         }
         set {
-            appWindow.isVisible = newValue
             objectWillChange.send()
+            appWindow.isVisible = newValue
         }
     }
 
@@ -58,6 +58,7 @@ public final class MacSettingsModel: ObservableObject {
             appService.status == .enabled
         }
         set {
+            objectWillChange.send()
             do {
                 if newValue {
                     try appService.register()
@@ -67,7 +68,6 @@ public final class MacSettingsModel: ObservableObject {
             } catch {
                 pp_log(.app, .error, "Unable to (un)register login item: \(error)")
             }
-            objectWillChange.send()
         }
     }
 
@@ -76,8 +76,8 @@ public final class MacSettingsModel: ObservableObject {
             defaults.bool(forKey: UIPreference.keepsInMenu.key)
         }
         set {
-            defaults.set(newValue, forKey: UIPreference.keepsInMenu.key)
             objectWillChange.send()
+            defaults.set(newValue, forKey: UIPreference.keepsInMenu.key)
         }
     }
 

--- a/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
+++ b/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
@@ -35,22 +35,10 @@ import ServiceManagement
 public final class MacSettingsModel: ObservableObject {
     private let defaults: UserDefaults
 
-    private let appWindow: AppWindow
-
     private let appService: SMAppService
 
     public var isStartedFromLoginItem: Bool {
         NSApp.isHidden
-    }
-
-    public var isVisible: Bool {
-        get {
-            appWindow.isVisible
-        }
-        set {
-            objectWillChange.send()
-            appWindow.isVisible = newValue
-        }
     }
 
     public var launchesOnLogin: Bool {
@@ -81,9 +69,8 @@ public final class MacSettingsModel: ObservableObject {
         }
     }
 
-    public init(defaults: UserDefaults, appWindow: AppWindow, loginItemId: String) {
+    public init(defaults: UserDefaults, loginItemId: String) {
         self.defaults = defaults
-        self.appWindow = appWindow
         appService = SMAppService.loginItem(identifier: loginItemId)
     }
 }

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -43,7 +43,6 @@ final class AppDelegate: NSObject {
 #if os(macOS)
     let settings = MacSettingsModel(
         defaults: .standard,
-        appWindow: .shared,
         loginItemId: BundleConfiguration.mainString(for: .loginItemId)
     )
 #endif

--- a/Passepartout/App/Platforms/App+macOS.swift
+++ b/Passepartout/App/Platforms/App+macOS.swift
@@ -38,7 +38,7 @@ extension AppDelegate: NSApplicationDelegate {
         configure(with: AppUIMain())
         context.onApplicationActive()
         if settings.isStartedFromLoginItem {
-            AppWindow.shared.isVisible = false
+            NSApp.setActivationPolicy(.accessory)
         }
     }
 

--- a/Passepartout/App/Platforms/App+macOS.swift
+++ b/Passepartout/App/Platforms/App+macOS.swift
@@ -38,7 +38,7 @@ extension AppDelegate: NSApplicationDelegate {
         configure(with: AppUIMain())
         context.onApplicationActive()
         if settings.isStartedFromLoginItem {
-            NSApp.setActivationPolicy(.accessory)
+            AppWindow.shared.isVisible = false
         }
     }
 


### PR DESCRIPTION
The first window was closed on launch, but the first window may be the status bar item. This is always the case when the app is launched as a login item because there is no main window. Match main window by internal class name.

"Show" doesn't work on login for the same reason: there's no main window. Nevertheless, observing that the main window is created when the app is opened manually, the trick of relaunching "self" seems to work.

Fixes #1103 