### PR TITLE
Verify the original profile in tunnel

### DIFF
--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -86,7 +86,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
                     return
                 }
                 await verifyEligibility(
-                    of: fwd.profile,
+                    of: fwd.originalProfile,
                     environment: environment,
                     interval: params.interval
                 )


### PR DESCRIPTION
E.g. ProviderModule must be verified before resolution.