### PR TITLE
Update Partout and refactor logging approach

### DIFF
--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutConfiguration+Logging.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutConfiguration+Logging.swift
@@ -24,10 +24,22 @@
 //
 
 import Foundation
+import PartoutPlatform
 
 extension PartoutConfiguration {
     public func configureLogging(to url: URL, parameters: Constants.Log, logsPrivateData: Bool) {
         pp_log(.app, .debug, "Log to: \(url)")
+
+        assertsMissingLoggingCategory = true
+        setLogger(OSLogDestination(.api))
+        setLogger(OSLogDestination(.app))
+        setLogger(OSLogDestination(.core))
+        setLogger(OSLogDestination(.ne))
+        setLogger(OSLogDestination(.openvpn))
+        setLogger(OSLogDestination(.wireguard))
+        setLogger(OSLogDestination(.App.iap))
+        setLogger(OSLogDestination(.App.migration))
+        setLogger(OSLogDestination(.App.profiles))
 
         setLocalLogger(
             url: url,

--- a/Packages/App/Sources/CommonLibrary/Shared.swift
+++ b/Packages/App/Sources/CommonLibrary/Shared.swift
@@ -26,15 +26,15 @@
 @_exported import CommonIAP
 import Foundation
 
-extension LoggerDestination {
-    public static let app = LoggerDestination(category: "app")
+extension LoggerCategory {
+    public static let app = LoggerCategory(rawValue: "app")
 
     public enum App {
-        public static let iap = LoggerDestination(category: "app.iap")
+        public static let iap = LoggerCategory(rawValue: "app.iap")
 
-        public static let migration = LoggerDestination(category: "app.migration")
+        public static let migration = LoggerCategory(rawValue: "app.migration")
 
-        public static let profiles = LoggerDestination(category: "app.profiles")
+        public static let profiles = LoggerCategory(rawValue: "app.profiles")
     }
 }
 

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -27,6 +27,7 @@ import CommonLibrary
 import Foundation
 import PartoutNE
 import PartoutOpenVPNOpenSSL
+import PartoutPlatform
 import PartoutWireGuardGo
 
 extension Dependencies {
@@ -68,6 +69,10 @@ private extension Dependencies {
                     return try await OpenVPNConnection(
                         parameters: $0,
                         module: $1,
+                        prng: AppleRandom(),
+                        dns: SimpleDNSResolver {
+                            CFDNSStrategy(hostname: $0)
+                        },
                         options: options,
                         cachesURL: FileManager.default.temporaryDirectory
                     )


### PR DESCRIPTION
Following https://github.com/passepartoutvpn/partout/pull/12

Add loggers manually, now non-static and platform-specific.