### PR TITLE
Heuristic not sticking to same server category

### DIFF
--- a/Passepartout/App/Context/DefaultAppProcessor.swift
+++ b/Passepartout/App/Context/DefaultAppProcessor.swift
@@ -145,6 +145,7 @@ private extension ProviderModule.Builder {
         try await providerManager.setRepository(repo, for: providerModuleType)
 
         var filters = ProviderFilters()
+        filters.categoryName = entity.server.metadata.categoryName
         filters.presetId = entity.preset.presetId
 
         switch heuristic {


### PR DESCRIPTION
Use the same principle of preset filter. Heuristic should now stay within the current server category/preset.