### PR TITLE
Customize IPv4/6 address in Routing module

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Modules/IPView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/IPView.swift
@@ -41,8 +41,8 @@ struct IPView: View, ModuleDraftEditing {
 
     var body: some View {
         Group {
-            ipSections(for: .v4)
-            ipSections(for: .v6)
+            ipSections(for: $draft.module.ipv4 ?? IPSettings(subnet: nil), family: .v4)
+            ipSections(for: $draft.module.ipv6 ?? IPSettings(subnet: nil), family: .v6)
             interfaceSection
         }
         .moduleView(draft: draft)
@@ -88,8 +88,7 @@ private extension IPView {
     }
 
     @ViewBuilder
-    func ipSections(for family: Address.Family) -> some View {
-        let ip = binding(forSettingsIn: family)
+    func ipSections(for ip: Binding<IPSettings>, family: Address.Family) -> some View {
         Group {
             ForEach(Array(ip.wrappedValue.includedRoutes.enumerated()), id: \.offset) { item in
                 row(forRoute: item.element) {
@@ -151,16 +150,6 @@ private extension IPView {
 }
 
 private extension IPView {
-    func binding(forSettingsIn family: Address.Family) -> Binding<IPSettings> {
-        switch family {
-        case .v4:
-            return $draft.module.ipv4 ?? IPSettings(subnet: nil)
-
-        case .v6:
-            return $draft.module.ipv6 ?? IPSettings(subnet: nil)
-        }
-    }
-
     func routeModal(item: RoutePresentation) -> some View {
         NavigationStack {
             RouteView(family: item.family) { route in

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -452,6 +452,10 @@ public enum Strings {
       }
     }
     public enum Ip {
+      public enum Address {
+        /// Automatic
+        public static let automatic = Strings.tr("Localizable", "modules.ip.address.automatic", fallback: "Automatic")
+      }
       public enum Routes {
         /// Add %@
         public static func addFamily(_ p1: Any) -> String {

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "iCloud ist erforderlich, um Ihre Profile mit Ihrem Apple TV zu teilen.";
 "modules.general.sections.storage.tv.footer.purchase" = "Kaufen Sie, um die Einschränkung aufzuheben.";
 "modules.http_proxy.bypass_domains.add" = "Domain zum Umgehen hinzufügen";
+"modules.ip.address.automatic" = "Automatisch";
 "modules.ip.routes.add_family" = "Hinzufügen %@";
 "modules.ip.routes.exclude" = "Route ausschließen";
 "modules.ip.routes.excluded" = "Ausgeschlossene Routen";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "Απαιτείται iCloud για να μοιραστείτε τα προφίλ σας με το Apple TV σας.";
 "modules.general.sections.storage.tv.footer.purchase" = "Αγοράστε για να καταργήσετε τον περιορισμό.";
 "modules.http_proxy.bypass_domains.add" = "Προσθήκη τομέα παράκαμψης";
+"modules.ip.address.automatic" = "Αυτόματο";
 "modules.ip.routes.add_family" = "Προσθήκη %@";
 "modules.ip.routes.exclude" = "Εξαίρεση διαδρομής";
 "modules.ip.routes.excluded" = "Εξαιρούμενες διαδρομές";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -170,6 +170,7 @@
 "modules.dns.search_domains.add" = "Add domain";
 "modules.http_proxy.bypass_domains.add" = "Add bypass domain";
 
+"modules.ip.address.automatic" = "Automatic";
 "modules.ip.routes.include" = "Include route";
 "modules.ip.routes.exclude" = "Exclude route";
 "modules.ip.routes.included" = "Included routes";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "Se requiere iCloud para compartir tus perfiles con tu Apple TV.";
 "modules.general.sections.storage.tv.footer.purchase" = "Compra para eliminar la restricción.";
 "modules.http_proxy.bypass_domains.add" = "Añadir dominio para omitir";
+"modules.ip.address.automatic" = "Automático";
 "modules.ip.routes.add_family" = "Añadir %@";
 "modules.ip.routes.exclude" = "Excluir ruta";
 "modules.ip.routes.excluded" = "Rutas excluidas";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "iCloud est requis pour partager vos profils avec votre Apple TV.";
 "modules.general.sections.storage.tv.footer.purchase" = "Achetez pour supprimer la restriction.";
 "modules.http_proxy.bypass_domains.add" = "Ajouter un domaine à contourner";
+"modules.ip.address.automatic" = "Automatique";
 "modules.ip.routes.add_family" = "Ajouter %@";
 "modules.ip.routes.exclude" = "Exclure une route";
 "modules.ip.routes.excluded" = "Routes exclues";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "iCloud è necessario per condividere i tuoi profili con Apple TV.";
 "modules.general.sections.storage.tv.footer.purchase" = "Acquista per rimuovere la restrizione.";
 "modules.http_proxy.bypass_domains.add" = "Aggiungi dominio di bypass";
+"modules.ip.address.automatic" = "Automatico";
 "modules.ip.routes.add_family" = "Aggiungi %@";
 "modules.ip.routes.exclude" = "Escludi rotta";
 "modules.ip.routes.excluded" = "Rotte escluse";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "iCloud is vereist om je profielen met je Apple TV te delen.";
 "modules.general.sections.storage.tv.footer.purchase" = "Koop om de beperking op te heffen.";
 "modules.http_proxy.bypass_domains.add" = "Bypass-domein toevoegen";
+"modules.ip.address.automatic" = "Automatisch";
 "modules.ip.routes.add_family" = "Voeg %@ toe";
 "modules.ip.routes.exclude" = "Route uitsluiten";
 "modules.ip.routes.excluded" = "Uitgesloten routes";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "iCloud jest wymagany do udostępniania profili na Apple TV.";
 "modules.general.sections.storage.tv.footer.purchase" = "Zakup, aby usunąć ograniczenie.";
 "modules.http_proxy.bypass_domains.add" = "Dodaj domenę wykluczającą";
+"modules.ip.address.automatic" = "Automatyczny";
 "modules.ip.routes.add_family" = "Dodaj %@";
 "modules.ip.routes.exclude" = "Wyklucz trasę";
 "modules.ip.routes.excluded" = "Wykluczone trasy";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "O iCloud é necessário para compartilhar seus perfis com a Apple TV.";
 "modules.general.sections.storage.tv.footer.purchase" = "Compre para remover a restrição.";
 "modules.http_proxy.bypass_domains.add" = "Adicionar domínio a ignorar";
+"modules.ip.address.automatic" = "Automático";
 "modules.ip.routes.add_family" = "Adicionar %@";
 "modules.ip.routes.exclude" = "Excluir rota";
 "modules.ip.routes.excluded" = "Rotas excluídas";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "Для совместного использования профилей с Apple TV требуется iCloud.";
 "modules.general.sections.storage.tv.footer.purchase" = "Купите, чтобы снять ограничение.";
 "modules.http_proxy.bypass_domains.add" = "Добавить исключаемый домен";
+"modules.ip.address.automatic" = "Автоматически";
 "modules.ip.routes.add_family" = "Добавить %@";
 "modules.ip.routes.exclude" = "Исключить маршрут";
 "modules.ip.routes.excluded" = "Исключенные маршруты";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "iCloud krävs för att dela dina profiler med din Apple TV.";
 "modules.general.sections.storage.tv.footer.purchase" = "Köp för att ta bort begränsningen.";
 "modules.http_proxy.bypass_domains.add" = "Lägg till kringgående domän";
+"modules.ip.address.automatic" = "Automatisk";
 "modules.ip.routes.add_family" = "Lägg till %@";
 "modules.ip.routes.exclude" = "Exkludera rutt";
 "modules.ip.routes.excluded" = "Exkluderade rutter";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "Для спільного використання профілів з Apple TV потрібен iCloud.";
 "modules.general.sections.storage.tv.footer.purchase" = "Придбайте, щоб зняти обмеження.";
 "modules.http_proxy.bypass_domains.add" = "Додати домен у винятки";
+"modules.ip.address.automatic" = "Автоматично";
 "modules.ip.routes.add_family" = "Додати %@";
 "modules.ip.routes.exclude" = "Виключити маршрут";
 "modules.ip.routes.excluded" = "Виключені маршрути";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -161,6 +161,7 @@
 "modules.general.sections.storage.tv.footer" = "需要 iCloud 才能与 Apple TV 共享您的配置文件。";
 "modules.general.sections.storage.tv.footer.purchase" = "购买以移除限制。";
 "modules.http_proxy.bypass_domains.add" = "添加绕过域名";
+"modules.ip.address.automatic" = "自动";
 "modules.ip.routes.add_family" = "添加 %@";
 "modules.ip.routes.exclude" = "排除路由";
 "modules.ip.routes.excluded" = "已排除路由";


### PR DESCRIPTION
Allow customization of the address field in the routing module view. Normally, this is inherited from a VPN.