### PR TITLE
Move provider migration to library and include entity

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -95,7 +95,6 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
                 .toolbar(content: toolbarContent)
         }
         .modifier(OnboardingModifier(
-            tunnel: tunnel,
             modalRoute: $modalRoute
         ))
         .modifier(PaywallModifier(

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -95,6 +95,7 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
                 .toolbar(content: toolbarContent)
         }
         .modifier(OnboardingModifier(
+            tunnel: tunnel,
             modalRoute: $modalRoute
         ))
         .modifier(PaywallModifier(

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -146,7 +146,7 @@ private extension OnboardingModifier {
         case .migrateV3_2_2:
             isAlertPresented = true
         default:
-            if onboardingManager.step != OnboardingStep.allCases.last {
+            if onboardingManager.step < .last {
                 advance()
             }
         }

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -41,9 +41,6 @@ struct OnboardingModifier: ViewModifier {
     @Environment(\.isUITesting)
     private var isUITesting
 
-    @ObservedObject
-    var tunnel: ExtendedTunnel
-
     @Binding
     var modalRoute: AppCoordinator.ModalRoute?
 
@@ -95,7 +92,6 @@ private extension OnboardingModifier {
         case .migrateV3_2_2:
             Button(Strings.Global.Nouns.ok) {
                 Task {
-                    try await tunnel.disconnect()
                     await apiManager.resetLastUpdateForAllProviders()
                     advance()
                 }

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -41,9 +41,6 @@ struct OnboardingModifier: ViewModifier {
     @Environment(\.isUITesting)
     private var isUITesting
 
-    @ObservedObject
-    var tunnel: ExtendedTunnel
-
     @Binding
     var modalRoute: AppCoordinator.ModalRoute?
 
@@ -73,8 +70,6 @@ private extension OnboardingModifier {
         switch item {
         case .community:
             return Strings.Unlocalized.reddit
-        case .migrateV3_2_2:
-            return Strings.Global.Nouns.migration
         default:
             return ""
         }
@@ -92,15 +87,6 @@ private extension OnboardingModifier {
 
             Button(Strings.Onboarding.Community.dismiss, role: .cancel, action: advance)
 
-        case .migrateV3_2_2:
-            Button(Strings.Global.Nouns.ok) {
-                Task {
-                    try await tunnel.disconnect()
-                    await apiManager.resetLastUpdateForAllProviders()
-                    advance()
-                }
-            }
-
         default:
             EmptyView()
         }
@@ -111,8 +97,6 @@ private extension OnboardingModifier {
         switch item {
         case .community:
             Text(Strings.Onboarding.Community.message(Strings.Unlocalized.appName))
-        case .migrateV3_2_2:
-            Text(Strings.Onboarding.Migrate322.message)
         default:
             EmptyView()
         }
@@ -144,7 +128,10 @@ private extension OnboardingModifier {
         case .community:
             isAlertPresented = true
         case .migrateV3_2_2:
-            isAlertPresented = true
+            Task {
+                await apiManager.resetLastUpdateForAllProviders()
+                advance()
+            }
         default:
             if onboardingManager.step < .last {
                 advance()

--- a/Packages/App/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -368,31 +368,12 @@ private extension ProfileManager {
             }
             .map(\.id))
 
-        var processedResult = result
+        allProfiles = result
+            .filter {
+                !excludedIds.contains($0.id)
+            }
             .reduce(into: [:]) {
                 $0[$1.id] = $1
-            }
-
-        if let processor {
-            let toMigrate = processedResult.values.compactMap {
-                do {
-                    return try processor.migratedProfile(from: $0)
-                } catch {
-                    pp_log(.App.profiles, .error, "Unable to migrate profile \($0.id): \(error)")
-                    return nil
-                }
-            }
-            if !toMigrate.isEmpty {
-                pp_log(.App.profiles, .info, "Migrate profiles: \(toMigrate.map(\.id))")
-                toMigrate.forEach {
-                    processedResult[$0.id] = $0
-                }
-            }
-        }
-
-        allProfiles = processedResult
-            .filter {
-                !excludedIds.contains($0.key)
             }
 
         pp_log(.App.profiles, .info, "Local profiles after exclusions: \(allProfiles.keys)")

--- a/Packages/App/Sources/CommonLibrary/Strategy/Processors.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/Processors.swift
@@ -28,8 +28,6 @@ import PassepartoutKit
 
 @MainActor
 public protocol ProfileProcessor: Sendable {
-    func migratedProfile(from profile: Profile) throws -> Profile?
-
     func isIncluded(_ profile: Profile) -> Bool
 
     func preview(from profile: Profile) -> ProfilePreview

--- a/Packages/App/Sources/UILibrary/Business/OnboardingManager.swift
+++ b/Packages/App/Sources/UILibrary/Business/OnboardingManager.swift
@@ -68,10 +68,6 @@ public final class OnboardingManager: ObservableObject {
 }
 
 extension OnboardingStep {
-    var order: Int {
-        OnboardingStep.allCases.firstIndex(of: self) ?? .max
-    }
-
     var nextStep: OnboardingStep {
         let all = OnboardingStep.allCases
         guard let index = all.firstIndex(of: self) else {
@@ -81,9 +77,5 @@ extension OnboardingStep {
             return self
         }
         return all[index + 1]
-    }
-
-    static func < (lhs: Self, rhs: Self) -> Bool {
-        lhs.order < rhs.order
     }
 }

--- a/Packages/App/Sources/UILibrary/Domain/OnboardingStep.swift
+++ b/Packages/App/Sources/UILibrary/Domain/OnboardingStep.swift
@@ -39,3 +39,19 @@ public enum OnboardingStep: String, RawRepresentable, CaseIterable {
 
     case doneV3_2_2
 }
+
+extension OnboardingStep {
+    public static var last: Self {
+        allCases.last!
+    }
+}
+
+extension OnboardingStep: Comparable {
+    var order: Int {
+        OnboardingStep.allCases.firstIndex(of: self) ?? .max
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.order < rhs.order
+    }
+}

--- a/Packages/App/Sources/UILibrary/Strategy/MockAppProcessor.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/MockAppProcessor.swift
@@ -36,10 +36,6 @@ final class MockAppProcessor {
 }
 
 extension MockAppProcessor: ProfileProcessor {
-    func migratedProfile(from profile: Profile) -> Profile? {
-        nil
-    }
-
     func isIncluded(_ profile: Profile) -> Bool {
         true
     }

--- a/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
@@ -42,10 +42,6 @@ final class MockProfileProcessor: ProfileProcessor {
         profile.name
     }
 
-    func migratedProfile(from profile: Profile) throws -> Profile? {
-        nil
-    }
-
     func isIncluded(_ profile: Profile) -> Bool {
         isIncludedCount += 1
         return isIncludedBlock(profile)


### PR DESCRIPTION
Make migration as smooth as possible on upgrade. Especially important if a profile candidate for migration was on-demand and connected, because without the entity, the profile would be stuck reconnecting in vain.