### PR TITLE
Refactor to use Partout as mono package

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: passepartoutvpn/action-prepare-xcode-build@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-          submodules: recursive
+          submodules: true
       - name: Run Xcode tests
         run: |
           ci/run-xcode-tests.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: passepartoutvpn/action-prepare-xcode-build@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-          submodules: recursive
+          submodules: true
       - name: Save app version
         id: app_version
         run: |
@@ -58,7 +58,7 @@ jobs:
       - uses: passepartoutvpn/action-prepare-xcode-build@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-          submodules: recursive
+          submodules: true
       - name: Upload ${{ matrix.platform }} app
         id: upload_app
         timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,10 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 16.1
+      - name: Use remote Core binary
+        run: |
+          sed -i '' "s/environment = .production/environment = .onlineBinary/" "Partout/Package.swift"
       - name: "Run tests"
         run: |
-          sed -i '' "s/environment = .production/environment = .onlineDevelopment/" "Partout/Core/Package.swift"
           cd Packages/App
           swift test

--- a/Packages/App/Package.resolved
+++ b/Packages/App/Package.resolved
@@ -14,8 +14,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/passepartoutvpn/openssl-apple",
       "state" : {
-        "revision" : "685680e3adbfccdeef84d37fc5732b0031f188c7",
-        "version" : "3.2.108"
+        "revision" : "38aa6fa15ebddc7b1ec248551325e1121580c9da",
+        "version" : "3.4.200"
+      }
+    },
+    {
+      "identity" : "partout-core",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:passepartoutvpn/partout-core.git",
+      "state" : {
+        "revision" : "225c91e2d3c0637db5e06574820b487f8a4d41f8"
       }
     },
     {

--- a/Packages/App/Package.swift
+++ b/Packages/App/Package.swift
@@ -171,7 +171,8 @@ let package = Package(
         .target(
             name: "PassepartoutImplementations",
             dependencies: [
-                .product(name: "PartoutNetworking", package: "Partout")
+                .product(name: "PartoutOpenVPN", package: "Partout"),
+                .product(name: "PartoutWireGuard", package: "Partout")
             ],
             path: "Sources/Empty/PassepartoutImplementations"
         ),

--- a/Packages/App/Sources/CommonLibrary/CommonLibrary.swift
+++ b/Packages/App/Sources/CommonLibrary/CommonLibrary.swift
@@ -24,10 +24,7 @@
 //
 
 import Foundation
-
-@_exported import PartoutAPI
-@_exported import PartoutCore
-@_exported import PartoutSupport
+@_exported import Partout
 
 public final class CommonLibrary {
     public enum Target {

--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutConfiguration+Logging.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutConfiguration+Logging.swift
@@ -24,8 +24,6 @@
 //
 
 import Foundation
-import PartoutCore
-import PartoutSupport
 
 extension PartoutConfiguration {
     public func configureLogging(to url: URL, parameters: Constants.Log, logsPrivateData: Bool) {

--- a/Packages/App/Sources/CommonLibrary/Strategy/NEProfileRepository.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/NEProfileRepository.swift
@@ -26,7 +26,6 @@
 import Combine
 import Foundation
 import NetworkExtension
-import PartoutNE
 
 public final class NEProfileRepository: ProfileRepository {
     private let repository: NETunnelManagerRepository

--- a/Packages/App/Sources/LegacyV2/Domain/Profile+WireGuardSettings.swift
+++ b/Packages/App/Sources/LegacyV2/Domain/Profile+WireGuardSettings.swift
@@ -25,7 +25,7 @@
 
 import CommonLibrary
 import Foundation
-import PartoutWireGuardGo
+import PartoutWireGuard
 
 extension ProfileV2 {
     struct WireGuardSettings: Codable, Equatable, VPNProtocolProviding {

--- a/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -70,7 +70,7 @@ extension PartoutError: @retroactive LocalizedError {
     public var errorDescription: String? {
         let V = Strings.Errors.App.Passepartout.self
         switch code {
-        case .Support.corruptProviderModule:
+        case .API.corruptProviderModule:
             return V.corruptProviderModule(reason?.localizedDescription ?? "")
 
         case .incompatibleModules:

--- a/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
@@ -26,7 +26,6 @@
 import Combine
 @testable import CommonLibrary
 import Foundation
-import PartoutCore
 import XCTest
 
 final class ExtendedTunnelTests: XCTestCase {

--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,14 @@
       }
     },
     {
+      "identity" : "partout-core",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:passepartoutvpn/partout-core.git",
+      "state" : {
+        "revision" : "225c91e2d3c0637db5e06574820b487f8a4d41f8"
+      }
+    },
+    {
       "identity" : "wg-go-apple",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/passepartoutvpn/wg-go-apple",

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -32,7 +32,6 @@ import CommonUtils
 import CoreData
 import Foundation
 import LegacyV2
-import PartoutNE
 import UIAccessibility
 import UILibrary
 

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -25,10 +25,8 @@
 
 import CommonLibrary
 import Foundation
-import PartoutNE
-import PartoutOpenVPNOpenSSL
-import PartoutSupport
-import PartoutWireGuardGo
+import PartoutOpenVPN
+import PartoutWireGuard
 
 extension Dependencies {
     var registry: Registry {

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -67,10 +67,8 @@ private extension Dependencies {
                     return try await OpenVPNConnection(
                         parameters: $0,
                         module: $1,
-                        prng: AppleRandom(),
-                        dns: SimpleDNSResolver {
-                            CFDNSStrategy(hostname: $0)
-                        },
+                        prng: PartoutConfiguration.platform.newPRNG(),
+                        dns: PartoutConfiguration.platform.newDNSResolver(),
                         options: options,
                         cachesURL: FileManager.default.temporaryDirectory
                     )

--- a/Passepartout/Tests/LocalizationTests.swift
+++ b/Passepartout/Tests/LocalizationTests.swift
@@ -23,8 +23,8 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+@testable import _PartoutWireGuardGo
 import Foundation
-@testable import PartoutWireGuardGo
 import UILibrary
 import WireGuardKit
 import XCTest

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -25,7 +25,6 @@
 
 import CommonLibrary
 @preconcurrency import NetworkExtension
-import PartoutNE
 
 final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ $ git submodule update --init
 
 Then:
 
-- Edit `Partout/Core/Package.swift`
-- Set `environment = .onlineDevelopment`
+- Edit `Partout/Package.swift`
+- Set `environment = .onlineBinary`
 
 For everything to work properly, you must comply with all the capabilities and entitlements in the main app and the tunnel extension target. Therefore, you must update the `Config.xcconfig` file according to your developer account.
 

--- a/ci/run-partout-tests.sh
+++ b/ci/run-partout-tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cd Partout && swift test && ./scripts/test-plugins.sh
+cd Partout && swift test


### PR DESCRIPTION
Partout is now a [mono-package](https://github.com/passepartoutvpn/partout/pull/31), friendlier to SwiftPM. Use PlatformFactory for PRNG and DNS.