### PR TITLE
Resolve more migration issues

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -94,10 +94,7 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
             contentView
                 .toolbar(content: toolbarContent)
         }
-        .modifier(OnboardingModifier(
-            tunnel: tunnel,
-            modalRoute: $modalRoute
-        ))
+        .modifier(OnboardingModifier(modalRoute: $modalRoute))
         .modifier(PaywallModifier(
             reason: $paywallReason,
             otherTitle: Strings.Views.Paywall.Alerts.Confirmation.editProfile,

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -94,7 +94,10 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
             contentView
                 .toolbar(content: toolbarContent)
         }
-        .modifier(OnboardingModifier(modalRoute: $modalRoute))
+        .modifier(OnboardingModifier(
+            tunnel: tunnel,
+            modalRoute: $modalRoute
+        ))
         .modifier(PaywallModifier(
             reason: $paywallReason,
             otherTitle: Strings.Views.Paywall.Alerts.Confirmation.editProfile,

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -33,10 +33,13 @@ struct OnboardingModifier: ViewModifier {
     private var apiManager: APIManager
 
     @EnvironmentObject
+    private var onboardingManager: OnboardingManager
+
+    @EnvironmentObject
     private var migrationManager: MigrationManager
 
     @EnvironmentObject
-    private var onboardingManager: OnboardingManager
+    private var tunnel: ExtendedTunnel
 
     @Environment(\.isUITesting)
     private var isUITesting
@@ -92,6 +95,7 @@ private extension OnboardingModifier {
         case .migrateV3_2_2:
             Button(Strings.Global.Nouns.ok) {
                 Task {
+                    try await tunnel.disconnect()
                     await apiManager.resetLastUpdateForAllProviders()
                     advance()
                 }

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -38,11 +38,11 @@ struct OnboardingModifier: ViewModifier {
     @EnvironmentObject
     private var migrationManager: MigrationManager
 
-    @EnvironmentObject
-    private var tunnel: ExtendedTunnel
-
     @Environment(\.isUITesting)
     private var isUITesting
+
+    @ObservedObject
+    var tunnel: ExtendedTunnel
 
     @Binding
     var modalRoute: AppCoordinator.ModalRoute?

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -41,9 +41,6 @@ struct OnboardingModifier: ViewModifier {
     @Environment(\.isUITesting)
     private var isUITesting
 
-    @ObservedObject
-    var tunnel: ExtendedTunnel
-
     @Binding
     var modalRoute: AppCoordinator.ModalRoute?
 
@@ -95,7 +92,6 @@ private extension OnboardingModifier {
         case .migrateV3_2_2:
             Button(Strings.Global.Nouns.ok) {
                 Task {
-                    try await tunnel.disconnect()
                     await apiManager.resetLastUpdateForAllProviders()
                     advance()
                 }

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -41,6 +41,9 @@ struct OnboardingModifier: ViewModifier {
     @Environment(\.isUITesting)
     private var isUITesting
 
+    @ObservedObject
+    var tunnel: ExtendedTunnel
+
     @Binding
     var modalRoute: AppCoordinator.ModalRoute?
 
@@ -92,6 +95,7 @@ private extension OnboardingModifier {
         case .migrateV3_2_2:
             Button(Strings.Global.Nouns.ok) {
                 Task {
+                    try await tunnel.disconnect()
                     await apiManager.resetLastUpdateForAllProviders()
                     advance()
                 }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
@@ -252,7 +252,7 @@ private extension ProviderView {
             let module = try draft.module.tryBuild()
             return try module.resolvedModule(with: registry)
         } catch {
-            pp_log(.app, .error, "Unable to resolve provider module: \(error)")
+            pp_log(.app, .debug, "Unable to resolve provider module: \(error)")
             return nil
         }
     }

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
@@ -287,13 +287,13 @@ private extension ProviderView {
 
     func loadCurrentProvider() {
        Task {
-           await refreshIndex()
            if let providerId {
                loadPreferences(for: providerId)
                if let providerEntity {
                    await loadSupportedPresets(for: providerEntity.server)
                }
            }
+           await refreshIndex()
        }
     }
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
@@ -341,11 +341,14 @@ private extension ProviderView {
     }
 
     func savePreferences() {
+        guard let providerId else {
+            return
+        }
         do {
-            pp_log(.app, .debug, "Save preferences for provider \(providerId.debugDescription)")
+            pp_log(.app, .debug, "Save preferences for provider \(providerId)")
             try providerPreferences.save()
         } catch {
-            pp_log(.app, .error, "Unable to save preferences for provider \(providerId.debugDescription): \(error)")
+            pp_log(.app, .error, "Unable to save preferences for provider \(providerId): \(error)")
         }
     }
 }

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -118,8 +118,7 @@ extension AppContext {
             processor: processor,
             repository: mainProfileRepository,
             backupRepository: backupProfileRepository,
-            mirrorsRemoteRepository: dependencies.mirrorsRemoteRepository,
-            readyAfterRemote: true
+            mirrorsRemoteRepository: dependencies.mirrorsRemoteRepository
         )
 
         let tunnel = ExtendedTunnel(


### PR DESCRIPTION
- Prevent index from delaying ProviderView appearance
- Avoid the initial spinner on upgrade to 3.2.2 (caused by StoreKit)
  - Do not wait for remote profiles for them to show up (fixes #1212)
  - Disconnect active tunnel