### PR TITLE
Restore active profile header on Mac

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileGridView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileGridView.swift
@@ -56,13 +56,11 @@ struct ProfileGridView: View, Routable, TunnelInstallationProviding {
         return ScrollViewReader { scrollProxy in
             ScrollView {
                 VStack(spacing: .zero) {
-#if os(iOS)
                     if !isUITesting && !isSearching && pinsActiveProfile {
                         headerView(scrollProxy: scrollProxy)
                             .padding(.bottom)
                             .unanimated()
                     }
-#endif
                     LazyVGrid(columns: columns) {
                         ForEach(allPreviews, content: profileView)
                             .onDelete { offsets in
@@ -93,30 +91,29 @@ private extension ProfileGridView {
         profileManager.previews
     }
 
-#if os(iOS)
+    // FIXME: #218, move to InstalledProfileView when .multiple
     func headerView(scrollProxy: ScrollViewProxy) -> some View {
-        InstalledProfileView(
-            layout: .grid,
-            profileManager: profileManager,
-            profile: installedProfile,
-            tunnel: tunnel,
-            errorHandler: errorHandler,
-            flow: flow
-        )
-        .contextMenu {
-            installedProfile.map {
+        ForEach(installedProfiles) { profile in
+            InstalledProfileView(
+                layout: .grid,
+                profileManager: profileManager,
+                profile: profile,
+                tunnel: tunnel,
+                errorHandler: errorHandler,
+                flow: flow
+            )
+            .contextMenu {
                 ProfileContextMenu(
                     style: .installedProfile,
                     profileManager: profileManager,
                     tunnel: tunnel,
-                    preview: .init($0),
+                    preview: .init(profile),
                     errorHandler: errorHandler,
                     flow: flow
                 )
             }
         }
     }
-#endif
 
     func profileView(for preview: ProfilePreview) -> some View {
         ProfileRowView(

--- a/Packages/App/Sources/AppUIMain/Views/App/ProfileListView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/ProfileListView.swift
@@ -58,12 +58,10 @@ struct ProfileListView: View, Routable, TunnelInstallationProviding {
     var body: some View {
         debugChanges()
         return Form {
-#if os(iOS)
             if !isUITesting && !isSearching && pinsActiveProfile {
                 headerView
                     .unanimated()
             }
-#endif
             Section {
                 ForEach(allPreviews, content: profileView)
                     .onDelete { offsets in
@@ -86,23 +84,23 @@ private extension ProfileListView {
         profileManager.previews
     }
 
-#if os(iOS)
+    // FIXME: #218, move to InstalledProfileView when .multiple
     var headerView: some View {
-        InstalledProfileView(
-            layout: .list,
-            profileManager: profileManager,
-            profile: installedProfile,
-            tunnel: tunnel,
-            errorHandler: errorHandler,
-            flow: flow
-        )
-        .contextMenu {
-            installedProfile.map {
+        ForEach(installedProfiles) { profile in
+            InstalledProfileView(
+                layout: .list,
+                profileManager: profileManager,
+                profile: profile,
+                tunnel: tunnel,
+                errorHandler: errorHandler,
+                flow: flow
+            )
+            .contextMenu {
                 ProfileContextMenu(
                     style: .installedProfile,
                     profileManager: profileManager,
                     tunnel: tunnel,
-                    preview: .init($0),
+                    preview: .init(profile),
                     errorHandler: errorHandler,
                     flow: flow
                 )
@@ -110,7 +108,6 @@ private extension ProfileListView {
         }
         .modifier(HideActiveProfileModifier())
     }
-#endif
 
     func profileView(for preview: ProfilePreview) -> some View {
         ProfileRowView(

--- a/Packages/App/Sources/CommonLibrary/Domain/AppPreference.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/AppPreference.swift
@@ -33,6 +33,8 @@ public enum AppPreference: String, PreferenceProtocol {
 
     case lastInfrastructureRefresh
 
+    case lastUsedProfileId
+
     case logsPrivateData
 
     public var key: String {

--- a/Packages/App/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/TunnelInstallationProviding+Extensions.swift
@@ -26,14 +26,13 @@
 import CommonLibrary
 import Foundation
 
-#if os(iOS) || os(tvOS)
 @MainActor
 extension TunnelInstallationProviding {
-    public var installedProfile: Profile? {
-        guard let activeProfile = tunnel.activeProfile else {
-            return nil
-        }
-        return profileManager.profile(withId: activeProfile.id)
+    public var installedProfiles: [Profile] {
+        tunnel
+            .activeProfiles
+            .compactMap {
+                profileManager.profile(withId: $0.key)
+            }
     }
 }
-#endif

--- a/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
@@ -68,11 +68,11 @@ public struct PreferencesView: View {
             systemAppearanceSection
 #if os(iOS)
             lockInBackgroundSection
-            pinActiveProfileSection
 #elseif os(macOS)
             launchesOnLoginSection
             keepsInMenuSection
 #endif
+            pinActiveProfileSection
             dnsFallsBackSection
             enablesPurchasesSection
             eraseCloudKitSection
@@ -105,10 +105,6 @@ private extension PreferencesView {
             .themeSectionWithSingleRow(footer: Strings.Views.Preferences.LocksInBackground.footer)
     }
 
-    var pinActiveProfileSection: some View {
-        PinActiveProfileToggle()
-            .themeSectionWithSingleRow(footer: Strings.Views.Preferences.PinsActiveProfile.footer)
-    }
 #elseif os(macOS)
     var launchesOnLoginSection: some View {
         Toggle(Strings.Views.Preferences.launchesOnLogin, isOn: $settings.launchesOnLogin)
@@ -120,6 +116,11 @@ private extension PreferencesView {
             .themeSectionWithSingleRow(footer: Strings.Views.Preferences.KeepsInMenu.footer)
     }
 #endif
+
+    var pinActiveProfileSection: some View {
+        PinActiveProfileToggle()
+            .themeSectionWithSingleRow(footer: Strings.Views.Preferences.PinsActiveProfile.footer)
+    }
 
     var dnsFallsBackSection: some View {
         Toggle(Strings.Views.Preferences.dnsFallsBack, isOn: $dnsFallsBack)

--- a/Passepartout/App/Context/AppContext+Shared.swift
+++ b/Passepartout/App/Context/AppContext+Shared.swift
@@ -135,6 +135,7 @@ extension AppContext {
             tunnel: Tunnel(strategy: tunnelStrategy) {
                 dependencies.appTunnelEnvironment(strategy: tunnelStrategy, profileId: $0)
             },
+            kvStore: localKVStore,
             processor: processor,
             interval: Constants.shared.tunnel.refreshInterval
         )


### PR DESCRIPTION
Revert relevant part of #1368 to keep functionality as is until #218.