### PR TITLE
Adjust profile management for Developer ID

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,6 +18,7 @@ disabled_rules:
   - file_length
   - force_cast
   - function_body_length
+  - generic_type_name
   - identifier_name
   - line_length
   - inclusive_language

--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -773,6 +773,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		0E8D852E2C328C54005493DE /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -791,6 +792,7 @@
 		};
 		0EAD6A702DC3AED900419346 /* Embed Extensions */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -182,6 +182,7 @@ extension AppContext {
             // toggle CloudKit sync based on .sharing eligibility
             let remoteStore = newRemoteStore(isRemoteImportingEnabled)
 
+#if !PP_BUILD_MAC
             // @Published
             profileManager.isRemoteImportingEnabled = isRemoteImportingEnabled
 
@@ -201,24 +202,25 @@ extension AppContext {
                         }
                     )
                 }())
-
-                pp_log(.app, .info, "\tRefresh modules preferences repository...")
-                preferencesManager.modulesRepositoryFactory = {
-                    try AppData.cdModulePreferencesRepositoryV3(
-                        context: remoteStore.context,
-                        moduleId: $0
-                    )
-                }
-
-                pp_log(.app, .info, "\tRefresh providers preferences repository...")
-                preferencesManager.providersRepositoryFactory = {
-                    try AppData.cdProviderPreferencesRepositoryV3(
-                        context: remoteStore.context,
-                        providerId: $0
-                    )
-                }
             } catch {
                 pp_log(.App.profiles, .error, "\tUnable to re-observe remote profiles: \(error)")
+            }
+#endif
+
+            pp_log(.app, .info, "\tRefresh modules preferences repository...")
+            preferencesManager.modulesRepositoryFactory = {
+                try AppData.cdModulePreferencesRepositoryV3(
+                    context: remoteStore.context,
+                    moduleId: $0
+                )
+            }
+
+            pp_log(.app, .info, "\tRefresh providers preferences repository...")
+            preferencesManager.providersRepositoryFactory = {
+                try AppData.cdProviderPreferencesRepositoryV3(
+                    context: remoteStore.context,
+                    providerId: $0
+                )
             }
 
             pp_log(.App.profiles, .info, "\tReload profiles required features...")

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -61,11 +61,17 @@ extension AppContext {
             author: nil
         )
         let newRemoteStore: (_ cloudKit: Bool) -> CoreDataPersistentStore = {
-            CoreDataPersistentStore(
+            let cloudKitIdentifier: String?
+#if PP_BUILD_MAC
+            cloudKitIdentifier = nil
+#else
+            cloudKitIdentifier = $0 ? BundleConfiguration.mainString(for: .cloudKitId) : nil
+#endif
+            return CoreDataPersistentStore(
                 logger: dependencies.coreDataLogger(),
                 containerName: Constants.shared.containers.remote,
                 model: cdRemoteModel,
-                cloudKitIdentifier: $0 ? BundleConfiguration.mainString(for: .cloudKitId) : nil,
+                cloudKitIdentifier: cloudKitIdentifier,
                 author: nil
             )
         }
@@ -86,7 +92,11 @@ extension AppContext {
             betaChecker: dependencies.betaChecker(),
             productsAtBuild: dependencies.productsAtBuild()
         )
+#if PP_BUILD_MAC
+        iapManager.isEnabled = false
+#else
         iapManager.isEnabled = !sharedKVStore.bool(forKey: AppPreference.skipsPurchases.key)
+#endif
         let processor = dependencies.appProcessor(
             apiManager: apiManager,
             iapManager: iapManager,
@@ -131,6 +141,9 @@ extension AppContext {
             interval: Constants.shared.tunnel.refreshInterval
         )
 
+#if PP_BUILD_MAC
+        let migrationManager = MigrationManager()
+#else
         let migrationManager: MigrationManager = {
             let profileStrategy = ProfileV2MigrationStrategy(
                 coreDataLogger: dependencies.coreDataLogger(),
@@ -155,6 +168,7 @@ extension AppContext {
             }
             return MigrationManager(profileStrategy: profileStrategy, simulation: migrationSimulation)
         }()
+#endif
 
         let onboardingManager = OnboardingManager(kvStore: localKVStore)
         let preferencesManager = PreferencesManager()

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -92,7 +92,7 @@ extension AppContext {
             betaChecker: dependencies.betaChecker(),
             productsAtBuild: dependencies.productsAtBuild()
         )
-#if PP_BUILD_MAC
+#if PP_BUILD_FREE
         iapManager.isEnabled = false
 #else
         iapManager.isEnabled = !sharedKVStore.bool(forKey: AppPreference.skipsPurchases.key)

--- a/Passepartout/Config.mac.xcconfig
+++ b/Passepartout/Config.mac.xcconfig
@@ -30,4 +30,4 @@ CFG_APP_ID = com.algoritmico.mac.Passepartout
 CFG_ENTITLEMENTS = Passepartout/App/AppMac.entitlements
 CFG_TUNNEL_INFO_PLIST = Passepartout/Tunnel/TunnelMac.plist
 CFG_TUNNEL_ENTITLEMENT = $(CFG_TUNNEL_ENTITLEMENT_BASE)-systemextension
-CFG_SWIFT_FLAGS =
+CFG_SWIFT_FLAGS = "PP_BUILD_MAC"

--- a/Passepartout/Config.mac.xcconfig
+++ b/Passepartout/Config.mac.xcconfig
@@ -30,4 +30,4 @@ CFG_APP_ID = com.algoritmico.mac.Passepartout
 CFG_ENTITLEMENTS = Passepartout/App/AppMac.entitlements
 CFG_TUNNEL_INFO_PLIST = Passepartout/Tunnel/TunnelMac.plist
 CFG_TUNNEL_ENTITLEMENT = $(CFG_TUNNEL_ENTITLEMENT_BASE)-systemextension
-CFG_SWIFT_FLAGS = "PP_BUILD_MAC"
+CFG_SWIFT_FLAGS = "PP_BUILD_MAC PP_BUILD_FREE"

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -38,12 +38,20 @@ extension Dependencies {
     }
 
     func neProtocolCoder() -> NEProtocolCoder {
+#if PP_BUILD_MAC
+        ProviderNEProtocolCoder(
+            tunnelBundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
+            registry: registry,
+            coder: profileCoder(),
+        )
+#else
         KeychainNEProtocolCoder(
             tunnelBundleIdentifier: BundleConfiguration.mainString(for: .tunnelId),
             registry: registry,
             coder: profileCoder(),
             keychain: AppleKeychain(group: BundleConfiguration.mainString(for: .keychainGroupId))
         )
+#endif
     }
 
     func tunnelEnvironment() -> TunnelEnvironment {

--- a/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
+++ b/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
@@ -38,6 +38,11 @@ extension TunnelContext {
             betaChecker: dependencies.betaChecker(),
             productsAtBuild: dependencies.productsAtBuild()
         )
+#if PP_BUILD_MAC
+        iapManager.isEnabled = false
+#else
+        iapManager.isEnabled = !kvStore.bool(forKey: AppPreference.skipsPurchases.key)
+#endif
         let processor = DefaultTunnelProcessor()
         return TunnelContext(
             iapManager: iapManager,

--- a/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
+++ b/Passepartout/Tunnel/Context/TunnelContext+Shared.swift
@@ -38,7 +38,7 @@ extension TunnelContext {
             betaChecker: dependencies.betaChecker(),
             productsAtBuild: dependencies.productsAtBuild()
         )
-#if PP_BUILD_MAC
+#if PP_BUILD_FREE
         iapManager.isEnabled = false
 #else
         iapManager.isEnabled = !kvStore.bool(forKey: AppPreference.skipsPurchases.key)


### PR DESCRIPTION
Introduce the PP_BUILD_MAC conditional to pick different implementations over those unavailable to Developer ID builds and System Extensions:

- Replace keychain encoding with [Network Extension configuration], (https://developer.apple.com/documentation/networkextension/netunnelproviderprotocol/providerconfiguration), because keychain sharing is not possible (sysexs are run by root)
- Skip v2 migrations (MigrationManager)
- Disable unavailable frameworks
  - CloudKit
  - StoreKit

These changes allow for the initial profile management. The UI is not addressed in this PR.