### PR TITLE
Override Partout to use Core source in CI

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           submodules: true
+      - name: Use remote Core source
+        run: |
+          sed -i '' "s/^environment = .remoteBinary$/environment = .remoteSource/" "Submodules/partout/Package.swift"
       - name: Run Xcode tests
         run: |
           ci/run-xcode-tests.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Validate translations
         run: |
           scripts/clean-translations.sh
+      - name: Use remote Core source
+        run: |
+          sed -i '' "s/^environment = .remoteBinary$/environment = .remoteSource/" "Submodules/partout/Package.swift"
       - name: Run Xcode tests
         run: |
           ci/run-xcode-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           submodules: true
-      - name: Use remote Core binary
-        run: |
-          sed -i '' "s/environment = .remoteSource/environment = .remoteBinary/" "Submodules/partout/Package.swift"
       - name: "Run tests"
         run: |
           cd Packages/App


### PR DESCRIPTION
Partout SwiftPM defaults to binary now. If the environment fails to be set to .remoteSource, the release workflow will fail on iOS/tvOS for missing architectures (not included in PartoutCore binary).