### PR TITLE
Wrap occurrences of UserDefaults/AppStorage

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
@@ -44,8 +44,8 @@ struct DiagnosticsView: View {
     @EnvironmentObject
     private var iapManager: IAPManager
 
-    @AppStorage(AppPreference.logsPrivateData.key, store: .appGroup)
-    private var logsPrivateData = false
+    @EnvironmentObject
+    private var kvStore: KeyValueManager
 
     let profileManager: ProfileManager
 
@@ -62,6 +62,9 @@ struct DiagnosticsView: View {
                 }
         }.value
     }
+
+    @State
+    private var logsPrivateData = false
 
     @State
     private var tunnelLogs: [LogEntry] = []
@@ -90,6 +93,7 @@ struct DiagnosticsView: View {
         .task {
             tunnelLogs = await availableTunnelLogs()
         }
+        .themeKeyValue(kvStore, AppPreference.logsPrivateData.key, $logsPrivateData, default: false)
         .themeForm()
         .alert(Strings.Views.Diagnostics.ReportIssue.title, isPresented: $isPresentingUnableToEmail) {
             Button(Strings.Global.Nouns.ok, role: .cancel) {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView+Model.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView+Model.swift
@@ -34,7 +34,7 @@ extension ProviderFiltersView {
     final class Model: ObservableObject {
         typealias CodeWithDescription = (code: String, description: String)
 
-        private let defaults: UserDefaults
+        private let kvStore: KeyValueManager
 
         private var options: ProviderFilterOptions
 
@@ -55,8 +55,8 @@ extension ProviderFiltersView {
 
         private var subscriptions: Set<AnyCancellable>
 
-        init(defaults: UserDefaults = .standard) {
-            self.defaults = defaults
+        init(kvStore: KeyValueManager) {
+            self.kvStore = kvStore
             options = ProviderFilterOptions()
             categories = []
             countries = []
@@ -136,18 +136,18 @@ private extension ProviderFiltersView.Model {
         $onlyShowsFavorites
             .dropFirst()
             .sink { [weak self] in
-                self?.defaults.onlyShowsFavorites = $0
+                self?.kvStore.onlyShowsFavorites = $0
             }
             .store(in: &subscriptions)
 
         // send initial value
-        onlyShowsFavorites = defaults.onlyShowsFavorites
+        onlyShowsFavorites = kvStore.onlyShowsFavorites
     }
 }
 
 // MARK: -
 
-private extension UserDefaults {
+private extension KeyValueManager {
     var onlyShowsFavorites: Bool {
         get {
             bool(forKey: UIPreference.onlyShowsFavorites.key)

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
@@ -117,7 +117,7 @@ private extension ProviderFiltersView {
     NavigationStack {
         ProviderFiltersView(
             providerId: .mullvad,
-            model: .init(),
+            model: .init(kvStore: KeyValueManager()),
             heuristic: .constant(nil)
         )
     }

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
@@ -71,7 +71,9 @@ struct ProviderServerView: View {
     private var providerPreferences = ProviderPreferences()
 
     @StateObject
-    private var filtersViewModel = ProviderFiltersView.Model()
+    private var filtersViewModel = ProviderFiltersView.Model(
+        kvStore: KeyValueManager(store: UserDefaultsStore(.standard))
+    )
 
     @StateObject
     private var errorHandler: ErrorHandler = .default()

--- a/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ExtendedTunnel.swift
@@ -29,7 +29,7 @@ import Foundation
 public final class ExtendedTunnel: ObservableObject {
     public static nonisolated let isManualKey = "isManual"
 
-    private let defaults: UserDefaults?
+    private let kvStore: KeyValueManager?
 
     private let tunnel: Tunnel
 
@@ -54,13 +54,13 @@ public final class ExtendedTunnel: ObservableObject {
     private var subscriptions: [Task<Void, Never>]
 
     public init(
-        defaults: UserDefaults? = nil,
+        kvStore: KeyValueManager? = nil,
         tunnel: Tunnel,
         environment: TunnelEnvironment,
         processor: AppTunnelProcessor? = nil,
         interval: TimeInterval
     ) {
-        self.defaults = defaults
+        self.kvStore = kvStore
         self.tunnel = tunnel
         self.environment = environment
         self.processor = processor
@@ -176,7 +176,7 @@ private extension ExtendedTunnel {
 
                     // update last used profile
                     if let id = current?.id {
-                        defaults?.set(id.uuidString, forKey: AppPreference.lastUsedProfileId.key)
+                        kvStore?.set(id.uuidString, forKey: AppPreference.lastUsedProfileId.key)
                     }
 
                     // follow status updates
@@ -244,7 +244,7 @@ private extension ExtendedTunnel {
 
 private extension ExtendedTunnel {
     var lastUsedProfile: TunnelCurrentProfile? {
-        guard let uuidString = defaults?.object(forKey: AppPreference.lastUsedProfileId.key) as? String,
+        guard let uuidString = kvStore?.string(forKey: AppPreference.lastUsedProfileId.key),
               let uuid = UUID(uuidString: uuidString) else {
             return nil
         }

--- a/Packages/App/Sources/CommonLibrary/Business/KeyValueManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/KeyValueManager.swift
@@ -1,0 +1,102 @@
+//
+//  KeyValueManager.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/1/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonUtils
+import Foundation
+
+@MainActor
+public final class KeyValueManager: ObservableObject {
+    private var store: KeyValueStore
+
+    public var fallback: [String: Any]
+
+    public init(store: KeyValueStore = InMemoryStore(), fallback: [String: Any] = [:]) {
+        self.store = store
+        self.fallback = fallback
+    }
+
+    public func contains(_ key: String) -> Bool {
+        store.value(for: key) != nil
+    }
+
+    public func object<T>(forKey key: String) -> T? {
+        store.value(for: key) ?? fallback[key] as? T
+    }
+
+    public func set<T>(_ value: T?, forKey key: String) {
+        store.set(value, for: key)
+    }
+
+    public func removeObject(forKey key: String) {
+        store.removeValue(for: key)
+    }
+
+    public subscript<T>(_ key: String) -> T? {
+        get {
+            object(forKey: key)
+        }
+        set {
+            set(newValue, forKey: key)
+        }
+    }
+}
+
+extension KeyValueManager {
+    public struct InMemoryStore: KeyValueStore {
+        private var map: [String: Any]
+
+        public init() {
+            map = [:]
+        }
+
+        public func value<V>(for key: String) -> V? {
+            map[key] as? V
+        }
+
+        public mutating func set<V>(_ value: V, for key: String) {
+            map[key] = value
+        }
+
+        public mutating func removeValue(for key: String) {
+            map.removeValue(forKey: key)
+        }
+    }
+}
+
+// MARK: - Shortcuts
+
+extension KeyValueManager {
+    public func bool(forKey key: String) -> Bool {
+        self[key] as Bool? == true
+    }
+
+    public func integer(forKey key: String) -> Int {
+        self[key] as Int? ?? 0
+    }
+
+    public func string(forKey key: String) -> String? {
+        self[key] as String?
+    }
+}

--- a/Packages/App/Sources/CommonLibrary/CommonLibrary.swift
+++ b/Packages/App/Sources/CommonLibrary/CommonLibrary.swift
@@ -26,6 +26,7 @@
 import Foundation
 @_exported import Partout
 
+@MainActor
 public final class CommonLibrary {
     public enum Target {
         case app
@@ -33,7 +34,10 @@ public final class CommonLibrary {
         case tunnel
     }
 
-    public init() {
+    private let kvStore: KeyValueManager
+
+    public init(kvStore: KeyValueManager) {
+        self.kvStore = kvStore
     }
 
     public func configure(_ target: Target) {
@@ -53,7 +57,7 @@ private extension CommonLibrary {
         PartoutConfiguration.shared.configureLogging(
             to: BundleConfiguration.urlForAppLog,
             parameters: Constants.shared.log,
-            logsPrivateData: UserDefaults.appGroup.bool(forKey: AppPreference.logsPrivateData.key)
+            logsPrivateData: kvStore.bool(forKey: AppPreference.logsPrivateData.key)
         )
     }
 
@@ -63,9 +67,9 @@ private extension CommonLibrary {
         PartoutConfiguration.shared.configureLogging(
             to: BundleConfiguration.urlForTunnelLog,
             parameters: Constants.shared.log,
-            logsPrivateData: UserDefaults.appGroup.bool(forKey: AppPreference.logsPrivateData.key)
+            logsPrivateData: kvStore.bool(forKey: AppPreference.logsPrivateData.key)
         )
-        if UserDefaults.appGroup.bool(forKey: AppPreference.dnsFallsBack.key) {
+        if kvStore.bool(forKey: AppPreference.dnsFallsBack.key) {
             let servers = Constants.shared.tunnel.dnsFallbackServers
             PartoutConfiguration.shared.dnsFallbackServers = servers
             pp_log(.app, .info, "Enable DNS fallback servers: \(servers)")
@@ -73,9 +77,9 @@ private extension CommonLibrary {
     }
 
     func configureShared() {
-        UserDefaults.appGroup.register(defaults: [
+        kvStore.fallback = [
             AppPreference.dnsFallsBack.key: true,
             AppPreference.logsPrivateData.key: false
-        ])
+        ]
     }
 }

--- a/Packages/App/Sources/CommonUtils/Business/KeyValueStore.swift
+++ b/Packages/App/Sources/CommonUtils/Business/KeyValueStore.swift
@@ -1,0 +1,34 @@
+//
+//  KeyValueStore.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/1/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public protocol KeyValueStore {
+    func value<V>(for key: String) -> V?
+
+    mutating func set<V>(_ value: V?, for key: String)
+
+    mutating func removeValue(for key: String)
+}

--- a/Packages/App/Sources/CommonUtils/Business/UserDefaultsStore.swift
+++ b/Packages/App/Sources/CommonUtils/Business/UserDefaultsStore.swift
@@ -43,4 +43,8 @@ public final class UserDefaultsStore: KeyValueStore {
         }
         defaults.set(value, forKey: key)
     }
+
+    public func removeValue(for key: String) {
+        defaults.removeObject(forKey: key)
+    }
 }

--- a/Packages/App/Sources/CommonUtils/Business/UserDefaultsStore.swift
+++ b/Packages/App/Sources/CommonUtils/Business/UserDefaultsStore.swift
@@ -1,0 +1,46 @@
+//
+//  UserDefaultsStore.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/1/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public final class UserDefaultsStore: KeyValueStore {
+    private let defaults: UserDefaults
+
+    public init(_ defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    public func value<V>(for key: String) -> V? {
+        defaults.object(forKey: key) as? V
+    }
+
+    public func set<V>(_ value: V?, for key: String) {
+        guard let value else {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        defaults.set(value, forKey: key)
+    }
+}

--- a/Packages/App/Sources/UILibrary/Business/AppearanceManager.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppearanceManager.swift
@@ -23,24 +23,25 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
 import SwiftUI
 
 @MainActor
 public final class AppearanceManager: ObservableObject {
-    private let defaults: UserDefaults
+    private let kvStore: KeyValueManager
 
     @Published
     public var systemAppearance: SystemAppearance? {
         didSet {
-            defaults.set(systemAppearance?.rawValue, forKey: UIPreference.systemAppearance.key)
+            kvStore.set(systemAppearance?.rawValue, forKey: UIPreference.systemAppearance.key)
             apply()
         }
     }
 
-    public init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
-        systemAppearance = defaults.string(forKey: UIPreference.systemAppearance.key)
+    public init(kvStore: KeyValueManager) {
+        self.kvStore = kvStore
+        systemAppearance = kvStore.string(forKey: UIPreference.systemAppearance.key)
             .flatMap {
                 SystemAppearance(rawValue: $0)
             }

--- a/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
+++ b/Packages/App/Sources/UILibrary/Business/MacSettingsModel.swift
@@ -32,7 +32,7 @@ import ServiceManagement
 
 @MainActor
 public final class MacSettingsModel: ObservableObject {
-    private let defaults: UserDefaults?
+    private let kvStore: KeyValueManager?
 
     private let appService: SMAppService?
 
@@ -63,21 +63,21 @@ public final class MacSettingsModel: ObservableObject {
 
     public var keepsInMenu: Bool {
         get {
-            defaults?.bool(forKey: UIPreference.keepsInMenu.key) ?? false
+            kvStore?.bool(forKey: UIPreference.keepsInMenu.key) ?? false
         }
         set {
             objectWillChange.send()
-            defaults?.set(newValue, forKey: UIPreference.keepsInMenu.key)
+            kvStore?.set(newValue, forKey: UIPreference.keepsInMenu.key)
         }
     }
 
     public init() {
-        defaults = nil
+        kvStore = nil
         appService = nil
     }
 
-    public init(defaults: UserDefaults, loginItemId: String) {
-        self.defaults = defaults
+    public init(kvStore: KeyValueManager, loginItemId: String) {
+        self.kvStore = kvStore
         appService = SMAppService.loginItem(identifier: loginItemId)
     }
 }

--- a/Packages/App/Sources/UILibrary/Business/OnboardingManager.swift
+++ b/Packages/App/Sources/UILibrary/Business/OnboardingManager.swift
@@ -28,30 +28,30 @@ import Foundation
 
 @MainActor
 public final class OnboardingManager: ObservableObject {
-    private let defaults: UserDefaults?
+    private let kvStore: KeyValueManager?
 
     private let initialStep: OnboardingStep
 
     public private(set) var step: OnboardingStep {
         didSet {
-            defaults?.set(step.rawValue, forKey: UIPreference.onboardingStep.key)
+            kvStore?.set(step.rawValue, forKey: UIPreference.onboardingStep.key)
         }
     }
 
-    public init(defaults: UserDefaults? = nil, initialStep: OnboardingStep? = nil) {
-        self.defaults = defaults
+    public init(kvStore: KeyValueManager? = nil, initialStep: OnboardingStep? = nil) {
+        self.kvStore = kvStore
         self.initialStep = initialStep ?? .doneV2
         step = self.initialStep
     }
 
-    public convenience init(defaults: UserDefaults) {
+    public convenience init(kvStore: KeyValueManager) {
         let initialStep: OnboardingStep?
-        if let rawStep = defaults.string(forKey: UIPreference.onboardingStep.key) {
+        if let rawStep = kvStore.string(forKey: UIPreference.onboardingStep.key) {
             initialStep = OnboardingStep(rawValue: rawStep)
         } else {
             initialStep = nil
         }
-        self.init(defaults: defaults, initialStep: initialStep)
+        self.init(kvStore: kvStore, initialStep: initialStep)
     }
 
     public func advance() {

--- a/Packages/App/Sources/UILibrary/Extensions/View+Environment.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/View+Environment.swift
@@ -32,6 +32,7 @@ extension View {
             .environmentObject(context.apiManager)
             .environmentObject(context.appearanceManager)
             .environmentObject(context.iapManager)
+            .environmentObject(context.kvStore)
             .environmentObject(context.migrationManager)
             .environmentObject(context.onboardingManager)
             .environmentObject(context.preferencesManager)

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -29,6 +29,7 @@ import Foundation
 
 extension AppContext {
     public static let forPreviews: AppContext = {
+        let kvStore = KeyValueManager()
         let iapManager = IAPManager(
             customUserLevel: .complete,
             inAppHelper: FakeAppProductHelper(),
@@ -58,13 +59,16 @@ extension AppContext {
             repository: InMemoryAPIRepository()
         )
         let migrationManager = MigrationManager()
+        let preferencesManager = PreferencesManager()
+        let registry = Registry()
         return AppContext(
             apiManager: apiManager,
             iapManager: iapManager,
+            kvStore: kvStore,
             migrationManager: migrationManager,
-            preferencesManager: PreferencesManager(),
+            preferencesManager: preferencesManager,
             profileManager: profileManager,
-            registry: Registry(),
+            registry: registry,
             tunnel: tunnel
         )
     }()

--- a/Packages/App/Sources/UILibrary/UILibrary.swift
+++ b/Packages/App/Sources/UILibrary/UILibrary.swift
@@ -32,6 +32,7 @@ public protocol UILibraryConfiguring {
     func configure(with context: AppContext)
 }
 
+@MainActor
 public final class UILibrary: UILibraryConfiguring {
     private let uiConfiguring: UILibraryConfiguring?
 
@@ -40,7 +41,8 @@ public final class UILibrary: UILibraryConfiguring {
     }
 
     public func configure(with context: AppContext) {
-        CommonLibrary().configure(.app)
+        CommonLibrary(kvStore: context.kvStore)
+            .configure(.app)
 
         assertMissingImplementations(with: context.registry)
         context.appearanceManager.apply()

--- a/Packages/App/Sources/UILibrary/Views/Preferences/LogsPrivateDataToggle.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/LogsPrivateDataToggle.swift
@@ -28,7 +28,10 @@ import SwiftUI
 
 public struct LogsPrivateDataToggle: View {
 
-    @AppStorage(AppPreference.logsPrivateData.key, store: .appGroup)
+    @EnvironmentObject
+    private var kvStore: KeyValueManager
+
+    @State
     private var logsPrivateData = false
 
     public init() {
@@ -36,6 +39,7 @@ public struct LogsPrivateDataToggle: View {
 
     public var body: some View {
         Toggle(Strings.Views.Diagnostics.Rows.includePrivateData, isOn: $logsPrivateData)
+            .themeKeyValue(kvStore, AppPreference.logsPrivateData.key, $logsPrivateData, default: false)
             .onChange(of: logsPrivateData) {
                 PartoutConfiguration.shared.logsAddresses = $0
                 PartoutConfiguration.shared.logsModules = $0

--- a/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
@@ -37,6 +37,9 @@ public struct PreferencesView: View {
     @EnvironmentObject
     private var iapManager: IAPManager
 
+    @EnvironmentObject
+    private var kvStore: KeyValueManager
+
 #if os(iOS)
     @AppStorage(UIPreference.locksInBackground.key)
     private var locksInBackground = false
@@ -45,10 +48,10 @@ public struct PreferencesView: View {
     private var settings: MacSettingsModel
 #endif
 
-    @AppStorage(AppPreference.dnsFallsBack.key, store: .appGroup)
-    private var dnsFallsBack = true
-
     private let profileManager: ProfileManager
+
+    @State
+    private var dnsFallsBack = true
 
     @State
     private var isConfirmingEraseiCloud = false
@@ -74,6 +77,7 @@ public struct PreferencesView: View {
             enablesPurchasesSection
             eraseCloudKitSection
         }
+        .themeKeyValue(kvStore, AppPreference.dnsFallsBack.key, $dnsFallsBack, default: true)
         .themeForm()
     }
 }

--- a/Packages/App/Sources/UILibrary/Views/Theme/Theme+Modifiers.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/Theme+Modifiers.swift
@@ -23,7 +23,10 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import SwiftUI
+
+// FIXME: ###, sort alphabetically
 
 extension View {
     public func themeModal<Content>(
@@ -269,4 +272,18 @@ extension View {
         ))
     }
 #endif
+
+    public func themeKeyValue<T>(
+        _ store: KeyValueManager,
+        _ key: String,
+        _ value: Binding<T>,
+        default defaultValue: T
+    ) -> some View where T: Equatable {
+        modifier(ThemeKeyValueModifier(
+            store: store,
+            key: key,
+            value: value,
+            defaultValue: defaultValue
+        ))
+    }
 }

--- a/Packages/App/Sources/UILibrary/Views/Theme/ThemeKeyValueModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/ThemeKeyValueModifier.swift
@@ -1,0 +1,57 @@
+//
+//  ThemeKeyValueModifier.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/1/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import SwiftUI
+
+public struct ThemeKeyValueModifier<T>: ViewModifier where T: Equatable {
+
+    @ObservedObject
+    private var store: KeyValueManager
+
+    private let key: String
+
+    @Binding
+    private var value: T
+
+    private let defaultValue: T
+
+    public init(store: KeyValueManager, key: String, value: Binding<T>, defaultValue: T) {
+        self.store = store
+        self.key = key
+        _value = value
+        self.defaultValue = defaultValue
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .onLoad {
+                value = store.object(forKey: key) ?? defaultValue
+            }
+            .onChange(of: value) {
+                store.set($0, forKey: key)
+            }
+    }
+}

--- a/Packages/App/Sources/UILibrary/Views/UI/RefreshInfrastructureButton.swift
+++ b/Packages/App/Sources/UILibrary/Views/UI/RefreshInfrastructureButton.swift
@@ -31,11 +31,12 @@ public struct RefreshInfrastructureButton<Label>: View where Label: View {
     @EnvironmentObject
     private var apiManager: APIManager
 
+    @EnvironmentObject
+    private var kvStore: KeyValueManager
+
     private let providerId: ProviderID
 
     private let label: () -> Label
-
-    private let defaults: UserDefaults = .standard
 
     @State
     private var elapsed: TimeInterval = .infinity
@@ -95,7 +96,7 @@ public struct RefreshInfrastructureButtonProgressView: View {
 
 private extension RefreshInfrastructureButton {
     func loadLastUpdate() {
-        guard let map = defaults.object(forKey: AppPreference.lastInfrastructureRefresh.key) as? [String: TimeInterval] else {
+        guard let map = kvStore.object(forKey: AppPreference.lastInfrastructureRefresh.key) as [String: TimeInterval]? else {
             elapsed = .infinity
             return
         }
@@ -107,9 +108,9 @@ private extension RefreshInfrastructureButton {
     }
 
     func saveLastUpdate() {
-        var map = defaults.object(forKey: AppPreference.lastInfrastructureRefresh.key) as? [String: TimeInterval] ?? [:]
+        var map = kvStore.object(forKey: AppPreference.lastInfrastructureRefresh.key) as [String: TimeInterval]? ?? [:]
         map[providerId.rawValue] = Date.timeIntervalSinceReferenceDate
-        defaults.set(map, forKey: AppPreference.lastInfrastructureRefresh.key)
+        kvStore.set(map, forKey: AppPreference.lastInfrastructureRefresh.key)
         elapsed = .zero
     }
 }

--- a/Packages/App/Tests/CommonLibraryTests/Business/KeyValueManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/KeyValueManagerTests.swift
@@ -1,0 +1,70 @@
+//
+//  KeyValueManagerTests.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/1/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import CommonLibrary
+import Foundation
+import XCTest
+
+final class KeyValueManagerTests: XCTestCase {
+}
+
+@MainActor
+extension KeyValueManagerTests {
+    func test_givenKeyValue_whenSet_thenGets() {
+        let sut = KeyValueManager()
+
+        sut.set("foobar", forKey: "string")
+        sut.set(true, forKey: "boolean")
+        sut.set(123, forKey: "number")
+        XCTAssertEqual(sut.object(forKey: "string"), "foobar")
+        XCTAssertEqual(sut.object(forKey: "boolean"), true)
+        XCTAssertEqual(sut.object(forKey: "number"), 123)
+        XCTAssertEqual(sut.string(forKey: "string"), "foobar")
+        XCTAssertEqual(sut.bool(forKey: "boolean"), true)
+        XCTAssertEqual(sut.integer(forKey: "number"), 123)
+
+        sut.removeObject(forKey: "string")
+        sut.removeObject(forKey: "boolean")
+        sut.removeObject(forKey: "number")
+        XCTAssertFalse(sut.contains("string"))
+        XCTAssertFalse(sut.contains("boolean"))
+        XCTAssertFalse(sut.contains("number"))
+    }
+
+    func test_givenKeyValue_whenSetFallback_thenGetsFallback() {
+        let sut = KeyValueManager()
+        sut.fallback = [
+            "string": "foobar",
+            "boolean": true,
+            "number": 123
+        ]
+        XCTAssertEqual(sut.object(forKey: "string"), "foobar")
+        XCTAssertEqual(sut.object(forKey: "boolean"), true)
+        XCTAssertEqual(sut.object(forKey: "number"), 123)
+        XCTAssertEqual(sut.string(forKey: "string"), "foobar")
+        XCTAssertEqual(sut.bool(forKey: "boolean"), true)
+        XCTAssertEqual(sut.integer(forKey: "number"), 123)
+    }
+}

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -24,6 +24,7 @@
 //
 
 import CommonLibrary
+import CommonUtils
 import SwiftUI
 import UIAccessibility
 import UILibrary
@@ -41,7 +42,7 @@ final class AppDelegate: NSObject {
 
 #if os(macOS)
     let settings = MacSettingsModel(
-        defaults: .standard,
+        kvStore: KeyValueManager(store: UserDefaultsStore(.standard)),
         loginItemId: BundleConfiguration.mainString(for: .loginItemId)
     )
 #endif

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -31,6 +31,8 @@ import UILibrary
 extension AppContext {
     static func forUITesting(withRegistry registry: Registry) -> AppContext {
         let dependencies: Dependencies = .shared
+
+        let kvStore = KeyValueManager()
         let apiManager = APIManager(
             from: API.bundled,
             repository: InMemoryAPIRepository()
@@ -70,6 +72,7 @@ extension AppContext {
         return AppContext(
             apiManager: apiManager,
             iapManager: iapManager,
+            kvStore: kvStore,
             migrationManager: migrationManager,
             preferencesManager: preferencesManager,
             profileManager: profileManager,

--- a/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
+++ b/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
@@ -30,6 +30,7 @@ import Foundation
 extension TunnelContext {
     static let shared: TunnelContext = {
         let dependencies: Dependencies = .shared
+        let kvStore = KeyValueManager(store: UserDefaultsStore(.appGroup))
         let iapManager = IAPManager(
             customUserLevel: dependencies.customUserLevel,
             inAppHelper: dependencies.appProductHelper(),
@@ -40,6 +41,7 @@ extension TunnelContext {
         let processor = DefaultTunnelProcessor()
         return TunnelContext(
             iapManager: iapManager,
+            kvStore: kvStore,
             processor: processor
         )
     }()

--- a/Passepartout/Tunnel/Context/TunnelContext.swift
+++ b/Passepartout/Tunnel/Context/TunnelContext.swift
@@ -30,5 +30,7 @@ import Foundation
 struct TunnelContext {
     let iapManager: IAPManager
 
+    let kvStore: KeyValueManager
+
     let processor: PacketTunnelProcessor
 }

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -39,7 +39,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     private var verifierSubscription: Task<Void, Error>?
 
     override func startTunnel(options: [String: NSObject]? = nil) async throws {
-        CommonLibrary().configure(.tunnel)
+        await CommonLibrary(kvStore: context.kvStore)
+            .configure(.tunnel)
 
         pp_log(.app, .info, "Tunnel started with options: \(options?.description ?? "nil")")
 


### PR DESCRIPTION
Add a new KeyValueManager wrapper around UserDefaults and key-value stores in general.

Interpose KeyValueManager wherever UserDefaults and AppStorage are used. In particular, wrap those uses of UserDefaults that assume the App Groups entitlement to perform IPC between the app and the tunnel. A different IPC mechanism must be injected in those cases where App Groups is not available (Developer ID, non-Apple platforms).

Steps:

- Add a KeyValueManager in AppContext/TunnelContext
- Initialize the shared KeyValueManager with the UserDefaults from the App Group container (via UserDefaultsStore)
- Inject KeyValueManager into the SwiftUI environment
- Use .themeKeyValue() to mimic AppStorage behavior with KeyValueManager

Affected:

- Shared preferences: DNS fallback, log private data, last used profile, skip purchases, infrastructure button rate-limit
- Local preferences: system appearance, show only favorites, keep in menu, onboarding