### PR TITLE
Fix some issues when migrating to provider modules

### DIFF
--- a/Packages/App/Sources/AppDataProviders/Strategy/CDAPIRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataProviders/Strategy/CDAPIRepositoryV3.swift
@@ -156,6 +156,26 @@ private final class CDAPIRepositoryV3: NSObject, APIRepository {
         }
     }
 
+    func resetLastUpdate(for providerIds: [ProviderID]?) async {
+        try? await context.perform { [weak self] in
+            guard let self else {
+                return
+            }
+            let providerRequest = CDProviderV3.fetchRequest()
+            if let providerIds {
+                providerRequest.predicate = NSPredicate(
+                    format: "providerId in %@",
+                    providerIds.map(\.rawValue)
+                )
+            }
+            let providers = try providerRequest.execute()
+            providers.forEach {
+                $0.lastUpdate = nil
+            }
+            try context.save()
+        }
+    }
+
     nonisolated func presets(for server: ProviderServer, moduleType: ModuleType) async throws -> [ProviderPreset] {
         try await context.perform {
             let request = CDProviderPresetV3.fetchRequest()

--- a/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -41,7 +41,7 @@ struct AddProfileMenu: View {
 
     let onMigrateProfiles: () -> Void
 
-    let onNewProfile: (EditableProfile, UUID?) -> Void
+    let onNewProfile: (EditableProfile) -> Void
 
     var body: some View {
         Menu {
@@ -61,7 +61,7 @@ private extension AddProfileMenu {
     var emptyProfileButton: some View {
         Button {
             let editable = EditableProfile(name: newName)
-            onNewProfile(editable, nil)
+            onNewProfile(editable)
         } label: {
             ThemeImageLabel(Strings.Views.App.Toolbar.NewProfile.empty, .profileEdit)
         }
@@ -90,7 +90,7 @@ private extension AddProfileMenu {
             onSelect: {
                 var copy = $0
                 copy.name = profileManager.firstUniqueName(from: copy.name)
-                onNewProfile(copy, copy.modules.first?.id)
+                onNewProfile(copy)
             }
         )
     }

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
@@ -30,7 +30,7 @@ extension AppCoordinator {
     enum ModalRoute: Identifiable {
         case about
 
-        case editProfile(UUID?)
+        case editProfile
 
         case editProviderEntity(Profile, Bool, Module)
 

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -192,11 +192,10 @@ extension AppCoordinator {
                 tunnel: tunnel
             )
 
-        case .editProfile(let initialModuleId):
+        case .editProfile:
             ProfileCoordinator(
                 profileManager: profileManager,
                 profileEditor: profileEditor,
-                initialModuleId: initialModuleId,
                 registry: registry,
                 moduleViewFactory: DefaultModuleViewFactory(registry: registry),
                 path: $profilePath,
@@ -358,22 +357,22 @@ private extension AppCoordinator {
         }
     }
 
-    func onNewProfile(_ profile: EditableProfile, initialModuleId: UUID?) {
-        editProfile(profile, initialModuleId: initialModuleId)
+    func onNewProfile(_ profile: EditableProfile) {
+        editProfile(profile)
     }
 
     func onEditProfile(_ preview: ProfilePreview) {
         guard let profile = profileManager.profile(withId: preview.id) else {
             return
         }
-        editProfile(profile.editable(), initialModuleId: nil)
+        editProfile(profile.editable())
     }
 
-    func editProfile(_ profile: EditableProfile, initialModuleId: UUID?) {
+    func editProfile(_ profile: EditableProfile) {
         profilePath = NavigationPath()
         let isShared = profileManager.isRemotelyShared(profileWithId: profile.id)
         profileEditor.load(profile, isShared: isShared)
-        present(.editProfile(initialModuleId))
+        present(.editProfile)
     }
 }
 

--- a/Packages/App/Sources/AppUIMain/Views/App/AppToolbar.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppToolbar.swift
@@ -52,7 +52,7 @@ struct AppToolbar: ToolbarContent, SizeClassProviding {
 
     let onMigrateProfiles: () -> Void
 
-    let onNewProfile: (EditableProfile, UUID?) -> Void
+    let onNewProfile: (EditableProfile) -> Void
 
     var body: some ToolbarContent {
         if isBigDevice {
@@ -116,7 +116,7 @@ private extension AppToolbar {
                     onPreferences: {},
                     onAbout: {},
                     onMigrateProfiles: {},
-                    onNewProfile: { _, _ in }
+                    onNewProfile: { _ in }
                 )
             }
             .frame(width: 600, height: 400)

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -106,7 +106,9 @@ private extension OnboardingModifier {
                 advance()
             }
         default:
-            break
+            if step != OnboardingStep.allCases.last {
+                advance()
+            }
         }
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -100,7 +100,7 @@ private extension OnboardingModifier {
             modalRoute = .migrateProfiles
         case .community:
             isPresentingCommunity = true
-        case .migrateV3_2_1:
+        case .migrateV3_2_2:
             Task {
                 await apiManager.resetLastUpdateForAllProviders()
                 advance()

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -30,6 +30,9 @@ import SwiftUI
 struct OnboardingModifier: ViewModifier {
 
     @EnvironmentObject
+    private var apiManager: APIManager
+
+    @EnvironmentObject
     private var migrationManager: MigrationManager
 
     @Environment(\.isUITesting)
@@ -97,6 +100,11 @@ private extension OnboardingModifier {
             modalRoute = .migrateProfiles
         case .community:
             isPresentingCommunity = true
+        case .migrateV3_2_1:
+            Task {
+                await apiManager.resetLastUpdateForAllProviders()
+                advance()
+            }
         default:
             break
         }

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView+List.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView+List.swift
@@ -86,6 +86,7 @@ private extension MigrateContentView.ListView {
                         )
                     }
                 }
+                .disabled(!step.canSelect)
             } header: {
                 EditProfilesButton(isEditing: $isEditing, selection: $selection) {
                     onDelete(profiles.filter {
@@ -94,10 +95,10 @@ private extension MigrateContentView.ListView {
                     // disable isEditing after confirmation
                 }
                 .textCase(.none)
+                .disabled(!step.canSelect)
             }
         }
         .listStyle(.plain)
-        .disabled(!step.canSelect)
         .themeEmpty(if: isEmpty, message: Strings.Views.Migration.noProfiles)
     }
 

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView+Table.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView+Table.swift
@@ -95,8 +95,8 @@ private extension MigrateContentView.TableView {
                 }
                 .width(20)
             }
+            .disabled(!step.canSelect)
         }
-        .disabled(!step.canSelect)
         .themeForm()
         .themeEmpty(if: isEmpty, message: Strings.Views.Migration.noProfiles)
     }

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView.swift
@@ -129,9 +129,16 @@ private struct PrivatePreviews {
     static let profiles: [MigratableProfile] = [
         .init(id: UUID(), name: "1 One", lastUpdate: Date().addingTimeInterval(-oneDay)),
         .init(id: UUID(), name: "2 Two", lastUpdate: Date().addingTimeInterval(-3 * oneDay)),
-        .init(id: UUID(), name: "3 Three", lastUpdate: Date().addingTimeInterval(-90 * oneDay)),
-        .init(id: UUID(), name: "4 Four", lastUpdate: Date().addingTimeInterval(-180 * oneDay)),
-        .init(id: UUID(), name: "5 Five", lastUpdate: Date().addingTimeInterval(-240 * oneDay))
+        .init(id: UUID(), name: "3 Three", lastUpdate: Date().addingTimeInterval(-9 * oneDay)),
+        .init(id: UUID(), name: "4 Four", lastUpdate: Date().addingTimeInterval(-18 * oneDay)),
+        .init(id: UUID(), name: "5 Five", lastUpdate: Date().addingTimeInterval(-24 * oneDay)),
+        .init(id: UUID(), name: "6 Six", lastUpdate: Date().addingTimeInterval(-60 * oneDay)),
+        .init(id: UUID(), name: "7 Seven", lastUpdate: Date().addingTimeInterval(-64 * oneDay)),
+        .init(id: UUID(), name: "8 Eight", lastUpdate: Date().addingTimeInterval(-120 * oneDay)),
+        .init(id: UUID(), name: "9 Nine", lastUpdate: Date().addingTimeInterval(-130 * oneDay)),
+        .init(id: UUID(), name: "10 Ten", lastUpdate: Date().addingTimeInterval(-400 * oneDay)),
+        .init(id: UUID(), name: "11 Eleven", lastUpdate: Date().addingTimeInterval(-412 * oneDay)),
+        .init(id: UUID(), name: "12 Twelve", lastUpdate: Date().addingTimeInterval(-640 * oneDay))
     ]
 
     struct MigratePreview: View {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
@@ -164,14 +164,17 @@ private extension ProviderView {
     }
 
     var presetPicker: some View {
-        providerEntity.map { _ in
-            Picker(Strings.Views.Providers.preset, selection: presetIdBinding) {
-                ForEach(availablePresets, id: \.presetId) {
-                    Text($0.description)
-                        .tag($0.presetId as String?)
-                }
+        Picker(Strings.Views.Providers.preset, selection: presetIdBinding) {
+            if draft.module.entity == nil {
+                Text(Strings.Views.Providers.Preset.placeholder)
+                    .tag(nil as String?)
+            }
+            ForEach(availablePresets, id: \.presetId) {
+                Text($0.description)
+                    .tag($0.presetId as String?)
             }
         }
+        .disabled(draft.module.entity == nil)
     }
 
     var optionsSection: some View {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -50,8 +50,6 @@ struct ProfileCoordinator: View {
 
     let profileEditor: ProfileEditor
 
-    let initialModuleId: UUID?
-
     let registry: Registry
 
     let moduleViewFactory: any ModuleViewFactory
@@ -83,7 +81,6 @@ private extension ProfileCoordinator {
         ProfileEditView(
             profileManager: profileManager,
             profileEditor: profileEditor,
-            initialModuleId: initialModuleId,
             moduleViewFactory: moduleViewFactory,
             path: $path,
             paywallReason: $paywallReason,
@@ -99,7 +96,6 @@ private extension ProfileCoordinator {
         ProfileSplitView(
             profileManager: profileManager,
             profileEditor: profileEditor,
-            initialModuleId: initialModuleId,
             moduleViewFactory: moduleViewFactory,
             paywallReason: $paywallReason,
             flow: .init(
@@ -191,7 +187,6 @@ private extension ProfileEditor {
     ProfileCoordinator(
         profileManager: .forPreviews,
         profileEditor: ProfileEditor(profile: .newMockProfile()),
-        initialModuleId: nil,
         registry: Registry(),
         moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
         path: .constant(NavigationPath()),

--- a/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -36,8 +36,6 @@ struct ProfileEditView: View, Routable {
     @ObservedObject
     var profileEditor: ProfileEditor
 
-    let initialModuleId: UUID?
-
     let moduleViewFactory: any ModuleViewFactory
 
     @Binding
@@ -74,11 +72,6 @@ struct ProfileEditView: View, Routable {
         .navigationBarBackButtonHidden(true)
         .navigationDestination(for: NavigationRoute.self, destination: pushDestination)
         .navigationDestination(for: profileEditor, path: $path)
-        .onLoad {
-            if let initialModuleId {
-                push(.moduleDetail(moduleId: initialModuleId))
-            }
-        }
     }
 }
 
@@ -188,7 +181,6 @@ private extension ProfileEditView {
         ProfileEditView(
             profileManager: .forPreviews,
             profileEditor: ProfileEditor(profile: .newMockProfile()),
-            initialModuleId: nil,
             moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
             path: .constant(NavigationPath()),
             paywallReason: .constant(nil)

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
@@ -35,8 +35,6 @@ struct ProfileSplitView: View, Routable {
 
     let profileEditor: ProfileEditor
 
-    let initialModuleId: UUID?
-
     let moduleViewFactory: any ModuleViewFactory
 
     @Binding
@@ -79,11 +77,6 @@ struct ProfileSplitView: View, Routable {
             .themeNavigationStack(path: $detailPath)
             .toolbar(content: toolbarContent)
             .environment(\.navigationPath, $detailPath)
-        }
-        .onLoad {
-            if let initialModuleId {
-                selectedModuleId = initialModuleId
-            }
         }
     }
 }
@@ -148,7 +141,6 @@ private extension ProfileSplitView {
     ProfileSplitView(
         profileManager: .forPreviews,
         profileEditor: ProfileEditor(profile: .newMockProfile()),
-        initialModuleId: nil,
         moduleViewFactory: DefaultModuleViewFactory(registry: Registry()),
         paywallReason: .constant(nil)
     )

--- a/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+Main.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+Main.swift
@@ -60,9 +60,16 @@ extension BundleConfiguration {
         return main.displayName
     }
 
-    public static var mainVersionString: String {
+    public static var mainVersionNumber: String {
         if isPreview {
             return "preview-1.2.3"
+        }
+        return main.versionNumber
+    }
+
+    public static var mainVersionString: String {
+        if isPreview {
+            return "preview-1.2.3-1234"
         }
         return main.versionString
     }

--- a/Packages/App/Sources/CommonLibrary/Strategy/Processors.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/Processors.swift
@@ -28,7 +28,7 @@ import PassepartoutKit
 
 @MainActor
 public protocol ProfileProcessor: Sendable {
-    func migrated(_ profile: Profile) throws -> Profile?
+    func migratedProfile(from profile: Profile) throws -> Profile?
 
     func isIncluded(_ profile: Profile) -> Bool
 

--- a/Packages/App/Sources/UILibrary/Domain/OnboardingStep.swift
+++ b/Packages/App/Sources/UILibrary/Domain/OnboardingStep.swift
@@ -32,6 +32,10 @@ public enum OnboardingStep: String, RawRepresentable, CaseIterable {
     case community
 
     case doneV3
+
+    case migrateV3_2_1
+
+    case doneV3_2_1
 }
 
 extension Optional where Wrapped == OnboardingStep {

--- a/Packages/App/Sources/UILibrary/Domain/OnboardingStep.swift
+++ b/Packages/App/Sources/UILibrary/Domain/OnboardingStep.swift
@@ -33,9 +33,9 @@ public enum OnboardingStep: String, RawRepresentable, CaseIterable {
 
     case doneV3
 
-    case migrateV3_2_1
+    case migrateV3_2_2
 
-    case doneV3_2_1
+    case doneV3_2_2
 }
 
 extension Optional where Wrapped == OnboardingStep {

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -968,6 +968,10 @@ public enum Strings {
         /// Loading...
         public static let loading = Strings.tr("Localizable", "views.providers.last_updated.loading", fallback: "Loading...")
       }
+      public enum Preset {
+        /// Select server
+        public static let placeholder = Strings.tr("Localizable", "views.providers.preset.placeholder", fallback: "Select server")
+      }
     }
     public enum Purchased {
       /// No purchases

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Typ";
 "views.providers.only_favorites" = "Nur Favoriten";
 "views.providers.preset" = "Voreinstellung";
+"views.providers.preset.placeholder" = "Server auswählen";
 "views.providers.refresh_infrastructure" = "Infrastruktur aktualisieren";
 "views.providers.select_entity" = "Wählen";
 "views.providers.select_module" = "Typ auswählen";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Τύπος";
 "views.providers.only_favorites" = "Μόνο αγαπημένα";
 "views.providers.preset" = "Προκαθορισμένο";
+"views.providers.preset.placeholder" = "Επιλέξτε διακομιστή";
 "views.providers.refresh_infrastructure" = "Ανανέωση υποδομής";
 "views.providers.select_entity" = "Επιλογή";
 "views.providers.select_module" = "Επιλέξτε τύπο";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 
 "views.providers.module" = "Type";
 "views.providers.preset" = "Preset";
+"views.providers.preset.placeholder" = "Select server";
 "views.providers.select_provider" = "Select provider";
 "views.providers.select_module" = "Select type";
 "views.providers.select_entity" = "Select";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Tipo";
 "views.providers.only_favorites" = "Solo favoritos";
 "views.providers.preset" = "Preestablecido";
+"views.providers.preset.placeholder" = "Seleccionar servidor";
 "views.providers.refresh_infrastructure" = "Actualizar infraestructura";
 "views.providers.select_entity" = "Seleccionar";
 "views.providers.select_module" = "Seleccionar tipo";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Type";
 "views.providers.only_favorites" = "Favoris uniquement";
 "views.providers.preset" = "Préréglé";
+"views.providers.preset.placeholder" = "Sélectionner un serveur";
 "views.providers.refresh_infrastructure" = "Rafraîchir l'infrastructure";
 "views.providers.select_entity" = "Sélectionner";
 "views.providers.select_module" = "Sélectionner un type";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Tipo";
 "views.providers.only_favorites" = "Solo preferiti";
 "views.providers.preset" = "Preimpostato";
+"views.providers.preset.placeholder" = "Seleziona server";
 "views.providers.refresh_infrastructure" = "Ricarica infrastruttura";
 "views.providers.select_entity" = "Seleziona";
 "views.providers.select_module" = "Seleziona tipo";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Type";
 "views.providers.only_favorites" = "Alleen favorieten";
 "views.providers.preset" = "Voorinstelling";
+"views.providers.preset.placeholder" = "Server selecteren";
 "views.providers.refresh_infrastructure" = "Infrastructuur vernieuwen";
 "views.providers.select_entity" = "Selecteer";
 "views.providers.select_module" = "Selecteer type";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Typ";
 "views.providers.only_favorites" = "Tylko ulubione";
 "views.providers.preset" = "Wstępna konfiguracja";
+"views.providers.preset.placeholder" = "Wybierz serwer";
 "views.providers.refresh_infrastructure" = "Odśwież infrastrukturę";
 "views.providers.select_entity" = "Wybierz";
 "views.providers.select_module" = "Wybierz typ";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Tipo";
 "views.providers.only_favorites" = "Apenas favoritos";
 "views.providers.preset" = "Predefinição";
+"views.providers.preset.placeholder" = "Selecionar servidor";
 "views.providers.refresh_infrastructure" = "Atualizar infraestrutura";
 "views.providers.select_entity" = "Selecionar";
 "views.providers.select_module" = "Selecionar tipo";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Тип";
 "views.providers.only_favorites" = "Только избранное";
 "views.providers.preset" = "Предустановка";
+"views.providers.preset.placeholder" = "Выберите сервер";
 "views.providers.refresh_infrastructure" = "Обновить инфраструктуру";
 "views.providers.select_entity" = "Выбрать";
 "views.providers.select_module" = "Выбрать тип";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Typ";
 "views.providers.only_favorites" = "Endast favoriter";
 "views.providers.preset" = "Förinställning";
+"views.providers.preset.placeholder" = "Välj server";
 "views.providers.refresh_infrastructure" = "Uppdatera infrastruktur";
 "views.providers.select_entity" = "Välj";
 "views.providers.select_module" = "Välj typ";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "Тип";
 "views.providers.only_favorites" = "Тільки улюблені";
 "views.providers.preset" = "Попередньо встановлено";
+"views.providers.preset.placeholder" = "Виберіть сервер";
 "views.providers.refresh_infrastructure" = "Оновити інфраструктуру";
 "views.providers.select_entity" = "Вибрати";
 "views.providers.select_module" = "Виберіть тип";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -307,6 +307,7 @@
 "views.providers.module" = "类型";
 "views.providers.only_favorites" = "仅收藏";
 "views.providers.preset" = "预设";
+"views.providers.preset.placeholder" = "选择服务器";
 "views.providers.refresh_infrastructure" = "刷新基础设施";
 "views.providers.select_entity" = "选择";
 "views.providers.select_module" = "选择类型";

--- a/Packages/App/Sources/UILibrary/Strategy/MockAppProcessor.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/MockAppProcessor.swift
@@ -36,7 +36,7 @@ final class MockAppProcessor {
 }
 
 extension MockAppProcessor: ProfileProcessor {
-    func migrated(_ profile: Profile) -> Profile? {
+    func migratedProfile(from profile: Profile) -> Profile? {
         nil
     }
 

--- a/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
@@ -42,7 +42,7 @@ final class MockProfileProcessor: ProfileProcessor {
         profile.name
     }
 
-    func migrated(_ profile: Profile) throws -> Profile? {
+    func migratedProfile(from profile: Profile) throws -> Profile? {
         nil
     }
 

--- a/Passepartout/App/Context/DefaultAppProcessor.swift
+++ b/Passepartout/App/Context/DefaultAppProcessor.swift
@@ -55,15 +55,21 @@ extension DefaultAppProcessor: ProfileProcessor {
         case nil:
             var builder = profile.builder(withNewId: false, forUpgrade: true)
 
-            // convert OpenVPN provider modules to ProviderModule of type .openVPN
+            // convert OpenVPN provider modules...
             let ovpnPairs: [(offset: Int, module: OpenVPNModule)] = builder.modules
                 .enumerated()
                 .compactMap {
-                    guard let module = $0.element as? OpenVPNModule else {
+                    guard let module = $0.element as? OpenVPNModule,
+                          module.providerSelection != nil else {
                         return nil
                     }
                     return ($0.offset, module)
                 }
+            guard !ovpnPairs.isEmpty else {
+                return nil
+            }
+
+            // ...to ProviderModule of type .openVPN
             try ovpnPairs
                 .forEach {
                     guard let selection = $0.module.providerSelection else {

--- a/Passepartout/App/Context/DefaultAppProcessor.swift
+++ b/Passepartout/App/Context/DefaultAppProcessor.swift
@@ -54,6 +54,7 @@ extension DefaultAppProcessor: ProfileProcessor {
         switch profile.version {
         case nil:
             var builder = profile.builder(withNewId: false, forUpgrade: true)
+            builder.name = profile.name + " [\(BundleConfiguration.mainVersionNumber)]"
 
             // convert OpenVPN provider modules...
             let ovpnPairs: [(offset: Int, module: OpenVPNModule)] = builder.modules

--- a/Passepartout/App/Context/DefaultAppProcessor.swift
+++ b/Passepartout/App/Context/DefaultAppProcessor.swift
@@ -50,7 +50,7 @@ final class DefaultAppProcessor: Sendable {
 }
 
 extension DefaultAppProcessor: ProfileProcessor {
-    func migrated(_ profile: Profile) throws -> Profile? {
+    func migratedProfile(from profile: Profile) throws -> Profile? {
         switch profile.version {
         case nil:
             var builder = profile.builder(withNewId: false, forUpgrade: true)
@@ -85,17 +85,11 @@ extension DefaultAppProcessor: ProfileProcessor {
                     try providerBuilder.setOptions(options, for: .openVPN)
                     let provider = try providerBuilder.tryBuild()
 
+                    // replace old module
                     builder.modules[$0.offset] = provider
                     builder.activeModulesIds.insert(provider.id)
+                    builder.activeModulesIds.remove($0.module.id)
                 }
-
-            // remove old modules
-            ovpnPairs.forEach { pair in
-                builder.modules.removeAll {
-                    pair.module.id == $0.id
-                }
-                builder.activeModulesIds.remove(pair.module.id)
-            }
 
             return try builder.tryBuild()
         default:


### PR DESCRIPTION
Fixes:

- CRITICAL: Do not migrate non-provider OpenVPN modules!
- Reset providers' last update on upgrade to 3.2.2
- Migrate in ProfileManager.reloadLocalProfiles() to avoid potential recursion in allProfiles.didSet
- Append a version suffix to migrated profiles to highlight backward incompatibility

Extra:

- Fix disabled scrolling after migrating v2 profiles
- Do not pre-push provider module on profile creation, TipKit may break navigation

Regressions in #1255 