### PR TITLE
Ensure that PartoutCore source matches submodule in CI

### DIFF
--- a/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/ExtendedTunnelTests.swift
@@ -118,7 +118,8 @@ extension ExtendedTunnelTests {
         let profile = try Profile.Builder(modules: [module], activatingModules: true).tryBuild()
         try await sut.install(profile)
 
-        await stream.waitForNext(2) // include initial nil
+        await stream.waitForNext() // include initial nil
+        await stream.waitForNext()
         XCTAssertEqual(tunnel.currentProfile?.id, profile.id)
 //        XCTAssertEqual(processor.titleCount, 1) // unused by FakeTunnelStrategy
         XCTAssertEqual(processor.willInstallCount, 1)

--- a/ci/use-partout-core-source.sh
+++ b/ci/use-partout-core-source.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 manifest="Submodules/partout/Package.swift"
-sha1=`git submodule status Submodules/partout-core | cut -d ' ' -f 2`
+core_status=`git submodule status Submodules/partout-core`
+sha1=${core_status:1:40}
+echo "Update partout manifest, partout-core -> $sha1"
+
 sha1_line="let sha1 = .*"
 env_line="environment = .remoteBinary"
 sed -i '' "s/^${sha1_line}$/let sha1 = \"${sha1}\"/" "$manifest"

--- a/ci/use-partout-core-source.sh
+++ b/ci/use-partout-core-source.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+manifest="Submodules/partout/Package.swift"
+sha1=`git submodule status Submodules/partout-core | cut -d ' ' -f 2`
+sha1_line="let sha1 = .*"
 env_line="environment = .remoteBinary"
-sed -i '' "s/^${env_line}$/environment = .remoteSource/" "Submodules/partout/Package.swift"
+sed -i '' "s/^${sha1_line}$/let sha1 = \"${sha1}\"/" "$manifest"
+sed -i '' "s/^${env_line}$/environment = .remoteSource/" "$manifest"


### PR DESCRIPTION
Saves us from the hassle of updating the SHA-1 and the binary release in the Partout manifest every time. Passepartout may be occasionally ahead of the PartoutCore binary.

The SwiftPM tests workflow, for being unprivileged, still requires an updated binary.