### PR TITLE
WireGuard: Fix uneditable module

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView+Import.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView+Import.swift
@@ -41,6 +41,8 @@ extension WireGuardView {
         @ObservedObject
         var errorHandler: ErrorHandler
 
+        let onImport: (WireGuard.Configuration.Builder?) -> Void
+
         @State
         private var importURL: URL?
 
@@ -88,6 +90,7 @@ private extension WireGuardView.ImportModifier {
                 throw PartoutError(.parsing)
             }
             draft.module.configurationBuilder = module.configuration?.builder()
+            onImport(draft.module.configurationBuilder)
         } catch {
             pp_log(.app, .error, "Unable to import WireGuard configuration: \(error)")
             errorHandler.handle(error, title: draft.module.moduleType.localizedDescription)

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView.swift
@@ -41,7 +41,7 @@ struct WireGuardView: View, ModuleDraftEditing {
     private var paywallReason: PaywallReason?
 
     @State
-    private var configurationViewModel = WireGuardView.ConfigurationView.ViewModel()
+    private var configurationViewModel = ConfigurationView.ViewModel()
 
     @State
     private var isImporting = false

--- a/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/WireGuard/WireGuardView.swift
@@ -41,6 +41,9 @@ struct WireGuardView: View, ModuleDraftEditing {
     private var paywallReason: PaywallReason?
 
     @State
+    private var configurationViewModel = WireGuardView.ConfigurationView.ViewModel()
+
+    @State
     private var isImporting = false
 
     @StateObject
@@ -58,7 +61,13 @@ struct WireGuardView: View, ModuleDraftEditing {
                 draft: draft,
                 impl: impl,
                 isImporting: $isImporting,
-                errorHandler: errorHandler
+                errorHandler: errorHandler,
+                onImport: {
+                    guard let configurationBuilder = $0 else {
+                        return
+                    }
+                    configurationViewModel.load(from: configurationBuilder)
+                }
             ))
             .modifier(PaywallModifier(reason: $paywallReason))
             .withErrorHandler(errorHandler)
@@ -74,11 +83,16 @@ private extension WireGuardView {
         if draft.module.configurationBuilder != nil {
             ModuleImportSection(isImporting: $isImporting)
             ConfigurationView(
-                configuration: $draft.module.configurationBuilder ?? impl.map {
-                    .init(keyGenerator: $0.keyGenerator)
-                } ?? .init(privateKey: ""),
+                draft: draft,
+                viewModel: $configurationViewModel,
                 keyGenerator: impl?.keyGenerator
             )
+            .onLoad {
+                guard let configurationBuilder = draft.module.configurationBuilder else {
+                    return
+                }
+                configurationViewModel.load(from: configurationBuilder)
+            }
         } else {
             ModuleImportSection(isImporting: $isImporting)
         }


### PR DESCRIPTION
Receive view model from parent to apply import without .onChange

Fixes #1357 