### PR TITLE
Implement target conditionals for Developer ID distribution

### DIFF
--- a/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/AppUIMain.xcscheme
+++ b/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/AppUIMain.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/AppUITV.xcscheme
+++ b/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/AppUITV.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/CommonLibrary.xcscheme
+++ b/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/CommonLibrary.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/Library-Package.xcscheme
+++ b/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/Library-Package.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/TunnelLibrary.xcscheme
+++ b/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/TunnelLibrary.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/UILibrary.xcscheme
+++ b/Packages/App/.swiftpm/xcode/xcshareddata/xcschemes/UILibrary.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/App/Sources/AppUIMain/Extensions/EnvironmentValues+Extensions.swift
+++ b/Packages/App/Sources/AppUIMain/Extensions/EnvironmentValues+Extensions.swift
@@ -23,7 +23,6 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonLibrary
 import SwiftUI
 
 extension EnvironmentValues {

--- a/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -50,7 +50,7 @@ struct AddProfileMenu: View {
             emptyProfileButton
             importProfileButton
             Divider()
-            if distributionTarget.supportsIAP {
+            if distributionTarget.supportsPaidFeatures {
                 providerProfileMenu
                 Divider()
             }

--- a/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -31,6 +31,9 @@ struct AddProfileMenu: View {
     @EnvironmentObject
     private var apiManager: APIManager
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     let profileManager: ProfileManager
 
     let registry: Registry
@@ -47,8 +50,10 @@ struct AddProfileMenu: View {
             emptyProfileButton
             importProfileButton
             Divider()
-            providerProfileMenu
-            Divider()
+            if distributionTarget.supportsIAP {
+                providerProfileMenu
+                Divider()
+            }
             migrateProfilesButton
         } label: {
             ThemeImage(.add)

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
@@ -84,7 +84,7 @@ struct DiagnosticsView: View {
             if distributionTarget.supportsAppGroups {
                 tunnelLogsSection
             }
-            if AppCommandLine.contains(.withReportIssue) || iapManager.isEligibleForFeedback {
+            if canReportIssue {
                 reportIssueSection
             }
         }
@@ -178,6 +178,11 @@ private extension DiagnosticsView {
                 profileManager.profile(withId: $0.id)
             }
             .sorted(by: Profile.sorting)
+    }
+
+    var canReportIssue: Bool {
+        // TODO: ###, remove after stable Developer ID
+        AppCommandLine.contains(.withReportIssue) || iapManager.isEligibleForFeedback || distributionTarget.canReportIssue
     }
 
     func computedTunnelLogs() async -> [LogEntry] {

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
@@ -81,7 +81,9 @@ struct DiagnosticsView: View {
             }
             liveLogSection
             profilesSection
-            tunnelLogsSection
+            if distributionTarget.supportsAppGroups {
+                tunnelLogsSection
+            }
             if AppCommandLine.contains(.withReportIssue) || iapManager.isEligibleForFeedback {
                 reportIssueSection
             }

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
@@ -182,7 +182,7 @@ private extension DiagnosticsView {
 
     var canReportIssue: Bool {
         // TODO: ###, remove after stable Developer ID
-        AppCommandLine.contains(.withReportIssue) || iapManager.isEligibleForFeedback || distributionTarget.canReportIssue
+        AppCommandLine.contains(.withReportIssue) || iapManager.isEligibleForFeedback || distributionTarget.canAlwaysReportIssue
     }
 
     func computedTunnelLogs() async -> [LogEntry] {

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/DiagnosticsView.swift
@@ -50,6 +50,9 @@ struct DiagnosticsView: View {
     @EnvironmentObject
     private var kvStore: KeyValueManager
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     let profileManager: ProfileManager
 
     let tunnel: ExtendedTunnel
@@ -180,9 +183,10 @@ private extension DiagnosticsView {
     }
 
     func defaultTunnelLogs() async -> [LogEntry] {
-        await Task.detached {
+        let target = self.distributionTarget
+        return await Task.detached {
             LocalLogger.FileStrategy()
-                .availableLogs(at: BundleConfiguration.urlForTunnelLog)
+                .availableLogs(at: BundleConfiguration.urlForTunnelLog(in: target))
                 .sorted {
                     $0.key > $1.key
                 }
@@ -209,7 +213,7 @@ private extension DiagnosticsView {
 
     func removeTunnelLogs() {
         LocalLogger.FileStrategy()
-            .purgeLogs(at: BundleConfiguration.urlForTunnelLog)
+            .purgeLogs(at: BundleConfiguration.urlForTunnelLog(in: distributionTarget))
         Task {
             tunnelLogs = await computedTunnelLogs()
         }

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/ReportIssueButton.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/ReportIssueButton.swift
@@ -27,6 +27,10 @@ import CommonLibrary
 import SwiftUI
 
 struct ReportIssueButton {
+
+    @Environment(\.distributionTarget)
+    var distributionTarget: DistributionTarget
+
     let title: String
 
     let tunnel: ExtendedTunnel

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/iOS/ReportIssueButton+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/iOS/ReportIssueButton+iOS.swift
@@ -88,7 +88,7 @@ extension ReportIssueButton {
                 purchasedProducts: purchasedProducts,
                 providerLastUpdates: providerLastUpdates,
                 tunnel: tunnel,
-                urlForTunnelLog: BundleConfiguration.urlForTunnelLog,
+                urlForTunnelLog: BundleConfiguration.urlForTunnelLog(in: distributionTarget),
                 parameters: Constants.shared.log,
                 comment: comment
             ))

--- a/Packages/App/Sources/AppUIMain/Views/Diagnostics/macOS/ReportIssueButton+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Diagnostics/macOS/ReportIssueButton+macOS.swift
@@ -63,7 +63,7 @@ extension ReportIssueButton {
                 purchasedProducts: purchasedProducts,
                 providerLastUpdates: providerLastUpdates,
                 tunnel: tunnel,
-                urlForTunnelLog: BundleConfiguration.urlForTunnelLog,
+                urlForTunnelLog: BundleConfiguration.urlForTunnelLog(in: distributionTarget),
                 parameters: Constants.shared.log,
                 comment: comment
             ))

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
@@ -32,6 +32,9 @@ struct OnDemandView: View, ModuleDraftEditing {
     @EnvironmentObject
     private var theme: Theme
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     @ObservedObject
     var draft: ModuleDraft<OnDemandModule.Builder>
 
@@ -59,11 +62,13 @@ struct OnDemandView: View, ModuleDraftEditing {
 }
 
 private extension OnDemandView {
-    static let allPolicies: [OnDemandModule.Policy] = [
-        .any,
-        .excluding,
-        .including
-    ]
+    var allPolicies: [OnDemandModule.Policy] {
+        if distributionTarget.supportsIAP {
+            return [.any, .excluding, .including]
+        } else {
+            return [.any]
+        }
+    }
 
     @ViewBuilder
     var rulesArea: some View {
@@ -76,7 +81,7 @@ private extension OnDemandView {
 
     var policySection: some View {
         Picker(selection: $draft.module.policy) {
-            ForEach(Self.allPolicies, id: \.self) {
+            ForEach(allPolicies, id: \.self) {
                 Text($0.localizedDescription)
             }
         } label: {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/OnDemandView.swift
@@ -63,7 +63,7 @@ struct OnDemandView: View, ModuleDraftEditing {
 
 private extension OnDemandView {
     var allPolicies: [OnDemandModule.Policy] {
-        if distributionTarget.supportsIAP {
+        if distributionTarget.supportsPaidFeatures {
             return [.any, .excluding, .including]
         } else {
             return [.any]

--- a/Packages/App/Sources/AppUIMain/Views/Profile/AddModuleMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/AddModuleMenu.swift
@@ -33,6 +33,8 @@ import SwiftUI
 struct AddModuleMenu<Label>: View where Label: View {
     let moduleTypes: [ModuleType]
 
+    let withProviderType: Bool
+
     let action: (ModuleType) -> Void
 
     let label: () -> Label
@@ -43,7 +45,9 @@ struct AddModuleMenu<Label>: View where Label: View {
         let connectionModuleTypes = nonProviderTypes.filter(\.isConnection)
         let otherModuleTypes = nonProviderTypes.filter { !$0.isConnection }
         return Menu {
-            entryView(for: providerType)
+            if withProviderType {
+                entryView(for: providerType)
+            }
             if !connectionModuleTypes.isEmpty {
                 ForEach(connectionModuleTypes.sorted(), id: \.self, content: entryView)
                     .themeSection(header: Strings.Global.Nouns.connection)
@@ -71,6 +75,7 @@ private extension AddModuleMenu {
     List {
         AddModuleMenu(
             moduleTypes: ModuleType.allCases,
+            withProviderType: true,
             action: { _ in },
             label: {
                 Text("Add module")

--- a/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -30,6 +30,10 @@ import CommonUtils
 import SwiftUI
 
 struct ProfileEditView: View, Routable {
+
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     let profileManager: ProfileManager
 
     @ObservedObject
@@ -132,7 +136,10 @@ private extension ProfileEditView {
     }
 
     var addModuleMenu: some View {
-        AddModuleMenu(moduleTypes: profileEditor.availableModuleTypes) {
+        AddModuleMenu(
+            moduleTypes: availableTypes,
+            withProviderType: distributionTarget.supportsIAP
+        ) {
             flow?.onNewModule($0)
         } label: {
             Text(Strings.Views.Profile.Rows.addModule)
@@ -141,6 +148,10 @@ private extension ProfileEditView {
 }
 
 private extension ProfileEditView {
+    var availableTypes: [ModuleType] {
+        profileEditor.availableModuleTypes(forTarget: distributionTarget)
+    }
+
     func moveModules(from offsets: IndexSet, to newOffset: Int) {
         profileEditor.moveModules(from: offsets, to: newOffset)
     }

--- a/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/iOS/ProfileEditView+iOS.swift
@@ -138,7 +138,7 @@ private extension ProfileEditView {
     var addModuleMenu: some View {
         AddModuleMenu(
             moduleTypes: availableTypes,
-            withProviderType: distributionTarget.supportsIAP
+            withProviderType: distributionTarget.supportsPaidFeatures
         ) {
             flow?.onNewModule($0)
         } label: {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -126,7 +126,7 @@ private extension ModuleListView {
     var addModuleMenu: some View {
         AddModuleMenu(
             moduleTypes: availableTypes,
-            withProviderType: distributionTarget.supportsIAP
+            withProviderType: distributionTarget.supportsPaidFeatures
         ) {
             flow?.onNewModule($0)
         } label: {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -39,6 +39,9 @@ struct ModuleListView: View, Routable {
     @Environment(\.isUITesting)
     private var isUITesting
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     @ObservedObject
     var profileEditor: ProfileEditor
 
@@ -121,7 +124,10 @@ private extension ModuleListView {
     }
 
     var addModuleMenu: some View {
-        AddModuleMenu(moduleTypes: profileEditor.availableModuleTypes) {
+        AddModuleMenu(
+            moduleTypes: availableTypes,
+            withProviderType: distributionTarget.supportsIAP
+        ) {
             flow?.onNewModule($0)
         } label: {
             ThemeImage(.add)
@@ -130,6 +136,10 @@ private extension ModuleListView {
 }
 
 private extension ModuleListView {
+    var availableTypes: [ModuleType] {
+        profileEditor.availableModuleTypes(forTarget: distributionTarget)
+    }
+
     var requiredGeneralFeatures: Set<AppFeature> {
         var features: Set<AppFeature> = []
         if profileEditor.isShared {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileGeneralView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ProfileGeneralView+macOS.swift
@@ -29,6 +29,10 @@ import CommonLibrary
 import SwiftUI
 
 struct ProfileGeneralView: View {
+
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     let profileManager: ProfileManager
 
     @ObservedObject
@@ -44,10 +48,12 @@ struct ProfileGeneralView: View {
         Form {
             ProfileNameSection(name: $profileEditor.profile.name)
             profileEditor.shortcutsSections(path: $path)
-            ProfileStorageSection(
-                profileEditor: profileEditor,
-                paywallReason: $paywallReason
-            )
+            if distributionTarget.supportsCloudKit {
+                ProfileStorageSection(
+                    profileEditor: profileEditor,
+                    paywallReason: $paywallReason
+                )
+            }
             ProfileBehaviorSection(profileEditor: profileEditor)
             ProfileActionsSection(
                 profileManager: profileManager,

--- a/Packages/App/Sources/AppUIMain/Views/Settings/SettingsCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/SettingsCoordinator.swift
@@ -69,25 +69,18 @@ extension SettingsCoordinator {
         switch route {
         case .changelog:
             Strings.Unlocalized.changelog
-
         case .credits:
             Strings.Views.Settings.Credits.title
-
         case .diagnostics:
             Strings.Views.Diagnostics.title
-
         case .donate:
             Strings.Views.Donate.title
-
         case .links:
             Strings.Views.Settings.Links.title
-
         case .preferences:
             Strings.Global.Nouns.preferences
-
         case .purchased:
             Strings.Global.Nouns.purchases
-
         case .version:
             Strings.Views.Settings.title
         }

--- a/Packages/App/Sources/AppUIMain/Views/Settings/iOS/SettingsContentView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/iOS/SettingsContentView+iOS.swift
@@ -73,7 +73,7 @@ private extension SettingsContentView {
                 linkContent(.version)
                 linkContent(.links)
                 linkContent(.credits)
-                if !isBeta {
+                if !isBeta && distributionTarget.supportsIAP {
                     linkContent(.donate)
                 }
             }

--- a/Packages/App/Sources/AppUIMain/Views/Settings/iOS/SettingsContentView+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/iOS/SettingsContentView+iOS.swift
@@ -31,6 +31,9 @@ import UILibrary
 
 struct SettingsContentView<LinkContent, SettingsDestination, LogDestination>: View where LinkContent: View, SettingsDestination: View, LogDestination: View {
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     @Environment(\.dismiss)
     private var dismiss
 
@@ -78,7 +81,9 @@ private extension SettingsContentView {
 
             Group {
                 linkContent(.diagnostics)
-                linkContent(.purchased)
+                if distributionTarget.supportsIAP {
+                    linkContent(.purchased)
+                }
             }
             .themeSection(header: Strings.Global.Nouns.troubleshooting)
         }

--- a/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
@@ -83,7 +83,7 @@ private extension SettingsContentView {
                 linkContent(.version)
                 linkContent(.links)
                 linkContent(.credits)
-                if !isBeta {
+                if !isBeta && distributionTarget.supportsIAP {
                     linkContent(.donate)
                 }
             }

--- a/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
@@ -30,8 +30,8 @@ import SwiftUI
 
 struct SettingsContentView<LinkContent, SettingsDestination, DiagnosticsDestination>: View where LinkContent: View, SettingsDestination: View, DiagnosticsDestination: View {
 
-    @EnvironmentObject
-    private var theme: Theme
+    @Environment(\.distributionTarget)
+    private var distributionTarget
 
     @Environment(\.dismiss)
     private var dismiss
@@ -91,7 +91,9 @@ private extension SettingsContentView {
 
             Group {
                 linkContent(.diagnostics)
-                linkContent(.purchased)
+                if distributionTarget.supportsIAP {
+                    linkContent(.purchased)
+                }
             }
             .themeSection(header: Strings.Global.Nouns.troubleshooting)
         }

--- a/Packages/App/Sources/CommonLibrary/Domain/AppError.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/AppError.swift
@@ -54,5 +54,7 @@ public enum AppError: Error {
 extension PartoutError.Code {
     public enum App {
         public static let ineligibleProfile = PartoutError.Code("App.ineligibleProfile")
+
+        public static let multipleTunnels = PartoutError.Code("App.multipleTunnels")
     }
 }

--- a/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
@@ -32,8 +32,21 @@ extension BundleConfiguration {
         urlForCaches.appending(path: Constants.shared.log.appPath)
     }
 
-    public static var urlForTunnelLog: URL {
-        urlForCaches.appending(path: Constants.shared.log.tunnelPath)
+    public static func urlForTunnelLog(in target: DistributionTarget) -> URL {
+        let baseURL: URL
+        switch target {
+        case .standard, .enterprise:
+            baseURL = urlForCaches
+        case .developerID:
+            let fm: FileManager = .default
+            baseURL = fm.temporaryDirectory
+            do {
+                try fm.createDirectory(at: baseURL, withIntermediateDirectories: true)
+            } catch {
+                pp_log_g(.app, .error, "Unable to create temporary directory \(baseURL): \(error)")
+            }
+        }
+        return baseURL.appending(path: Constants.shared.log.tunnelPath)
     }
 }
 

--- a/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+AppGroup.swift
@@ -34,10 +34,9 @@ extension BundleConfiguration {
 
     public static func urlForTunnelLog(in target: DistributionTarget) -> URL {
         let baseURL: URL
-        switch target {
-        case .standard, .enterprise:
+        if target.supportsAppGroups {
             baseURL = urlForCaches
-        case .developerID:
+        } else {
             let fm: FileManager = .default
             baseURL = fm.temporaryDirectory
             do {

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -36,6 +36,10 @@ public enum DistributionTarget: Sendable {
 }
 
 extension DistributionTarget {
+    public var canReportIssue: Bool {
+        self == .developerID
+    }
+
     public var supportsAppGroups: Bool {
         self != .developerID
     }

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -32,3 +32,17 @@ public enum DistributionTarget: Sendable {
 
     case enterprise
 }
+
+extension DistributionTarget {
+    public var supportsAppGroups: Bool {
+        self != .developerID
+    }
+
+    public var supportsCloudKit: Bool {
+        self != .developerID
+    }
+
+    public var supportsIAP: Bool {
+        [.standard, .enterprise].contains(self)
+    }
+}

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -1,8 +1,8 @@
 //
-//  EnvironmentValues+Extensions.swift
+//  DistributionTarget.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 10/23/24.
+//  Created by Davide De Rosa on 5/21/25.
 //  Copyright (c) 2025 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,33 +23,12 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonLibrary
-import SwiftUI
+import Foundation
 
-extension EnvironmentValues {
-    var navigationPath: Binding<NavigationPath> {
-        get {
-            self[NavigationPathKey.self]
-        }
-        set {
-            self[NavigationPathKey.self] = newValue
-        }
-    }
+public enum DistributionTarget: Sendable {
+    case standard
 
-    var dismissProfile: () -> Void {
-        get {
-            self[DismissProfileKey.self]
-        }
-        set {
-            self[DismissProfileKey.self] = newValue
-        }
-    }
-}
+    case developerID
 
-private struct NavigationPathKey: EnvironmentKey {
-    static let defaultValue: Binding<NavigationPath> = .constant(NavigationPath())
-}
-
-private struct DismissProfileKey: EnvironmentKey {
-    static let defaultValue: () -> Void = {}
+    case enterprise
 }

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -51,6 +51,15 @@ extension DistributionTarget {
         self == .appStore
     }
 
+    // differs from !supportsIAP because:
+    //
+    // - .appStore supports paid features and IAP
+    // - .enterprise supports paid features but not IAP
+    // - .developerID supports neither
+    public var supportsPaidFeatures: Bool {
+        self != .developerID
+    }
+
     public var supportsV2Migration: Bool {
         self == .appStore
     }

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -47,4 +47,12 @@ extension DistributionTarget {
     public var supportsIAP: Bool {
         [.standard, .enterprise].contains(self)
     }
+
+    public var supportsV2Migration: Bool {
+        self == .standard
+    }
+
+    public var usesExperimentalPOSIXResolver: Bool {
+        self == .developerID
+    }
 }

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -26,11 +26,13 @@
 import Foundation
 
 public enum DistributionTarget: Sendable {
-    case standard
-
     case developerID
 
     case enterprise
+
+    case free
+
+    case standard
 }
 
 extension DistributionTarget {

--- a/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/DistributionTarget.swift
@@ -26,18 +26,17 @@
 import Foundation
 
 public enum DistributionTarget: Sendable {
+    case appStore
+
     case developerID
 
+    // TODO: ###, behave like .complete when this is implemented
     case enterprise
-
-    case free
-
-    case standard
 }
 
 extension DistributionTarget {
-    public var canReportIssue: Bool {
-        self == .developerID
+    public var canAlwaysReportIssue: Bool {
+        self != .appStore
     }
 
     public var supportsAppGroups: Bool {
@@ -49,11 +48,11 @@ extension DistributionTarget {
     }
 
     public var supportsIAP: Bool {
-        [.standard, .enterprise].contains(self)
+        self == .appStore
     }
 
     public var supportsV2Migration: Bool {
-        self == .standard
+        self == .appStore
     }
 
     public var usesExperimentalPOSIXResolver: Bool {

--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
@@ -29,7 +29,7 @@ extension PartoutLogger {
     public enum Target {
         case app
 
-        case tunnel(Profile.ID)
+        case tunnel(Profile.ID, DistributionTarget)
     }
 
     private static var isRegistered = false
@@ -49,8 +49,8 @@ extension PartoutLogger {
             PartoutLogger.register(logger)
             logger.logPreamble(parameters: Constants.shared.log)
             return .global
-        case .tunnel(let profileId):
-            let logger = tunnelLogger(preferences: preferences)
+        case .tunnel(let profileId, let target):
+            let logger = tunnelLogger(preferences: preferences, target: target)
             PartoutLogger.register(logger)
             logger.logPreamble(parameters: Constants.shared.log)
             return PartoutLoggerContext(profileId)
@@ -69,10 +69,10 @@ private extension PartoutLogger {
         return builder.build()
     }
 
-    static func tunnelLogger(preferences: AppPreferenceValues) -> PartoutLogger {
+    static func tunnelLogger(preferences: AppPreferenceValues, target: DistributionTarget) -> PartoutLogger {
         var builder = PartoutLogger.Builder()
         builder.configureLogging(
-            to: BundleConfiguration.urlForTunnelLog,
+            to: BundleConfiguration.urlForTunnelLog(in: target),
             parameters: Constants.shared.log,
             logsPrivateData: preferences.logsPrivateData
         )

--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
@@ -32,17 +32,11 @@ extension PartoutLogger {
         case tunnel(Profile.ID, DistributionTarget)
     }
 
-    private static var isRegistered = false
-
     @discardableResult
     public static func register(
         for target: Target,
         with preferences: AppPreferenceValues
     ) -> PartoutLoggerContext {
-        guard !isRegistered else {
-            fatalError("Registering target multiple times: \(target)")
-        }
-        isRegistered = true
         switch target {
         case .app:
             let logger = appLogger(preferences: preferences)

--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
@@ -32,6 +32,8 @@ extension PartoutLogger {
         case tunnel(Profile.ID, DistributionTarget)
     }
 
+    private static var isDefaultLoggerRegistered = false
+
     @discardableResult
     public static func register(
         for target: Target,
@@ -39,14 +41,20 @@ extension PartoutLogger {
     ) -> PartoutLoggerContext {
         switch target {
         case .app:
-            let logger = appLogger(preferences: preferences)
-            PartoutLogger.register(logger)
-            logger.logPreamble(parameters: Constants.shared.log)
+            if !isDefaultLoggerRegistered {
+                isDefaultLoggerRegistered = true
+                let logger = appLogger(preferences: preferences)
+                PartoutLogger.register(logger)
+                logger.logPreamble(parameters: Constants.shared.log)
+            }
             return .global
         case .tunnel(let profileId, let target):
-            let logger = tunnelLogger(preferences: preferences, target: target)
-            PartoutLogger.register(logger)
-            logger.logPreamble(parameters: Constants.shared.log)
+            if !isDefaultLoggerRegistered {
+                isDefaultLoggerRegistered = true
+                let logger = tunnelLogger(preferences: preferences, target: target)
+                PartoutLogger.register(logger)
+                logger.logPreamble(parameters: Constants.shared.log)
+            }
             return PartoutLoggerContext(profileId)
         }
     }

--- a/Packages/App/Sources/UILibrary/Business/AppContext.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppContext.swift
@@ -35,6 +35,8 @@ public final class AppContext: ObservableObject, Sendable {
 
     public let appearanceManager: AppearanceManager
 
+    public let distributionTarget: DistributionTarget
+
     public let iapManager: IAPManager
 
     public let kvStore: KeyValueManager
@@ -61,6 +63,7 @@ public final class AppContext: ObservableObject, Sendable {
 
     public init(
         apiManager: APIManager,
+        distributionTarget: DistributionTarget,
         iapManager: IAPManager,
         kvStore: KeyValueManager,
         migrationManager: MigrationManager,
@@ -73,6 +76,7 @@ public final class AppContext: ObservableObject, Sendable {
     ) {
         self.apiManager = apiManager
         appearanceManager = AppearanceManager(kvStore: kvStore)
+        self.distributionTarget = distributionTarget
         self.iapManager = iapManager
         self.kvStore = kvStore
         self.migrationManager = migrationManager

--- a/Packages/App/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Packages/App/Sources/UILibrary/Business/ProfileEditor.swift
@@ -68,9 +68,14 @@ extension ProfileEditor {
             .map(\.moduleType)
     }
 
-    public var availableModuleTypes: [ModuleType] {
-        ModuleType
-            .allCases
+    public func availableModuleTypes(forTarget target: DistributionTarget) -> [ModuleType] {
+        let types: [ModuleType]
+        if target.supportsIAP {
+            types = ModuleType.allCases
+        } else {
+            types = [.onDemand, .openVPN, .wireGuard]
+        }
+        return types
             .filter {
                 !moduleTypes.contains($0)
             }

--- a/Packages/App/Sources/UILibrary/Business/ProfileEditor.swift
+++ b/Packages/App/Sources/UILibrary/Business/ProfileEditor.swift
@@ -70,7 +70,7 @@ extension ProfileEditor {
 
     public func availableModuleTypes(forTarget target: DistributionTarget) -> [ModuleType] {
         let types: [ModuleType]
-        if target.supportsIAP {
+        if target.supportsPaidFeatures {
             types = ModuleType.allCases
         } else {
             types = [.onDemand, .openVPN, .wireGuard]

--- a/Packages/App/Sources/UILibrary/Extensions/EnvironmentValues+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/EnvironmentValues+Extensions.swift
@@ -51,5 +51,5 @@ private struct IsUITestingKey: EnvironmentKey {
 }
 
 private struct DistributionTargetKey: EnvironmentKey {
-    static let defaultValue: DistributionTarget = .standard
+    static let defaultValue: DistributionTarget = .appStore
 }

--- a/Packages/App/Sources/UILibrary/Extensions/EnvironmentValues+Extensions.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/EnvironmentValues+Extensions.swift
@@ -23,6 +23,7 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import SwiftUI
 
 extension EnvironmentValues {
@@ -34,8 +35,21 @@ extension EnvironmentValues {
             self[IsUITestingKey.self] = newValue
         }
     }
+
+    public var distributionTarget: DistributionTarget {
+        get {
+            self[DistributionTargetKey.self]
+        }
+        set {
+            self[DistributionTargetKey.self] = newValue
+        }
+    }
 }
 
 private struct IsUITestingKey: EnvironmentKey {
     static let defaultValue = false
+}
+
+private struct DistributionTargetKey: EnvironmentKey {
+    static let defaultValue: DistributionTarget = .standard
 }

--- a/Packages/App/Sources/UILibrary/Extensions/View+Environment.swift
+++ b/Packages/App/Sources/UILibrary/Extensions/View+Environment.swift
@@ -31,6 +31,7 @@ extension View {
         environmentObject(theme)
             .environmentObject(context.apiManager)
             .environmentObject(context.appearanceManager)
+            .environment(\.distributionTarget, context.distributionTarget)
             .environmentObject(context.iapManager)
             .environmentObject(context.kvStore)
             .environmentObject(context.migrationManager)

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -65,7 +65,7 @@ extension AppContext {
         let migrationManager = MigrationManager()
         let preferencesManager = PreferencesManager()
         let registry = Registry()
-        let distributionTarget: DistributionTarget = .standard
+        let distributionTarget: DistributionTarget = .appStore
         return AppContext(
             apiManager: apiManager,
             distributionTarget: distributionTarget,

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -65,8 +65,10 @@ extension AppContext {
         let migrationManager = MigrationManager()
         let preferencesManager = PreferencesManager()
         let registry = Registry()
+        let distributionTarget: DistributionTarget = .standard
         return AppContext(
             apiManager: apiManager,
+            distributionTarget: distributionTarget,
             iapManager: iapManager,
             kvStore: kvStore,
             migrationManager: migrationManager,

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -42,6 +42,9 @@ public struct OpenVPNCredentialsGroup: View {
     @EnvironmentObject
     private var apiManager: APIManager
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     @ObservedObject
     private var draft: ModuleDraft<OpenVPNModule.Builder>
 
@@ -99,7 +102,7 @@ private extension OpenVPNCredentialsGroup {
             }
             .themeRowWithSubtitle(interactiveFooter)
 
-            if draft.module.isInteractive && !isAuthenticating {
+            if distributionTarget.supportsIAP && draft.module.isInteractive && !isAuthenticating {
                 Picker(Strings.Unlocalized.otp, selection: $builder.otpMethod) {
                     ForEach(otpMethods, id: \.self) {
                         Text($0.localizedDescription(style: .entity))
@@ -190,7 +193,6 @@ private extension OpenVPNCredentialsGroup {
             switch builder.otpMethod {
             case .none:
                 focusedField = .username
-
             default:
                 focusedField = .otp
             }

--- a/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
+++ b/Packages/App/Sources/UILibrary/Views/Modules/OpenVPNView+Credentials.swift
@@ -102,7 +102,7 @@ private extension OpenVPNCredentialsGroup {
             }
             .themeRowWithSubtitle(interactiveFooter)
 
-            if distributionTarget.supportsIAP && draft.module.isInteractive && !isAuthenticating {
+            if distributionTarget.supportsPaidFeatures && draft.module.isInteractive && !isAuthenticating {
                 Picker(Strings.Unlocalized.otp, selection: $builder.otpMethod) {
                     ForEach(otpMethods, id: \.self) {
                         Text($0.localizedDescription(style: .entity))

--- a/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
@@ -48,6 +48,9 @@ public struct PreferencesView: View {
     private var settings: MacSettingsModel
 #endif
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     private let profileManager: ProfileManager
 
     @State
@@ -74,7 +77,9 @@ public struct PreferencesView: View {
 #endif
             pinActiveProfileSection
             dnsFallsBackSection
-            enablesPurchasesSection
+            if distributionTarget.supportsIAP {
+                enablesPurchasesSection
+            }
             eraseCloudKitSection
         }
         .themeKeyValue(kvStore, AppPreference.dnsFallsBack.key, $dnsFallsBack, default: true)

--- a/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Preferences/PreferencesView.swift
@@ -80,7 +80,9 @@ public struct PreferencesView: View {
             if distributionTarget.supportsIAP {
                 enablesPurchasesSection
             }
-            eraseCloudKitSection
+            if distributionTarget.supportsCloudKit {
+                eraseCloudKitSection
+            }
         }
         .themeKeyValue(kvStore, AppPreference.dnsFallsBack.key, $dnsFallsBack, default: true)
         .themeForm()

--- a/Packages/App/Sources/UILibrary/Views/Settings/LinksView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/LinksView.swift
@@ -31,6 +31,9 @@ public struct LinksView: View {
     @EnvironmentObject
     private var iapManager: IAPManager
 
+    @Environment(\.distributionTarget)
+    private var distributionTarget
+
     public init() {
     }
 
@@ -59,6 +62,9 @@ private extension LinksView {
             Link(Strings.Views.Settings.Links.Rows.openDiscussion, destination: constants.github.discussions)
             if iapManager.isPayingUser {
                 Link(Strings.Views.Settings.Links.Rows.writeReview, destination: BundleConfiguration.urlForReview)
+            }
+            if !iapManager.isBeta && !distributionTarget.supportsIAP {
+                WebDonationLink()
             }
         }
         .themeSection(header: Strings.Views.Settings.Links.Sections.support)

--- a/Packages/App/Sources/UILibrary/Views/Settings/WebDonationLink.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/WebDonationLink.swift
@@ -1,0 +1,33 @@
+//
+//  WebDonationLink.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/21/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import SwiftUI
+
+struct WebDonationLink: View {
+    var body: some View {
+        Link(Strings.Views.Donate.title, destination: Constants.shared.websites.donate)
+    }
+}

--- a/Packages/App/Tests/UILibraryTests/ProfileEditorTests.swift
+++ b/Packages/App/Tests/UILibraryTests/ProfileEditorTests.swift
@@ -70,7 +70,7 @@ extension ProfileEditorTests {
             DNSModule.Builder(),
             IPModule.Builder()
         ])
-        let moduleTypes = sut.availableModuleTypes
+        let moduleTypes = sut.availableModuleTypes(forTarget: .appStore)
 
         XCTAssertFalse(moduleTypes.contains(.dns))
         XCTAssertTrue(moduleTypes.contains(.httpProxy))

--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -630,7 +630,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1630;
-				LastUpgradeCheck = 1610;
+				LastUpgradeCheck = 1630;
 				TargetAttributes = {
 					0E06D18E2B87629100176E1D = {
 						CreatedOnToolsVersion = 15.2;
@@ -1029,6 +1029,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				REGISTER_APP_GROUPS = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1104,6 +1105,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				REGISTER_APP_GROUPS = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1217,7 +1219,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Passepartout/LoginItem/LoginItem.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(TARGET_NAME)";
 				INFOPLIST_KEY_LSBackgroundOnly = YES;
@@ -1238,7 +1239,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Passepartout/LoginItem/LoginItem.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(TARGET_NAME)";
 				INFOPLIST_KEY_LSBackgroundOnly = YES;
@@ -1346,6 +1346,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				REGISTER_APP_GROUPS = YES;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1416,7 +1417,6 @@
 				CODE_SIGN_ENTITLEMENTS = Passepartout/LoginItem/LoginItem.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(TARGET_NAME)";
 				INFOPLIST_KEY_LSBackgroundOnly = YES;
@@ -1469,7 +1469,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Passepartout/Tunnel/Tunnel.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(CFG_TUNNEL_INFO_PLIST)";
@@ -1484,7 +1483,6 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(CFG_TUNNEL_ID)";
 				PROVISIONING_PROFILE_SPECIFIER = "Passepartout DMG Tunnel";
-				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
@@ -1591,7 +1589,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Passepartout/Tunnel/Tunnel.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(CFG_TUNNEL_INFO_PLIST)";
@@ -1606,7 +1603,6 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(CFG_TUNNEL_ID)";
 				PROVISIONING_PROFILE_SPECIFIER = "Passepartout DMG Tunnel";
-				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
@@ -1620,7 +1616,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Passepartout/Tunnel/Tunnel.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
-				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "$(CFG_TUNNEL_INFO_PLIST)";
@@ -1635,7 +1630,6 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(CFG_TUNNEL_ID)";
 				PROVISIONING_PROFILE_SPECIFIER = "Passepartout DMG Tunnel";
-				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/Passepartout.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/Passepartout.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutIntents.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutIntents.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutLoginItem.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutLoginItem.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutTests.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "1630"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutTunnel.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutTunnel.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutUITests.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1610"
+   LastUpgradeVersion = "1630"
    version = "2.1">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -36,7 +36,12 @@ final class AppDelegate: NSObject {
             store: UserDefaultsStore(.standard),
             fallback: AppPreferenceValues()
         )
-        let ctx = PartoutLogger.register(for: .app, with: kvStore.preferences)
+        let ctx: PartoutLoggerContext
+        do {
+            ctx = try PartoutLogger.register(for: .app, with: kvStore.preferences)
+        } catch {
+            fatalError("Starting multiple app processes? \(error)")
+        }
         if AppCommandLine.contains(.uiTesting) {
             pp_log_g(.app, .info, "UI tests: mock AppContext")
             return .forUITesting

--- a/Passepartout/App/Context/AppContext+Production.swift
+++ b/Passepartout/App/Context/AppContext+Production.swift
@@ -42,6 +42,7 @@ extension AppContext {
 
         let dependencies: Dependencies = .shared
         let constants: Constants = .shared
+        let distributionTarget = dependencies.distributionTarget
 
         // MARK: Core Data
 
@@ -93,11 +94,11 @@ extension AppContext {
             betaChecker: dependencies.betaChecker(),
             productsAtBuild: dependencies.productsAtBuild()
         )
-#if PP_BUILD_FREE
-        iapManager.isEnabled = false
-#else
-        iapManager.isEnabled = !kvStore.bool(forKey: AppPreference.skipsPurchases.key)
-#endif
+        if distributionTarget.supportsIAP {
+            iapManager.isEnabled = !kvStore.bool(forKey: AppPreference.skipsPurchases.key)
+        } else {
+            iapManager.isEnabled = false
+        }
         let processor = dependencies.appProcessor(
             apiManager: apiManager,
             iapManager: iapManager,
@@ -236,7 +237,7 @@ extension AppContext {
 
         self.init(
             apiManager: apiManager,
-            distributionTarget: dependencies.distributionTarget,
+            distributionTarget: distributionTarget,
             iapManager: iapManager,
             kvStore: kvStore,
             migrationManager: migrationManager,

--- a/Passepartout/App/Context/AppContext+Production.swift
+++ b/Passepartout/App/Context/AppContext+Production.swift
@@ -236,6 +236,7 @@ extension AppContext {
 
         self.init(
             apiManager: apiManager,
+            distributionTarget: dependencies.distributionTarget,
             iapManager: iapManager,
             kvStore: kvStore,
             migrationManager: migrationManager,

--- a/Passepartout/App/Context/AppContext+Production.swift
+++ b/Passepartout/App/Context/AppContext+Production.swift
@@ -41,8 +41,8 @@ extension AppContext {
         // MARK: Declare globals
 
         let dependencies: Dependencies = .shared
+        let distributionTarget = Dependencies.distributionTarget
         let constants: Constants = .shared
-        let distributionTarget = dependencies.distributionTarget
 
         // MARK: Core Data
 
@@ -65,13 +65,13 @@ extension AppContext {
             cloudKitIdentifier: nil,
             author: nil
         )
-        let newRemoteStore: (_ cloudKit: Bool) -> CoreDataPersistentStore = {
+        let newRemoteStore: (_ cloudKit: Bool) -> CoreDataPersistentStore = { isEnabled in
             let cloudKitIdentifier: String?
-#if PP_BUILD_MAC
-            cloudKitIdentifier = nil
-#else
-            cloudKitIdentifier = $0 ? BundleConfiguration.mainString(for: .cloudKitId) : nil
-#endif
+            if isEnabled && distributionTarget.supportsCloudKit {
+                cloudKitIdentifier = BundleConfiguration.mainString(for: .cloudKitId)
+            } else {
+                cloudKitIdentifier = nil
+            }
             return CoreDataPersistentStore(
                 logger: dependencies.coreDataLogger(),
                 containerName: constants.containers.remote,
@@ -147,34 +147,35 @@ extension AppContext {
             interval: constants.tunnel.refreshInterval
         )
 
-#if PP_BUILD_MAC
-        let migrationManager = MigrationManager()
-#else
-        let migrationManager: MigrationManager = {
-            let profileStrategy = ProfileV2MigrationStrategy(
-                coreDataLogger: dependencies.coreDataLogger(),
-                profilesContainer: .init(
-                    constants.containers.legacyV2,
-                    BundleConfiguration.mainString(for: .legacyV2CloudKitId)
-                ),
-                tvProfilesContainer: .init(
-                    constants.containers.legacyV2TV,
-                    BundleConfiguration.mainString(for: .legacyV2TVCloudKitId)
+        let migrationManager: MigrationManager
+        if distributionTarget.supportsV2Migration {
+            migrationManager = {
+                let profileStrategy = ProfileV2MigrationStrategy(
+                    coreDataLogger: dependencies.coreDataLogger(),
+                    profilesContainer: .init(
+                        constants.containers.legacyV2,
+                        BundleConfiguration.mainString(for: .legacyV2CloudKitId)
+                    ),
+                    tvProfilesContainer: .init(
+                        constants.containers.legacyV2TV,
+                        BundleConfiguration.mainString(for: .legacyV2TVCloudKitId)
+                    )
                 )
-            )
-            let migrationSimulation: MigrationManager.Simulation?
-            if AppCommandLine.contains(.fakeMigration) {
-                migrationSimulation = MigrationManager.Simulation(
-                    fakeProfiles: true,
-                    maxMigrationTime: 3.0,
-                    randomFailures: true
-                )
-            } else {
-                migrationSimulation = nil
-            }
-            return MigrationManager(profileStrategy: profileStrategy, simulation: migrationSimulation)
-        }()
-#endif
+                let migrationSimulation: MigrationManager.Simulation?
+                if AppCommandLine.contains(.fakeMigration) {
+                    migrationSimulation = MigrationManager.Simulation(
+                        fakeProfiles: true,
+                        maxMigrationTime: 3.0,
+                        randomFailures: true
+                    )
+                } else {
+                    migrationSimulation = nil
+                }
+                return MigrationManager(profileStrategy: profileStrategy, simulation: migrationSimulation)
+            }()
+        } else {
+            migrationManager = MigrationManager()
+        }
 
         let onboardingManager = OnboardingManager(kvStore: kvStore)
         let preferencesManager = PreferencesManager()
@@ -188,30 +189,31 @@ extension AppContext {
             // toggle CloudKit sync based on .sharing eligibility
             let remoteStore = newRemoteStore(isRemoteImportingEnabled)
 
-#if !PP_BUILD_MAC
-            // @Published
-            profileManager.isRemoteImportingEnabled = isRemoteImportingEnabled
+            if distributionTarget.supportsCloudKit {
 
-            do {
-                pp_log(ctx, .app, .info, "\tRefresh remote sync (eligible=\(isEligibleForSharing), CloudKit=\(AppContext.isCloudKitEnabled))...")
+                // @Published
+                profileManager.isRemoteImportingEnabled = isRemoteImportingEnabled
 
-                pp_log(ctx, .App.profiles, .info, "\tRefresh remote profiles repository (sync=\(isRemoteImportingEnabled))...")
-                try await profileManager.observeRemote(repository: {
-                    AppData.cdProfileRepositoryV3(
-                        registry: dependencies.registry,
-                        coder: dependencies.profileCoder(),
-                        context: remoteStore.context,
-                        observingResults: true,
-                        onResultError: {
-                            pp_log(ctx, .App.profiles, .error, "Unable to decode remote profile: \($0)")
-                            return .ignore
-                        }
-                    )
-                }())
-            } catch {
-                pp_log(ctx, .App.profiles, .error, "\tUnable to re-observe remote profiles: \(error)")
+                do {
+                    pp_log(ctx, .app, .info, "\tRefresh remote sync (eligible=\(isEligibleForSharing), CloudKit=\(AppContext.isCloudKitEnabled))...")
+
+                    pp_log(ctx, .App.profiles, .info, "\tRefresh remote profiles repository (sync=\(isRemoteImportingEnabled))...")
+                    try await profileManager.observeRemote(repository: {
+                        AppData.cdProfileRepositoryV3(
+                            registry: dependencies.registry,
+                            coder: dependencies.profileCoder(),
+                            context: remoteStore.context,
+                            observingResults: true,
+                            onResultError: {
+                                pp_log(ctx, .App.profiles, .error, "Unable to decode remote profile: \($0)")
+                                return .ignore
+                            }
+                        )
+                    }())
+                } catch {
+                    pp_log(ctx, .App.profiles, .error, "\tUnable to re-observe remote profiles: \(error)")
+                }
             }
-#endif
 
             pp_log(ctx, .app, .info, "\tRefresh modules preferences repository...")
             preferencesManager.modulesRepositoryFactory = {

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -71,6 +71,7 @@ extension AppContext {
 
         return AppContext(
             apiManager: apiManager,
+            distributionTarget: dependencies.distributionTarget,
             iapManager: iapManager,
             kvStore: kvStore,
             migrationManager: migrationManager,

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -71,7 +71,7 @@ extension AppContext {
 
         return AppContext(
             apiManager: apiManager,
-            distributionTarget: dependencies.distributionTarget,
+            distributionTarget: Dependencies.distributionTarget,
             iapManager: iapManager,
             kvStore: kvStore,
             migrationManager: migrationManager,

--- a/Passepartout/Config.mac.xcconfig
+++ b/Passepartout/Config.mac.xcconfig
@@ -30,4 +30,4 @@ CFG_APP_ID = com.algoritmico.mac.Passepartout
 CFG_ENTITLEMENTS = Passepartout/App/AppMac.entitlements
 CFG_TUNNEL_INFO_PLIST = Passepartout/Tunnel/TunnelMac.plist
 CFG_TUNNEL_ENTITLEMENT = $(CFG_TUNNEL_ENTITLEMENT_BASE)-systemextension
-CFG_SWIFT_FLAGS = PP_BUILD_MAC PP_BUILD_FREE
+CFG_SWIFT_FLAGS = PP_BUILD_MAC

--- a/Passepartout/Shared/Dependencies+CoreData.swift
+++ b/Passepartout/Shared/Dependencies+CoreData.swift
@@ -28,7 +28,7 @@ import CommonUtils
 import Foundation
 
 extension Dependencies {
-    func coreDataLogger() -> LoggerProtocol {
+    nonisolated func coreDataLogger() -> LoggerProtocol {
         CoreDataPersistentStoreLogger()
     }
 }

--- a/Passepartout/Shared/Dependencies+IAPManager.swift
+++ b/Passepartout/Shared/Dependencies+IAPManager.swift
@@ -28,7 +28,7 @@ import CommonUtils
 import Foundation
 
 extension Dependencies {
-    var customUserLevel: AppUserLevel? {
+    nonisolated var customUserLevel: AppUserLevel? {
         guard let userLevelInteger = BundleConfiguration.mainIntegerIfPresent(for: .userLevel),
               let userLevel = AppUserLevel(rawValue: userLevelInteger) else {
             return nil
@@ -46,11 +46,11 @@ extension Dependencies {
         )
     }
 
-    func betaChecker() -> BetaChecker {
+    nonisolated func betaChecker() -> BetaChecker {
         TestFlightChecker()
     }
 
-    func productsAtBuild() -> BuildProducts<AppProduct> {
+    nonisolated func productsAtBuild() -> BuildProducts<AppProduct> {
         {
 #if os(iOS)
             if $0 <= 2016 {
@@ -70,7 +70,7 @@ extension Dependencies {
         }
     }
 
-    func iapLogger() -> LoggerProtocol {
+    nonisolated func iapLogger() -> LoggerProtocol {
         IAPLogger()
     }
 }

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -57,7 +57,14 @@ extension Dependencies {
     }
 
     nonisolated func appTunnelEnvironment(strategy: TunnelStrategy, profileId: Profile.ID) -> TunnelEnvironmentReader {
+#if PP_BUILD_MAC
+        guard let neStrategy = strategy as? NETunnelStrategy else {
+            fatalError("Mac build requires NETunnelStrategy")
+        }
+        return NETunnelEnvironment(strategy: neStrategy, profileId: profileId)
+#else
         tunnelEnvironment(profileId: profileId)
+#endif
     }
 
     nonisolated func tunnelEnvironment(profileId: Profile.ID) -> TunnelEnvironment {

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -33,7 +33,7 @@ extension Dependencies {
         Self.sharedRegistry
     }
 
-    func profileCoder() -> ProfileCoder {
+    nonisolated func profileCoder() -> ProfileCoder {
         CodableProfileCoder()
     }
 
@@ -100,6 +100,7 @@ private extension Dependencies {
 #endif
                         },
                         options: options,
+                        // FIXME: #218, this directory must be per-profile
                         cachesURL: FileManager.default.temporaryDirectory
                     )
                 }

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -92,7 +92,13 @@ private extension Dependencies {
                         parameters: $0,
                         module: $1,
                         prng: Partout.platform.newPRNG(ctx),
-                        dns: Partout.platform.newDNSResolver(ctx),
+                        dns: SimpleDNSResolver {
+#if PP_BUILD_MAC
+                            POSIXDNSStrategy(hostname: $0)
+#else
+                            CFDNSStrategy(hostname: $0)
+#endif
+                        },
                         options: options,
                         cachesURL: FileManager.default.temporaryDirectory
                     )

--- a/Passepartout/Shared/Dependencies+Partout.swift
+++ b/Passepartout/Shared/Dependencies+Partout.swift
@@ -100,7 +100,7 @@ private extension Dependencies {
                             }
                         },
                         options: options,
-                        // FIXME: #218, this directory must be per-profile
+                        // TODO: #218, this directory must be per-profile
                         cachesURL: FileManager.default.temporaryDirectory
                     )
                 }

--- a/Passepartout/Shared/Dependencies.swift
+++ b/Passepartout/Shared/Dependencies.swift
@@ -23,9 +23,20 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonLibrary
 import Foundation
 
 @MainActor
 struct Dependencies {
     static let shared = Dependencies()
+}
+
+extension Dependencies {
+    public nonisolated var distributionTarget: DistributionTarget {
+#if PP_BUILD_MAC
+        .developerID
+#else
+        .standard
+#endif
+    }
 }

--- a/Passepartout/Shared/Dependencies.swift
+++ b/Passepartout/Shared/Dependencies.swift
@@ -36,7 +36,7 @@ extension Dependencies {
 #if PP_BUILD_MAC
         .developerID
 #else
-        .standard
+        .appStore
 #endif
     }
 }

--- a/Passepartout/Shared/Dependencies.swift
+++ b/Passepartout/Shared/Dependencies.swift
@@ -32,7 +32,7 @@ struct Dependencies {
 }
 
 extension Dependencies {
-    public nonisolated var distributionTarget: DistributionTarget {
+    public nonisolated static var distributionTarget: DistributionTarget {
 #if PP_BUILD_MAC
         .developerID
 #else

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -92,7 +92,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         // MARK: Create PartoutLoggerContext with profile
 
-        let ctx = PartoutLogger.register(for: .tunnel(profileId), with: preferences)
+        let ctx = PartoutLogger.register(
+            for: .tunnel(profileId, dependencies.distributionTarget),
+            with: preferences
+        )
         self.ctx = ctx
 
         pp_log(ctx, .app, .info, "Tunnel started with options: \(options?.description ?? "nil")")

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -51,8 +51,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         // MARK: Declare globals
 
         let dependencies: Dependencies = await .shared
+        let distributionTarget = Dependencies.distributionTarget
         let constants: Constants = .shared
-        let distributionTarget = dependencies.distributionTarget
         await CommonLibrary.assertMissingImplementations(with: dependencies.registry)
 
         // MARK: Update or fetch existing preferences
@@ -94,7 +94,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         // MARK: Create PartoutLoggerContext with profile
 
         let ctx = PartoutLogger.register(
-            for: .tunnel(profileId, dependencies.distributionTarget),
+            for: .tunnel(profileId, distributionTarget),
             with: preferences
         )
         self.ctx = ctx

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -252,3 +252,9 @@ private extension PacketTunnelProvider {
 private extension TunnelEnvironmentKeys {
     static let holdFlag = TunnelEnvironmentKey<Bool>("Tunnel.onHold")
 }
+
+extension PartoutError: @retroactive LocalizedError {
+    public var errorDescription: String? {
+        debugDescription
+    }
+}

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -222,22 +222,30 @@ private extension PacketTunnelProvider {
 
 @MainActor
 private extension PacketTunnelProvider {
-    static var activeTunnels: Set<Profile.ID> = []
-
-    func trackContext(_ ctx: PartoutLoggerContext) throws {
-        if let profileId = ctx.profileId {
-            // TODO: #218, keep this until supported
-            guard Self.activeTunnels.isEmpty else {
-                throw PartoutError(.App.multipleTunnels)
-            }
-            Self.activeTunnels.insert(profileId)
+    static var activeTunnels: Set<Profile.ID> = [] {
+        didSet {
+            pp_log_g(.app, .info, "Active tunnels: \(activeTunnels)")
         }
     }
 
-    func untrackContext() {
-        if let profileId = ctx?.profileId {
-            Self.activeTunnels.remove(profileId)
+    func trackContext(_ ctx: PartoutLoggerContext) throws {
+        guard let profileId = ctx.profileId else {
+            return
         }
+        // TODO: #218, keep this until supported
+        guard Self.activeTunnels.isEmpty else {
+            throw PartoutError(.App.multipleTunnels)
+        }
+        pp_log_g(.app, .info, "Track context: \(profileId)")
+        Self.activeTunnels.insert(profileId)
+    }
+
+    func untrackContext() {
+        guard let profileId = ctx?.profileId else {
+            return
+        }
+        pp_log_g(.app, .info, "Untrack context: \(profileId)")
+        Self.activeTunnels.remove(profileId)
     }
 }
 

--- a/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -52,6 +52,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         let dependencies: Dependencies = await .shared
         let constants: Constants = .shared
+        let distributionTarget = dependencies.distributionTarget
         await CommonLibrary.assertMissingImplementations(with: dependencies.registry)
 
         // MARK: Update or fetch existing preferences
@@ -117,11 +118,11 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
                 betaChecker: dependencies.betaChecker(),
                 productsAtBuild: dependencies.productsAtBuild()
             )
-#if PP_BUILD_FREE
-            manager.isEnabled = false
-#else
-            manager.isEnabled = !kvStore.bool(forKey: AppPreference.skipsPurchases.key)
-#endif
+            if distributionTarget.supportsIAP {
+                manager.isEnabled = !kvStore.bool(forKey: AppPreference.skipsPurchases.key)
+            } else {
+                manager.isEnabled = false
+            }
             return manager
         }
 


### PR DESCRIPTION
Use the PP_BUILD_MAC symbol in a single point and propagate it as DistributionTarget throughout the SwiftPM packages, which are unaware of Xcode conditional flags. Use Dependencies.distributionTarget in top targets, and the \.distributionTarget environment value in SwiftUI.

Switch to different implementations in System Extension:

- UserDefaultsEnvironment → NETunnelEnvironment
- CFDNSStrategy → POSIXDNSStrategy
- Tunnel past logs are omitted

Removed functionality:

- iCloud
- Paid features
- Donations (replaced with web link)

Ultimately, fix #1375 this way:

- Track the active tunnels on startTunnel()/stopTunnel()
- Throw an exception in startTunnel() if active tunnels are not empty (multiple tunnels were started)

This is because the .sysex, for being always-on, must gracefully handle multiple calls to PartoutLogger.register(). It's enough that the default logger be registered once.

This PR wraps up the development side of #231.