### PR TITLE
Update dependencies on Partout packages

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -6,7 +6,6 @@ on:
 env:
   FASTLANE_USERNAME: ${{ secrets.FASTLANE_USERNAME }}
   FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
-  XCODEPROJ: "Passepartout.xcodeproj/project.pbxproj"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,16 +23,7 @@ jobs:
           submodules: recursive
       - name: Run Xcode tests
         run: |
-          bundle exec fastlane test
+          ci/run-xcode-tests.sh
       - name: Run Partout tests
         run: |
-          cd Partout
-          swift test
-      - name: Run OpenVPN tests
-        run: |
-          cd Partout/Plugins/PartoutOpenVPNOpenSSL
-          swift test
-      - name: Run WireGuard tests
-        run: |
-          cd Partout/Plugins/PartoutWireGuardGo
-          swift test
+          ci/run-partout-tests.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_tests:
-    name: Run tests
+  validate_codebase:
+    name: Validate codebase
     runs-on: macos-15
     timeout-minutes: 15
     steps:
@@ -36,12 +36,12 @@ jobs:
       - name: Validate translations
         run: |
           scripts/clean-translations.sh
-      - name: Run all tests
+      - name: Run Xcode tests
         run: |
-          bundle exec fastlane test
-          ( cd Partout && swift test )
-          ( cd Partout/Plugins/PartoutOpenVPNOpenSSL && swift test )
-          ( cd Partout/Plugins/PartoutWireGuardGo && swift test )
+          ci/run-xcode-tests.sh
+      - name: Run Partout tests
+        run: |
+          ci/run-partout-tests.sh
     outputs:
       version: ${{ steps.app_version.outputs.version }}
       build: ${{ steps.app_version.outputs.build }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,6 @@ jobs:
           xcode-version: 16.1
       - name: "Run tests"
         run: |
-          sed -i '' "s/environment = .production/environment = .onlineDevelopment/" "Partout/Package.swift"
+          sed -i '' "s/environment = .production/environment = .onlineDevelopment/" "Partout/Core/Package.swift"
           cd Packages/App
           swift test

--- a/Packages/App/Package.swift
+++ b/Packages/App/Package.swift
@@ -61,9 +61,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../../Partout"),
-        .package(path: "../../Partout/Plugins/PartoutOpenVPNOpenSSL"),
-        .package(path: "../../Partout/Plugins/PartoutWireGuardGo")
+        .package(path: "../../Partout")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -151,7 +149,7 @@ let package = Package(
             dependencies: [
                 "CommonIAP",
                 "CommonUtils",
-                .product(name: "Partout-Framework", package: "Partout")
+                "Partout"
             ],
             resources: [
                 .process("Resources")
@@ -173,8 +171,7 @@ let package = Package(
         .target(
             name: "PassepartoutImplementations",
             dependencies: [
-                "PartoutOpenVPNOpenSSL",
-                "PartoutWireGuardGo"
+                .product(name: "PartoutNetworking", package: "Partout")
             ],
             path: "Sources/Empty/PassepartoutImplementations"
         ),

--- a/Packages/App/Sources/AppDataPreferences/Domain/Mapper.swift
+++ b/Packages/App/Sources/AppDataPreferences/Domain/Mapper.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CoreData
 import Foundation
-import Partout
 
 struct DomainMapper {
 }

--- a/Packages/App/Sources/AppDataPreferences/Strategy/CDModulePreferencesRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataPreferences/Strategy/CDModulePreferencesRepositoryV3.swift
@@ -27,7 +27,6 @@ import AppData
 import CommonLibrary
 import CoreData
 import Foundation
-import Partout
 
 extension AppData {
 

--- a/Packages/App/Sources/AppDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
@@ -27,7 +27,6 @@ import AppData
 import CommonLibrary
 import CoreData
 import Foundation
-import Partout
 
 extension AppData {
 

--- a/Packages/App/Sources/AppDataProfiles/Strategy/CDProfileRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataProfiles/Strategy/CDProfileRepositoryV3.swift
@@ -29,7 +29,6 @@ import CommonLibrary
 import CommonUtils
 import CoreData
 import Foundation
-import Partout
 
 extension AppData {
     public static func cdProfileRepositoryV3(

--- a/Packages/App/Sources/AppDataProviders/Domain/CoreDataMapper.swift
+++ b/Packages/App/Sources/AppDataProviders/Domain/CoreDataMapper.swift
@@ -23,9 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CoreData
 import Foundation
-import Partout
 
 struct CoreDataMapper {
     let context: NSManagedObjectContext

--- a/Packages/App/Sources/AppDataProviders/Domain/DomainMapper.swift
+++ b/Packages/App/Sources/AppDataProviders/Domain/DomainMapper.swift
@@ -23,9 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CoreData
 import Foundation
-import Partout
 
 struct DomainMapper {
     func provider(from entity: CDProviderV3) -> Provider? {
@@ -66,7 +66,7 @@ struct DomainMapper {
                     $0[.init(rawValue: id)] = ProviderCache(lastUpdate: lastUpdate, tag: nil)
                 }
             } catch {
-                pp_log(.providers, .error, "Unable to decode cache: \(error)")
+                pp_log(.api, .error, "Unable to decode cache: \(error)")
             }
         }
     }

--- a/Packages/App/Sources/AppDataProviders/Domain/ProviderServerParameters+CoreData.swift
+++ b/Packages/App/Sources/AppDataProviders/Domain/ProviderServerParameters+CoreData.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 extension ProviderID {
     var predicate: NSPredicate {

--- a/Packages/App/Sources/AppDataProviders/Strategy/CDAPIRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataProviders/Strategy/CDAPIRepositoryV3.swift
@@ -25,10 +25,10 @@
 
 import AppData
 import Combine
+import CommonLibrary
 import CommonUtils
 import CoreData
 import Foundation
-import Partout
 
 extension AppData {
     public static func cdAPIRepositoryV3(context: NSManagedObjectContext) -> APIRepository {

--- a/Packages/App/Sources/AppDataProviders/Strategy/CDProviderRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataProviders/Strategy/CDProviderRepositoryV3.swift
@@ -24,10 +24,10 @@
 //
 
 import AppData
+import CommonLibrary
 import CommonUtils
 import CoreData
 import Foundation
-import Partout
 
 final class CDProviderRepositoryV3: ProviderRepository {
     private let context: NSManagedObjectContext

--- a/Packages/App/Sources/AppUIMain/AppUIMain.swift
+++ b/Packages/App/Sources/AppUIMain/AppUIMain.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 import TipKit
 import UIAccessibility
 @_exported import UILibrary

--- a/Packages/App/Sources/AppUIMain/Business/ProfileImporter.swift
+++ b/Packages/App/Sources/AppUIMain/Business/ProfileImporter.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 @MainActor
 final class ProfileImporter: ObservableObject {

--- a/Packages/App/Sources/AppUIMain/Domain/Issue+Metadata.swift
+++ b/Packages/App/Sources/AppUIMain/Domain/Issue+Metadata.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 extension Issue {
     struct Metadata {

--- a/Packages/App/Sources/AppUIMain/Domain/Issue.swift
+++ b/Packages/App/Sources/AppUIMain/Domain/Issue.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 struct Issue: Identifiable {
     let id: UUID

--- a/Packages/App/Sources/AppUIMain/Extensions/ProfileEditor+Destination.swift
+++ b/Packages/App/Sources/AppUIMain/Extensions/ProfileEditor+Destination.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 extension View {

--- a/Packages/App/Sources/AppUIMain/Extensions/ProviderRegion+Extensions.swift
+++ b/Packages/App/Sources/AppUIMain/Extensions/ProviderRegion+Extensions.swift
@@ -24,6 +24,7 @@
 //
 
 import CommonLibrary
+import Foundation
 
 extension ProviderServer {
     var region: ProviderRegion {

--- a/Packages/App/Sources/AppUIMain/Extensions/ProviderRegion+Extensions.swift
+++ b/Packages/App/Sources/AppUIMain/Extensions/ProviderRegion+Extensions.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 
 extension ProviderServer {
     var region: ProviderRegion {

--- a/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct AddProfileMenu: View {

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 extension AppCoordinator {
     enum ModalRoute: Identifiable {

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/App/AppToolbar.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppToolbar.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct AppToolbar: ToolbarContent, SizeClassProviding {

--- a/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/InstalledProfileView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIAccessibility
 

--- a/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/OnboardingModifier.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct OnboardingModifier: ViewModifier {

--- a/Packages/App/Sources/AppUIMain/Views/App/Profile+ProviderSelectorButton.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/Profile+ProviderSelectorButton.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileContainerView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileContainerView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProfileContainerView: View, Routable {

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileContextMenu.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIAccessibility
 import UILibrary

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileFlow.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileFlow.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 import UILibrary
 
 struct ProfileFlow {

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileImporterModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileImporterModifier.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProfileImporterModifier: ViewModifier {

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileRowView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProfileRowView: View, Routable, SizeClassProviding {

--- a/Packages/App/Sources/AppUIMain/Views/App/TunnelRestartButton.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/TunnelRestartButton.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct TunnelRestartButton<Label>: View where Label: View {

--- a/Packages/App/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/AppMenu/macOS/AppMenu.swift
@@ -28,7 +28,6 @@
 import Combine
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 public struct AppMenu: View {

--- a/Packages/App/Sources/AppUIMain/Views/AppMenu/macOS/AppMenuImage.swift
+++ b/Packages/App/Sources/AppUIMain/Views/AppMenu/macOS/AppMenuImage.swift
@@ -26,7 +26,6 @@
 #if os(macOS)
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct AppMenuImage: View {

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct DiagnosticsView: View {

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/ReportIssueButton.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/ReportIssueButton.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ReportIssueButton {

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/iOS/ReportIssueButton+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/iOS/ReportIssueButton+iOS.swift
@@ -27,7 +27,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIKit
 

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/macOS/ReportIssueButton+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/macOS/ReportIssueButton+macOS.swift
@@ -26,7 +26,6 @@
 #if os(macOS)
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 extension ReportIssueButton: View {

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateContentView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct MigrateContentView<PerformButton>: View where PerformButton: View {

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateView+Model.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateView+Model.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 extension MigrateView {
     struct Model: Equatable {

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 // TODO: #878, show CloudKit progress

--- a/Packages/App/Sources/AppUIMain/Views/Migration/MigrateViewStep.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Migration/MigrateViewStep.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 enum MigrateViewStep: Equatable {
     case initial

--- a/Packages/App/Sources/AppUIMain/Views/Modules/DNSView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/DNSView.swift
@@ -24,8 +24,8 @@
 //
 
 import Combine
+import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct DNSView: View, ModuleDraftEditing {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/HTTPProxyView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/HTTPProxyView.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct HTTPProxyView: View, ModuleDraftEditing {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/IPView+Route.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/IPView+Route.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 extension IPView {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/IPView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/IPView.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct IPView: View, ModuleDraftEditing {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct OnDemandView: View, ModuleDraftEditing {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPN+Previews.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPN+Previews.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 // swiftlint: disable force_try
 extension OpenVPN.Configuration.Builder {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNModule+UI.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Configuration.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Configuration.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 extension OpenVPNView.ConfigurationView where R == AnyHashable {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Import.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Import.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 extension OpenVPNView {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Remotes.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView+Remotes.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 extension OpenVPNView {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OpenVPN/OpenVPNView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct OpenVPNView: View, ModuleDraftEditing {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderModule+UI.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderNameRow.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderNameRow.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 struct ProviderNameRow: View {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderServerLink.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderServerLink.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 struct ProviderServerLink: View {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView+OpenVPN.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView+OpenVPN.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 // MARK: Credentials

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ProviderView: View, ModuleDraftEditing {
@@ -250,7 +249,7 @@ private extension ProviderView {
     var resolvedModule: Module? {
         do {
             let module = try draft.module.tryBuild()
-            return try module.resolvedModule(with: registry)
+            return try registry.resolvedModule(module, in: nil)
         } catch {
             pp_log(.app, .debug, "Unable to resolve provider module: \(error)")
             return nil

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/DNSModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/DNSModule+UI.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/HTTPProxyModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/HTTPProxyModule+UI.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/IPModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/IPModule+UI.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/UI/OnDemandModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/UI/OnDemandModule+UI.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuard+Previews.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuard+Previews.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 // swiftlint: disable force_try
 extension WireGuard.Configuration.Builder {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardModule+UI.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 extension WireGuardView {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView+Import.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView+Import.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 extension WireGuardView {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct WireGuardView: View, ModuleDraftEditing {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/AddModuleMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/AddModuleMenu.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 // WARNING: Menu sections look good on physical device, whereas

--- a/Packages/App/Sources/AppUIMain/Views/Profile/EditorModuleToggle.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/EditorModuleToggle.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 struct EditorModuleToggle<Label>: View where Label: View {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ModuleDetailView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ModuleDetailView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ModuleDetailView: View {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ModulePreferencesModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ModulePreferencesModifier.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct ModulePreferencesModifier: ViewModifier {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ModuleViewModifier.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ModuleViewModifier.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 import UIAccessibility
 

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileActionsSection.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileActionsSection.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ProfileActionsSection: View {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProfileCoordinator: View {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileSaveButton.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileSaveButton.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ProfileSaveButton: View {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -27,7 +27,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProfileEditView: View, Routable {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -27,7 +27,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIAccessibility
 

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileSplitView+macOS.swift
@@ -27,7 +27,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProfileSplitView: View, Routable {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderConnectToButton.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderConnectToButton.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 struct ProviderConnectToButton<Label>: View where Label: View {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView+Model.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView+Model.swift
@@ -26,7 +26,6 @@
 import Combine
 import CommonLibrary
 import Foundation
-import Partout
 import UIAccessibility
 
 extension ProviderFiltersView {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
@@ -25,7 +25,6 @@
 
 import Combine
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ProviderFiltersView: View {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderPicker.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderPicker.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct ProviderPicker: View {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerCoordinator.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProviderServerCoordinator: View {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
@@ -26,7 +26,6 @@
 import CommonAPI
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 struct ProviderServerView: View {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
@@ -27,7 +27,6 @@
 
 import CommonAPI
 import CommonLibrary
-import Partout
 import SwiftUI
 import UIAccessibility
 

--- a/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
@@ -27,7 +27,6 @@
 
 import CommonAPI
 import CommonLibrary
-import Partout
 import SwiftUI
 
 extension ProviderServerView {

--- a/Packages/App/Sources/AppUIMain/Views/Settings/SettingsCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/SettingsCoordinator.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Settings/iOS/SettingsContentView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/iOS/SettingsContentView+iOS.swift
@@ -26,7 +26,6 @@
 #if os(iOS)
 
 import CommonLibrary
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
@@ -26,7 +26,6 @@
 #if os(macOS)
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 struct SettingsContentView<LinkContent, SettingsDestination, DiagnosticsDestination>: View where LinkContent: View, SettingsDestination: View, DiagnosticsDestination: View {

--- a/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ActiveProfileView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIAccessibility
 

--- a/Packages/App/Sources/AppUITV/Views/Profile/ActiveTunnelButton.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ActiveTunnelButton.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUITV/Views/Profile/ProfileListView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ProfileListView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIAccessibility
 

--- a/Packages/App/Sources/AppUITV/Views/Profile/ProfileView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profile/ProfileView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/AppUITV/Views/Settings/SettingsView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Settings/SettingsView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UILibrary
 

--- a/Packages/App/Sources/CommonAPI/Shared.swift
+++ b/Packages/App/Sources/CommonAPI/Shared.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 // TODO: #716, move to Environment
 extension API {

--- a/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
@@ -25,7 +25,6 @@
 
 import Combine
 import Foundation
-import Partout
 
 @MainActor
 public final class ExtendedTunnel: ObservableObject {

--- a/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
@@ -26,7 +26,6 @@
 import Combine
 import CommonUtils
 import Foundation
-import Partout
 
 @MainActor
 public final class IAPManager: ObservableObject {

--- a/Packages/App/Sources/CommonLibrary/Business/MigrationManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/MigrationManager.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 public protocol MigrationManagerImporter {
     func importProfile(_ profile: Profile, remotelyShared: Bool) async throws

--- a/Packages/App/Sources/CommonLibrary/Business/ModulePreferences.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ModulePreferences.swift
@@ -25,7 +25,6 @@
 
 import CommonUtils
 import Foundation
-import Partout
 
 public final class ModulePreferences: ObservableObject, ModulePreferencesRepository {
     private var repository: ModulePreferencesRepository?

--- a/Packages/App/Sources/CommonLibrary/Business/PreferencesManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/PreferencesManager.swift
@@ -25,7 +25,6 @@
 
 import CommonUtils
 import Foundation
-import Partout
 
 @MainActor
 public final class PreferencesManager: ObservableObject {

--- a/Packages/App/Sources/CommonLibrary/Business/ProfileManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ProfileManager.swift
@@ -25,7 +25,6 @@
 
 import Combine
 import Foundation
-import Partout
 
 @MainActor
 public final class ProfileManager: ObservableObject {

--- a/Packages/App/Sources/CommonLibrary/Business/ProviderPreferences.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ProviderPreferences.swift
@@ -25,7 +25,6 @@
 
 import CommonUtils
 import Foundation
-import Partout
 
 public final class ProviderPreferences: ObservableObject, ProviderPreferencesRepository {
     private var repository: ProviderPreferencesRepository?

--- a/Packages/App/Sources/CommonLibrary/CommonLibrary.swift
+++ b/Packages/App/Sources/CommonLibrary/CommonLibrary.swift
@@ -24,7 +24,10 @@
 //
 
 import Foundation
-import Partout
+
+@_exported import PartoutAPI
+@_exported import PartoutCore
+@_exported import PartoutSupport
 
 public final class CommonLibrary {
     public enum Target {

--- a/Packages/App/Sources/CommonLibrary/Domain/AppError.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/AppError.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 public enum AppError: Error {
     case couldNotLaunch(reason: Error)

--- a/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 // WARNING: beware of Constants.shared dependency
 

--- a/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+Main.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+Main.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 // WARNING: beware of Constants.shared dependency
 

--- a/Packages/App/Sources/CommonLibrary/Domain/Constants.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/Constants.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 public struct Constants: Decodable, Sendable {
     public struct Containers: Decodable, Sendable {

--- a/Packages/App/Sources/CommonLibrary/Domain/EditableProfile.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/EditableProfile.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 public struct EditableProfile: MutableProfileType {
     public let version: Int? = nil

--- a/Packages/App/Sources/CommonLibrary/Domain/ProfileAttributes+ModulePreferences.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/ProfileAttributes+ModulePreferences.swift
@@ -25,7 +25,6 @@
 
 import CommonUtils
 import Foundation
-import Partout
 
 extension ProfileAttributes {
     public struct ModulePreferences {

--- a/Packages/App/Sources/CommonLibrary/Domain/ProfileAttributes.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/ProfileAttributes.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 // WARNING: upcast to [String: AnyHashable] relies on CodableProfileCoder
 // implementation returning JSONSerialization

--- a/Packages/App/Sources/CommonLibrary/Domain/ProfilePreview.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/ProfilePreview.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 public struct ProfilePreview: Identifiable, Hashable {
     public let id: Profile.ID

--- a/Packages/App/Sources/CommonLibrary/Extensions/Module+ModuleType.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/Module+ModuleType.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension Module {
     public var moduleType: ModuleType {

--- a/Packages/App/Sources/CommonLibrary/Extensions/ModuleType+Known.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/ModuleType+Known.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension ModuleType: @retroactive CaseIterable {
     public static let allCases: [ModuleType] = [

--- a/Packages/App/Sources/CommonLibrary/Extensions/ModuleType+New.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/ModuleType+New.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension ModuleType {
     public func newModule(with registry: Registry) -> any ModuleBuilder {

--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutConfiguration+Logging.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutConfiguration+Logging.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension PartoutConfiguration {
     public func configureLogging(to url: URL, parameters: Constants.Log, logsPrivateData: Bool) {

--- a/Packages/App/Sources/CommonLibrary/Extensions/ProfileManager+Importer.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/ProfileManager+Importer.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension ProfileManager: MigrationManagerImporter {
     public func importProfile(_ profile: Profile, remotelyShared: Bool) async throws {

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Modules.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Modules.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension DNSModule.Builder: AppFeatureRequiring {
     public var features: Set<AppFeature> {

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Profile.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Profile.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension Profile: AppFeatureRequiring {
     public var features: Set<AppFeature> {

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Providers.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureRequiring+Providers.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension ProviderID: AppFeatureRequiring {
     public var features: Set<AppFeature> {

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -26,7 +26,6 @@
 import CommonIAP
 import CommonUtils
 import Foundation
-import Partout
 
 extension IAPManager {
     public enum SuggestionFilter {

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 extension IAPManager {
     public func verify(_ profile: Profile, extra: Set<AppFeature>? = nil) throws {

--- a/Packages/App/Sources/CommonLibrary/Shared.swift
+++ b/Packages/App/Sources/CommonLibrary/Shared.swift
@@ -25,7 +25,6 @@
 
 @_exported import CommonIAP
 import Foundation
-import Partout
 
 extension LoggerDestination {
     public static let app = LoggerDestination(category: "app")

--- a/Packages/App/Sources/CommonLibrary/Strategy/InMemoryProfileRepository.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/InMemoryProfileRepository.swift
@@ -25,7 +25,6 @@
 
 import Combine
 import Foundation
-import Partout
 
 public final class InMemoryProfileRepository: ProfileRepository {
     var profiles: [Profile] {

--- a/Packages/App/Sources/CommonLibrary/Strategy/ModulePreferencesRepository.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/ModulePreferencesRepository.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 @MainActor
 public protocol ModulePreferencesRepository {

--- a/Packages/App/Sources/CommonLibrary/Strategy/NEProfileRepository.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/NEProfileRepository.swift
@@ -26,7 +26,7 @@
 import Combine
 import Foundation
 import NetworkExtension
-import Partout
+import PartoutNE
 
 public final class NEProfileRepository: ProfileRepository {
     private let repository: NETunnelManagerRepository

--- a/Packages/App/Sources/CommonLibrary/Strategy/Processors.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/Processors.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 @MainActor
 public protocol ProfileProcessor: Sendable {

--- a/Packages/App/Sources/CommonLibrary/Strategy/ProfileMigrationStrategy.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/ProfileMigrationStrategy.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 public protocol ProfileMigrationStrategy {
     var hasMigratableProfiles: Bool { get}

--- a/Packages/App/Sources/CommonLibrary/Strategy/ProfileRepository.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/ProfileRepository.swift
@@ -25,7 +25,6 @@
 
 import Combine
 import Foundation
-import Partout
 
 public protocol ProfileRepository {
     var profilesPublisher: AnyPublisher<[Profile], Never> { get }

--- a/Packages/App/Sources/CommonLibrary/Strategy/ProviderPreferencesRepository.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/ProviderPreferencesRepository.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 
 @MainActor
 public protocol ProviderPreferencesRepository {

--- a/Packages/App/Sources/CommonLibrary/Strategy/SharedReceiptReader.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/SharedReceiptReader.swift
@@ -25,7 +25,6 @@
 
 import CommonUtils
 import Foundation
-import Partout
 
 public actor SharedReceiptReader: AppReceiptReader {
     private let reader: InAppReceiptReader

--- a/Packages/App/Sources/LegacyV2/Domain/MapperV2.swift
+++ b/Packages/App/Sources/LegacyV2/Domain/MapperV2.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 struct MapperV2 {
     func toProfileV3(_ v2: ProfileV2, isTV: Bool) throws -> Profile {

--- a/Packages/App/Sources/LegacyV2/Domain/Network.swift
+++ b/Packages/App/Sources/LegacyV2/Domain/Network.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 enum Network {
 }

--- a/Packages/App/Sources/LegacyV2/Domain/Profile+OpenVPNSettings.swift
+++ b/Packages/App/Sources/LegacyV2/Domain/Profile+OpenVPNSettings.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 extension ProfileV2 {
     struct OpenVPNSettings: Codable, Equatable, VPNProtocolProviding {

--- a/Packages/App/Sources/LegacyV2/Domain/Profile+Provider.swift
+++ b/Packages/App/Sources/LegacyV2/Domain/Profile+Provider.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 typealias ProviderName = String
 

--- a/Packages/App/Sources/LegacyV2/Domain/Profile+WireGuardSettings.swift
+++ b/Packages/App/Sources/LegacyV2/Domain/Profile+WireGuardSettings.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 import PartoutWireGuardGo
 
 extension ProfileV2 {

--- a/Packages/App/Sources/LegacyV2/Strategy/CDProfileRepositoryV2.swift
+++ b/Packages/App/Sources/LegacyV2/Strategy/CDProfileRepositoryV2.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 @preconcurrency import CoreData
 import Foundation
-import Partout
 
 final class CDProfileRepositoryV2: Sendable {
     static var model: NSManagedObjectModel {

--- a/Packages/App/Sources/LegacyV2/Strategy/ProfileV2MigrationStrategy.swift
+++ b/Packages/App/Sources/LegacyV2/Strategy/ProfileV2MigrationStrategy.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 public final class ProfileV2MigrationStrategy: ProfileMigrationStrategy, Sendable {
     public struct Container {

--- a/Packages/App/Sources/UILibrary/Business/AppContext.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppContext.swift
@@ -27,7 +27,6 @@ import Combine
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 import UIAccessibility
 
 @MainActor

--- a/Packages/App/Sources/UILibrary/Business/InteractiveManager.swift
+++ b/Packages/App/Sources/UILibrary/Business/InteractiveManager.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 public final class InteractiveManager: ObservableObject {

--- a/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
+++ b/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
@@ -28,7 +28,6 @@
 import AppKit
 import CommonLibrary
 import CommonUtils
-import Partout
 import ServiceManagement
 
 @MainActor

--- a/Packages/App/Sources/UILibrary/Business/ModuleDraft.swift
+++ b/Packages/App/Sources/UILibrary/Business/ModuleDraft.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 public final class ModuleDraft<T>: ObservableObject where T: ModuleBuilder {

--- a/Packages/App/Sources/UILibrary/Business/OnboardingManager.swift
+++ b/Packages/App/Sources/UILibrary/Business/OnboardingManager.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 public final class OnboardingManager: ObservableObject {

--- a/Packages/App/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Packages/App/Sources/UILibrary/Business/ProfileEditor.swift
@@ -26,7 +26,6 @@
 import Combine
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 public final class ProfileEditor: ObservableObject {

--- a/Packages/App/Sources/UILibrary/Extensions/AppCoordinatorConforming+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/AppCoordinatorConforming+Extensions.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 extension AppCoordinatorConforming {
     public func onConnect(_ profile: Profile, force: Bool, verify: Bool = true) async {
@@ -48,7 +47,7 @@ extension AppCoordinatorConforming {
             }
         } catch let ppError as PartoutError {
             switch ppError.code {
-            case .missingProviderEntity:
+            case .API.missingProviderEntity:
                 onProviderEntityRequired(profile, force: force)
             default:
                 onError(ppError, profile: profile)

--- a/Packages/App/Sources/UILibrary/Extensions/ModuleBuilder+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/ModuleBuilder+Previews.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 extension ModuleBuilder where Self: ModuleViewProviding {

--- a/Packages/App/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/ProfileEditor+UI.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 extension ProfileEditor {

--- a/Packages/App/Sources/UILibrary/Extensions/ProfileManager+Editing.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/ProfileManager+Editing.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 extension ProfileManager {

--- a/Packages/App/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 extension TunnelInstallationProviding {

--- a/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension AppError: LocalizedError {
     public var errorDescription: String? {
@@ -71,7 +70,7 @@ extension PartoutError: @retroactive LocalizedError {
     public var errorDescription: String? {
         let V = Strings.Errors.App.Passepartout.self
         switch code {
-        case .corruptProviderModule:
+        case .Support.corruptProviderModule:
             return V.corruptProviderModule(reason?.localizedDescription ?? "")
 
         case .incompatibleModules:
@@ -96,7 +95,7 @@ extension PartoutError: @retroactive LocalizedError {
                 .compactMap { $0 }
                 .joined(separator: " ")
 
-        case .missingProviderEntity:
+        case .API.missingProviderEntity:
             return V.missingProviderEntity
 
         case .noActiveModules:
@@ -108,9 +107,6 @@ extension PartoutError: @retroactive LocalizedError {
             return [V.parsing, message]
                 .compactMap { $0 }
                 .joined(separator: " ")
-
-        case .providerRequired:
-            return V.providerRequired
 
         case .timeout:
             return V.timeout

--- a/Packages/App/Sources/UILibrary/L10n/ErrorHandler+Default.swift
+++ b/Packages/App/Sources/UILibrary/L10n/ErrorHandler+Default.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 extension ErrorHandler {

--- a/Packages/App/Sources/UILibrary/L10n/ModuleBuilder+Description.swift
+++ b/Packages/App/Sources/UILibrary/L10n/ModuleBuilder+Description.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 extension ModuleBuilder {
 

--- a/Packages/App/Sources/UILibrary/L10n/ModuleType+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/ModuleType+L10n.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension ModuleType: LocalizableEntity {
     public var localizedDescription: String {

--- a/Packages/App/Sources/UILibrary/L10n/Modules/DNSModule+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/Modules/DNSModule+L10n.swift
@@ -23,9 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension DNSProtocol: LocalizableEntity {
     public var localizedDescription: String {

--- a/Packages/App/Sources/UILibrary/L10n/Modules/HTTPProxyModule+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/Modules/HTTPProxyModule+L10n.swift
@@ -25,4 +25,3 @@
 
 import CommonUtils
 import Foundation
-import Partout

--- a/Packages/App/Sources/UILibrary/L10n/Modules/OpenVPNModule+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/Modules/OpenVPNModule+L10n.swift
@@ -23,9 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension OpenVPN.PullMask: LocalizableEntity {
     public var localizedDescription: String {

--- a/Packages/App/Sources/UILibrary/L10n/Partout+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/Partout+L10n.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension Profile {
     public var localizedPreview: ProfilePreview {

--- a/Packages/App/Sources/UILibrary/L10n/Strings+Unlocalized.swift
+++ b/Packages/App/Sources/UILibrary/L10n/Strings+Unlocalized.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 extension Strings {
     public enum Unlocalized {

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -137,8 +137,6 @@ public enum Strings {
         public static let noActiveModules = Strings.tr("Localizable", "errors.app.passepartout.no_active_modules", fallback: "The profile has no active modules.")
         /// Unable to parse file.
         public static let parsing = Strings.tr("Localizable", "errors.app.passepartout.parsing", fallback: "Unable to parse file.")
-        /// No provider selected.
-        public static let providerRequired = Strings.tr("Localizable", "errors.app.passepartout.provider_required", fallback: "No provider selected.")
         /// The operation timed out.
         public static let timeout = Strings.tr("Localizable", "errors.app.passepartout.timeout", fallback: "The operation timed out.")
       }

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension AppContext {
     public static let forPreviews: AppContext = {

--- a/Packages/App/Sources/UILibrary/Previews/Profile+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/Profile+Previews.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 extension Profile {
     public static let forPreviews: Profile = {

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Kein Server beim Anbieter ausgewählt.";
 "errors.app.passepartout.no_active_modules" = "Das Profil hat keine aktiven Module.";
 "errors.app.passepartout.parsing" = "Datei konnte nicht analysiert werden.";
-"errors.app.passepartout.provider_required" = "Kein Anbieter ausgewählt.";
 "errors.app.passepartout.timeout" = "Die Operation hat das Zeitlimit überschritten.";
 "errors.app.permission_denied" = "Zugriff verweigert";
 "errors.app.tunnel" = "Aktion konnte nicht ausgeführt werden.";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Δεν επιλέχθηκε διακομιστής στον πάροχο.";
 "errors.app.passepartout.no_active_modules" = "Το προφίλ δεν έχει ενεργές μονάδες.";
 "errors.app.passepartout.parsing" = "Δεν ήταν δυνατή η ανάλυση αρχείου.";
-"errors.app.passepartout.provider_required" = "Δεν έχει επιλεγεί πάροχος.";
 "errors.app.passepartout.timeout" = "Η λειτουργία έληξε λόγω χρονικού ορίου.";
 "errors.app.permission_denied" = "Άρνηση άδειας";
 "errors.app.tunnel" = "Δεν ήταν δυνατή η εκτέλεση της ενέργειας.";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -409,7 +409,6 @@
 "errors.app.passepartout.missing_provider_entity" = "No server selected in provider.";
 "errors.app.passepartout.no_active_modules" = "The profile has no active modules.";
 "errors.app.passepartout.parsing" = "Unable to parse file.";
-"errors.app.passepartout.provider_required" = "No provider selected.";
 "errors.app.passepartout.timeout" = "The operation timed out.";
 
 "errors.tunnel.auth" = "Auth failed";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "No se seleccionó un servidor en el proveedor.";
 "errors.app.passepartout.no_active_modules" = "El perfil no tiene módulos activos.";
 "errors.app.passepartout.parsing" = "No se pudo analizar el archivo.";
-"errors.app.passepartout.provider_required" = "No se ha seleccionado proveedor.";
 "errors.app.passepartout.timeout" = "La operación agotó el tiempo de espera.";
 "errors.app.permission_denied" = "Permiso denegado";
 "errors.app.tunnel" = "No se pudo ejecutar la operación.";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Aucun serveur sélectionné chez le fournisseur.";
 "errors.app.passepartout.no_active_modules" = "Le profil n'a pas de modules actifs.";
 "errors.app.passepartout.parsing" = "Impossible d'analyser le fichier.";
-"errors.app.passepartout.provider_required" = "Aucun fournisseur sélectionné.";
 "errors.app.passepartout.timeout" = "L'opération a expiré.";
 "errors.app.permission_denied" = "Permission refusée";
 "errors.app.tunnel" = "Impossible d'exécuter l'opération.";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Nessun server selezionato nel provider.";
 "errors.app.passepartout.no_active_modules" = "Il profilo non ha moduli attivi.";
 "errors.app.passepartout.parsing" = "Impossibile analizzare il file.";
-"errors.app.passepartout.provider_required" = "Nessun provider selezionato.";
 "errors.app.passepartout.timeout" = "L'operazione ha superato il tempo limite.";
 "errors.app.permission_denied" = "Permesso negato";
 "errors.app.tunnel" = "Impossibile eseguire l'operazione.";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Geen server geselecteerd bij provider.";
 "errors.app.passepartout.no_active_modules" = "Het profiel heeft geen actieve modules.";
 "errors.app.passepartout.parsing" = "Kan bestand niet parseren.";
-"errors.app.passepartout.provider_required" = "Geen provider geselecteerd.";
 "errors.app.passepartout.timeout" = "De bewerking is verlopen.";
 "errors.app.permission_denied" = "Toegang geweigerd";
 "errors.app.tunnel" = "Actie kan niet worden uitgevoerd.";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Nie wybrano serwera w dostawcy.";
 "errors.app.passepartout.no_active_modules" = "Profil nie ma aktywnych modułów.";
 "errors.app.passepartout.parsing" = "Nie można przeanalizować pliku.";
-"errors.app.passepartout.provider_required" = "Nie wybrano dostawcy.";
 "errors.app.passepartout.timeout" = "Operacja przekroczyła limit czasu.";
 "errors.app.permission_denied" = "Brak uprawnień";
 "errors.app.tunnel" = "Nie można wykonać operacji.";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Nenhum servidor selecionado no provedor.";
 "errors.app.passepartout.no_active_modules" = "O perfil não possui módulos ativos.";
 "errors.app.passepartout.parsing" = "Não foi possível analisar o arquivo.";
-"errors.app.passepartout.provider_required" = "Nenhum provedor selecionado.";
 "errors.app.passepartout.timeout" = "A operação expirou.";
 "errors.app.permission_denied" = "Permissão negada";
 "errors.app.tunnel" = "Não foi possível executar a operação.";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "На провайдере не выбран сервер.";
 "errors.app.passepartout.no_active_modules" = "В профиле нет активных модулей.";
 "errors.app.passepartout.parsing" = "Не удалось разобрать файл.";
-"errors.app.passepartout.provider_required" = "Поставщик не выбран.";
 "errors.app.passepartout.timeout" = "Время операции истекло.";
 "errors.app.permission_denied" = "Доступ запрещен";
 "errors.app.tunnel" = "Не удалось выполнить операцию.";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Ingen server vald hos leverantören.";
 "errors.app.passepartout.no_active_modules" = "Profilen har inga aktiva moduler.";
 "errors.app.passepartout.parsing" = "Kan inte tolka filen.";
-"errors.app.passepartout.provider_required" = "Ingen leverantör vald.";
 "errors.app.passepartout.timeout" = "Åtgärden tog för lång tid.";
 "errors.app.permission_denied" = "Åtkomst nekad";
 "errors.app.tunnel" = "Kunde inte utföra åtgärden.";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "Не вибрано сервер у постачальника.";
 "errors.app.passepartout.no_active_modules" = "Профіль не має активних модулів.";
 "errors.app.passepartout.parsing" = "Не вдалося розібрати файл.";
-"errors.app.passepartout.provider_required" = "Не вибрано постачальника.";
 "errors.app.passepartout.timeout" = "Час виконання операції вичерпано.";
 "errors.app.permission_denied" = "Доступ заборонено";
 "errors.app.tunnel" = "Не вдалося виконати операцію.";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -35,7 +35,6 @@
 "errors.app.passepartout.missing_provider_entity" = "未在提供商中选择服务器。";
 "errors.app.passepartout.no_active_modules" = "配置文件没有激活模块。";
 "errors.app.passepartout.parsing" = "无法解析文件。";
-"errors.app.passepartout.provider_required" = "未选择提供商。";
 "errors.app.passepartout.timeout" = "操作超时。";
 "errors.app.permission_denied" = "权限被拒绝";
 "errors.app.tunnel" = "无法执行操作。";

--- a/Packages/App/Sources/UILibrary/Strategy/AppCoordinatorConforming.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/AppCoordinatorConforming.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 public protocol AppCoordinatorConforming {

--- a/Packages/App/Sources/UILibrary/Strategy/MockAppProcessor.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/MockAppProcessor.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 final class MockAppProcessor {
     private let iapManager: IAPManager

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleDestinationProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleDestinationProviding.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public protocol ModuleDestinationProviding {

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleDraftEditing.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleDraftEditing.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 @MainActor

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleShortcutsProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleShortcutsProviding.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 public protocol ModuleShortcutsProviding: ModuleBuilder {

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleViewFactory+Default.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleViewFactory+Default.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 import SwiftUI
 
 public final class DefaultModuleViewFactory: ModuleViewFactory {

--- a/Packages/App/Sources/UILibrary/Strategy/ModuleViewProviding.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/ModuleViewProviding.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public protocol ModuleViewProviding {

--- a/Packages/App/Sources/UILibrary/Theme/Theme+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Theme/Theme+Extensions.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 extension ModuleBuilder {

--- a/Packages/App/Sources/UILibrary/UILibrary.swift
+++ b/Packages/App/Sources/UILibrary/UILibrary.swift
@@ -26,7 +26,6 @@
 import CommonAPI
 import CommonLibrary
 import Foundation
-import Partout
 
 @MainActor
 public protocol UILibraryConfiguring {

--- a/Packages/App/Sources/UILibrary/Views/Diagnostics/DebugLogView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Diagnostics/DebugLogView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 public struct DebugLogView<Content>: View where Content: View {

--- a/Packages/App/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/Extensions/OpenVPNModule+Extensions.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 extension OpenVPNModule.Builder: InteractiveViewProviding {

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 public struct OpenVPNCredentialsGroup: View {

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier+Reason.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier+Reason.swift
@@ -24,8 +24,8 @@
 //
 
 import CommonIAP
+import CommonLibrary
 import Foundation
-import Partout
 
 public typealias PaywallReason = PaywallModifier.Reason
 

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct PaywallModifier: ViewModifier {

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import StoreKit
 import SwiftUI
 

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PurchaseRequiredView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PurchaseRequiredView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 public struct PurchaseRequiredView<Content>: View where Content: View {

--- a/Packages/App/Sources/UILibrary/Views/Preferences/LogsPrivateDataToggle.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/LogsPrivateDataToggle.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct LogsPrivateDataToggle: View {

--- a/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 #if !os(tvOS)

--- a/Packages/App/Sources/UILibrary/Views/Settings/ChangelogView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/ChangelogView.swift
@@ -27,7 +27,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import WebKit
 

--- a/Packages/App/Sources/UILibrary/Views/Settings/LinksView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/LinksView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct LinksView: View {

--- a/Packages/App/Sources/UILibrary/Views/Settings/VersionView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/VersionView.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct VersionView<R, Icon>: View where R: Hashable, Icon: View {

--- a/Packages/App/Sources/UILibrary/Views/UI/ConnectionFlow.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/ConnectionFlow.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
 
 public struct ConnectionFlow {
     public let onConnect: (Profile) async -> Void

--- a/Packages/App/Sources/UILibrary/Views/UI/ConnectionStatusText.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/ConnectionStatusText.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 import SwiftUI
 
 public struct ConnectionStatusText: View {

--- a/Packages/App/Sources/UILibrary/Views/UI/EndpointCardView.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/EndpointCardView.swift
@@ -23,7 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Partout
+import CommonLibrary
 import SwiftUI
 
 public struct EndpointCardView: View {

--- a/Packages/App/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/InteractiveCoordinator.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 public struct InteractiveCoordinator: View {

--- a/Packages/App/Sources/UILibrary/Views/UI/RefreshInfrastructureButton.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/RefreshInfrastructureButton.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 public struct RefreshInfrastructureButton<Label>: View where Label: View {

--- a/Packages/App/Sources/UILibrary/Views/UI/TunnelToggle.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/TunnelToggle.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 
 public struct TunnelToggle<Label>: View where Label: View {

--- a/Packages/App/Tests/AppUIMainTests/ProfileImporterTests.swift
+++ b/Packages/App/Tests/AppUIMainTests/ProfileImporterTests.swift
@@ -27,7 +27,6 @@
 import Combine
 import CommonLibrary
 import Foundation
-import Partout
 import XCTest
 
 final class ProfileImporterTests: XCTestCase {

--- a/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
@@ -26,7 +26,6 @@
 import Combine
 @testable import CommonLibrary
 import Foundation
-import Partout
 import XCTest
 
 final class ExtendedTunnelTests: XCTestCase {

--- a/Packages/App/Tests/CommonLibraryTests/Business/MigrationManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/MigrationManagerTests.swift
@@ -26,7 +26,6 @@
 @testable import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 import XCTest
 
 @MainActor

--- a/Packages/App/Tests/CommonLibraryTests/Business/ProfileManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/ProfileManagerTests.swift
@@ -26,7 +26,6 @@
 import Combine
 @testable import CommonLibrary
 import Foundation
-import Partout
 import XCTest
 
 @MainActor

--- a/Packages/App/Tests/CommonLibraryTests/Domain/ModuleTypeTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Domain/ModuleTypeTests.swift
@@ -25,7 +25,6 @@
 
 @testable import CommonLibrary
 import Foundation
-import Partout
 import XCTest
 
 final class ModuleTypeTests: XCTestCase {

--- a/Packages/App/Tests/CommonLibraryTests/Domain/ProfileAttributesTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Domain/ProfileAttributesTests.swift
@@ -25,7 +25,6 @@
 
 @testable import CommonLibrary
 import Foundation
-import Partout
 import XCTest
 
 final class ProfileAttributesTests: XCTestCase {

--- a/Packages/App/Tests/CommonLibraryTests/Mock/MockMigrationManagerImporter.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Mock/MockMigrationManagerImporter.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 actor MockMigrationManagerImporter: MigrationManagerImporter {
     private var failing: Set<UUID>

--- a/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileMigrationStrategy.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileMigrationStrategy.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 final class MockProfileMigrationStrategy: ProfileMigrationStrategy {
     var migratableProfiles: [MigratableProfile] = []

--- a/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Mock/MockProfileProcessor.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 final class MockProfileProcessor: ProfileProcessor {
     var isIncludedCount = 0

--- a/Packages/App/Tests/CommonLibraryTests/Mock/MockTunnelProcessor.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Mock/MockTunnelProcessor.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 final class MockTunnelProcessor: AppTunnelProcessor {
     var titleCount = 0

--- a/Packages/App/Tests/LegacyV2Tests/MapperV2Tests.swift
+++ b/Packages/App/Tests/LegacyV2Tests/MapperV2Tests.swift
@@ -23,9 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
 @testable import LegacyV2
-import Partout
 import XCTest
 
 final class MapperV2Tests: XCTestCase {

--- a/Packages/App/Tests/UILibraryTests/ProfileEditorTests.swift
+++ b/Packages/App/Tests/UILibraryTests/ProfileEditorTests.swift
@@ -26,7 +26,6 @@
 import Combine
 import CommonLibrary
 import Foundation
-import Partout
 @testable import UILibrary
 import XCTest
 

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -24,7 +24,6 @@
 //
 
 import CommonLibrary
-import Partout
 import SwiftUI
 import UIAccessibility
 import UILibrary

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -32,7 +32,7 @@ import CommonUtils
 import CoreData
 import Foundation
 import LegacyV2
-import Partout
+import PartoutNE
 import UIAccessibility
 import UILibrary
 

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 import UILibrary
 
 extension AppContext {

--- a/Passepartout/App/Context/DefaultAppProcessor.swift
+++ b/Passepartout/App/Context/DefaultAppProcessor.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 final class DefaultAppProcessor: Sendable {
     private let apiManager: APIManager
@@ -105,7 +104,7 @@ extension DefaultAppProcessor: AppTunnelProcessor {
 
         // validate provider modules
         do {
-            _ = try newProfile.resolvingProviderModules(with: registry)
+            _ = try registry.resolvedProfile(newProfile)
             return newProfile
         } catch {
             pp_log(.app, .error, "Unable to inject provider modules: \(error)")

--- a/Passepartout/App/Context/Dependencies+Processors.swift
+++ b/Passepartout/App/Context/Dependencies+Processors.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 import UILibrary
 
 extension Dependencies {

--- a/Passepartout/App/Context/ProfileManager+Testing.swift
+++ b/Passepartout/App/Context/ProfileManager+Testing.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 extension ProfileManager {
     public static func forUITesting(withRegistry registry: Registry, processor: ProfileProcessor) -> ProfileManager {

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -30,7 +30,6 @@ import AppUITV
 #endif
 
 import CommonLibrary
-import Partout
 import SwiftUI
 
 @main

--- a/Passepartout/App/Platforms/App+macOS.swift
+++ b/Passepartout/App/Platforms/App+macOS.swift
@@ -27,7 +27,6 @@ import AppUIMain
 import Combine
 import CommonLibrary
 import CommonUtils
-import Partout
 import SwiftUI
 import UIAccessibility
 

--- a/Passepartout/Shared/Dependencies+CoreData.swift
+++ b/Passepartout/Shared/Dependencies+CoreData.swift
@@ -23,9 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension Dependencies {
     func coreDataLogger() -> LoggerProtocol {

--- a/Passepartout/Shared/Dependencies+IAPManager.swift
+++ b/Passepartout/Shared/Dependencies+IAPManager.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension Dependencies {
     var customUserLevel: AppUserLevel? {

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -23,8 +23,9 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
-import Partout
+import PartoutNE
 import PartoutOpenVPNOpenSSL
 import PartoutWireGuardGo
 

--- a/Passepartout/Tests/LocalizationTests.swift
+++ b/Passepartout/Tests/LocalizationTests.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import Partout
 @testable import PartoutWireGuardGo
 import UILibrary
 import WireGuardKit

--- a/Passepartout/Tests/MigrationManagerTests.swift
+++ b/Passepartout/Tests/MigrationManagerTests.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import Foundation
 @testable import LegacyV2
-import Partout
 import XCTest
 
 @MainActor

--- a/Passepartout/Tunnel/Context/DefaultTunnelProcessor.swift
+++ b/Passepartout/Tunnel/Context/DefaultTunnelProcessor.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 import Foundation
-import Partout
 
 final class DefaultTunnelProcessor: Sendable {
     init() {

--- a/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
+++ b/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
@@ -26,7 +26,6 @@
 import CommonLibrary
 import CommonUtils
 import Foundation
-import Partout
 
 extension TunnelContext {
     static let shared: TunnelContext = {

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -25,7 +25,7 @@
 
 import CommonLibrary
 @preconcurrency import NetworkExtension
-import Partout
+import PartoutNE
 
 final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ git submodule update --init
 
 Then:
 
-- Edit `Partout/Package.swift`
+- Edit `Partout/Core/Package.swift`
 - Set `environment = .onlineDevelopment`
 
 For everything to work properly, you must comply with all the capabilities and entitlements in the main app and the tunnel extension target. Therefore, you must update the `Config.xcconfig` file according to your developer account.

--- a/ci/run-partout-tests.sh
+++ b/ci/run-partout-tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd Partout && swift test && ./scripts/test-plugins.sh

--- a/ci/run-xcode-tests.sh
+++ b/ci/run-xcode-tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle exec fastlane test


### PR DESCRIPTION
Adjust to the refactoring done in https://github.com/passepartoutvpn/partout/pull/5. Imply most Partout imports from CommonLibrary, and import plugins explicitly.

This way, the app will not require updating hundreds of imports again.