### PR TITLE
Fix default value for DNS fallback

### DIFF
--- a/Packages/App/Sources/CommonLibrary/Business/KeyValueManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/KeyValueManager.swift
@@ -89,14 +89,26 @@ extension KeyValueManager {
 
 extension KeyValueManager {
     public func bool(forKey key: String) -> Bool {
-        self[key] as Bool? == true
+        var value = self[key] as Bool?
+        if value == nil {
+            value = fallback[key] as? Bool
+        }
+        return value ?? false
     }
 
     public func integer(forKey key: String) -> Int {
-        self[key] as Int? ?? 0
+        var value = self[key] as Int?
+        if value == nil {
+            value = fallback[key] as? Int
+        }
+        return value ?? 0
     }
 
     public func string(forKey key: String) -> String? {
-        self[key] as String?
+        var value = self[key] as String?
+        if value == nil {
+            value = fallback[key] as? String
+        }
+        return value
     }
 }

--- a/Packages/App/Sources/CommonLibrary/Domain/AppPreference.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/AppPreference.swift
@@ -43,7 +43,7 @@ public enum AppPreference: String, PreferenceProtocol {
 }
 
 public struct AppPreferenceValues: Sendable {
-    public var dnsFallsBack = false
+    public var dnsFallsBack = true
 
     public var skipsPurchases = false
 


### PR DESCRIPTION
Currently false, must default to true. Also, add missing fallback logic to shortcut methods of KeyValueManager.

Regression in #1376