### PR TITLE
Activate and alert about tunnel System Extension

### DIFF
--- a/Packages/App/Sources/AppDataProviders/Strategy/CDAPIRepositoryV3.swift
+++ b/Packages/App/Sources/AppDataProviders/Strategy/CDAPIRepositoryV3.swift
@@ -28,7 +28,6 @@ import CommonLibrary
 import CommonUtils
 import CoreData
 import Foundation
-import Partout
 
 extension AppData {
     public static func cdAPIRepositoryV3(context: NSManagedObjectContext) -> APIRepository {

--- a/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AddProfileMenu.swift
@@ -53,8 +53,8 @@ struct AddProfileMenu: View {
             if distributionTarget.supportsPaidFeatures {
                 providerProfileMenu
                 Divider()
+                migrateProfilesButton
             }
-            migrateProfilesButton
         } label: {
             ThemeImage(.add)
         }

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator+ModalRoute.swift
@@ -38,6 +38,8 @@ extension AppCoordinator {
 
         case settings
 
+        case systemExtension
+
         var id: Int {
             switch self {
             case .editProfile: return 1
@@ -45,6 +47,7 @@ extension AppCoordinator {
             case .interactiveLogin: return 3
             case .migrateProfiles: return 4
             case .settings: return 5
+            case .systemExtension: return 6
             }
         }
 
@@ -72,6 +75,8 @@ private extension AppCoordinator.ModalRoute {
             return .custom(width: 500, height: 200)
         case .migrateProfiles:
             return .custom(width: 700, height: 400)
+        case .systemExtension:
+            return .small
         default:
             return .large
         }

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -233,6 +233,12 @@ extension AppCoordinator {
             )
             .themeNavigationStack(closable: true, path: $migrationPath)
 
+#if os(macOS)
+        case .systemExtension:
+            SystemExtensionView()
+                .themeNavigationStack(closable: true, closeTitle: Strings.Global.Nouns.ok)
+#endif
+
         default:
             EmptyView()
         }
@@ -318,6 +324,10 @@ extension AppCoordinator {
     }
 
     public func onError(_ error: Error, profile: Profile) {
+        if case AppError.systemExtension(let result) = error, result != .success {
+            modalRoute = .systemExtension
+            return
+        }
         errorHandler.handle(
             error,
             title: profile.name,

--- a/Packages/App/Sources/AppUIMain/Views/Settings/SettingsCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/SettingsCoordinator.swift
@@ -81,6 +81,8 @@ extension SettingsCoordinator {
             Strings.Global.Nouns.preferences
         case .purchased:
             Strings.Global.Nouns.purchases
+        case .systemExtension:
+            Strings.Global.Nouns.Apple.systemExtension
         case .version:
             Strings.Views.Settings.title
         }
@@ -130,6 +132,12 @@ extension SettingsCoordinator {
         case .purchased:
             PurchasedView()
                 .navigationTitle(Strings.Global.Nouns.purchases)
+
+#if os(macOS)
+        case .systemExtension:
+            SystemExtensionView()
+                .navigationTitle(Strings.Global.Nouns.Apple.systemExtension)
+#endif
 
         case .version:
             VersionView(changelogRoute: SettingsCoordinatorRoute.changelog)

--- a/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SettingsContentView+macOS.swift
@@ -90,6 +90,9 @@ private extension SettingsContentView {
             .themeSection(header: Strings.Global.Nouns.about)
 
             Group {
+                if distributionTarget == .developerID {
+                    linkContent(.systemExtension)
+                }
                 linkContent(.diagnostics)
                 if distributionTarget.supportsIAP {
                     linkContent(.purchased)

--- a/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SystemExtensionView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SystemExtensionView+macOS.swift
@@ -1,8 +1,8 @@
 //
-//  SettingsCoordinatorRoute.swift
+//  SystemExtensionView+macOS.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 11/23/24.
+//  Created by Davide De Rosa on 5/22/25.
 //  Copyright (c) 2025 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,24 +23,28 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import Foundation
+#if os(macOS)
 
-enum SettingsCoordinatorRoute: Hashable {
-    case changelog
+import CommonUtils
+import SwiftUI
 
-    case credits
-
-    case diagnostics
-
-    case donate
-
-    case links
-
-    case preferences
-
-    case purchased
-
-    case systemExtension
-
-    case version
+struct SystemExtensionView: View {
+    var body: some View {
+        Form {
+            Text(Strings.Views.Settings.SystemExtension.message(
+                Strings.Unlocalized.appName,
+                Strings.Global.Nouns.Apple.systemExtension,
+                Strings.Global.Nouns.Apple.networkExtensions,
+                Strings.Unlocalized.appName
+            ))
+            Link(Strings.Views.Settings.SystemExtension.Buttons.open, destination: SystemExtensionManager.preferencesURL)
+        }
+        .themeForm()
+    }
 }
+
+#Preview {
+    SystemExtensionView()
+}
+
+#endif

--- a/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SystemExtensionsManager+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Settings/macOS/SystemExtensionsManager+UI.swift
@@ -1,8 +1,8 @@
 //
-//  AppError.swift
+//  SystemExtensionManager+UI.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 8/27/24.
+//  Created by Davide De Rosa on 5/22/25.
 //  Copyright (c) 2025 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,41 +23,18 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#if os(macOS)
+
+import AppKit
 import CommonUtils
 import Foundation
 
-public enum AppError: Error {
-    case couldNotLaunch(reason: Error)
+extension SystemExtensionManager {
+    public static let preferencesURL = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension")!
 
-    case emptyProducts
-
-    case emptyProfileName
-
-    case ineligibleProfile(Set<AppFeature>)
-
-    case interactiveLogin
-
-    case malformedModule(any ModuleBuilder, error: Error)
-
-    case permissionDenied
-
-    case systemExtension(SystemExtensionManager.Result)
-
-    case generic(PartoutError)
-
-    public init(_ error: Error) {
-        if let spError = error as? AppError {
-            self = spError
-        } else {
-            self = .generic(PartoutError(error))
-        }
+    public func openPreferences() {
+        NSWorkspace.shared.open(Self.preferencesURL)
     }
 }
 
-extension PartoutError.Code {
-    public enum App {
-        public static let ineligibleProfile = PartoutError.Code("App.ineligibleProfile")
-
-        public static let multipleTunnels = PartoutError.Code("App.multipleTunnels")
-    }
-}
+#endif

--- a/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+Main.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/BundleConfiguration+Main.swift
@@ -66,6 +66,13 @@ extension BundleConfiguration {
         return main.versionNumber
     }
 
+    public static var mainBuildNumber: Int {
+        if isPreview {
+            return 12345
+        }
+        return main.buildNumber
+    }
+
     public static var mainVersionString: String {
         if isPreview {
             return "preview-1.2.3-1234"

--- a/Packages/App/Sources/CommonUtils/Business/SystemExtensionManager.swift
+++ b/Packages/App/Sources/CommonUtils/Business/SystemExtensionManager.swift
@@ -1,0 +1,224 @@
+//
+//  SystemExtensionManager.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 5/22/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public final class SystemExtensionManager: NSObject {
+    public enum Result: Sendable {
+        case unknown
+
+        case success
+
+        case needsApproval
+
+        case requiresRestart
+    }
+
+    private let queue: DispatchQueue
+
+    fileprivate let identifier: String
+
+    fileprivate let version: String
+
+    fileprivate let build: Int
+
+    private var result: Result
+
+    private var isPending: Bool
+
+    private var pendingContinuation: CheckedContinuation<Result, Error>?
+
+    public init(identifier: String, version: String, build: Int) {
+        queue = DispatchQueue(label: "SystemExtensionManager")
+        self.identifier = identifier
+        self.version = version
+        self.build = build
+        result = .unknown
+        isPending = false
+    }
+
+    public var currentResult: Result {
+        queue.sync {
+            result
+        }
+    }
+}
+
+#if os(macOS)
+
+import SystemExtensions
+
+extension SystemExtensionManager {
+    public func load() async throws -> Result {
+        queue.sync {
+            guard !isPending else {
+                assertionFailure("Loading twice: \(identifier)")
+                return
+            }
+            isPending = true
+        }
+
+        let request: OSSystemExtensionRequest = .propertiesRequest(forExtensionWithIdentifier: identifier, queue: .main)
+        request.delegate = self
+
+        let result = try await withCheckedThrowingContinuation { continuation in
+            pendingContinuation = continuation
+            OSSystemExtensionManager.shared.submitRequest(request)
+        }
+
+        queue.sync {
+            isPending = false
+        }
+        return result
+    }
+
+    public func install() async throws -> Result {
+        queue.sync {
+            guard !isPending else {
+                assertionFailure("Installing twice: \(identifier)")
+                return
+            }
+            isPending = true
+        }
+
+        let request: OSSystemExtensionRequest = .activationRequest(forExtensionWithIdentifier: identifier, queue: .main)
+        request.delegate = self
+
+        let result = try await withCheckedThrowingContinuation { continuation in
+            pendingContinuation = continuation
+            OSSystemExtensionManager.shared.submitRequest(request)
+        }
+
+        queue.sync {
+            isPending = false
+        }
+        return result
+    }
+}
+
+extension SystemExtensionManager: OSSystemExtensionRequestDelegate {
+    public func request(_ request: OSSystemExtensionRequest, foundProperties properties: [OSSystemExtensionProperties]) {
+        NSLog("SystemExtensionManager: self = {\(identifier) \(version) \(build)}")
+        NSLog("SystemExtensionManager: found properties")
+        let sortedProperties = properties.sorted(by: OSSystemExtensionProperties.sorted)
+        sortedProperties.forEach {
+            NSLog("\t\($0.localDescription)")
+        }
+        let matching = sortedProperties
+            .filter {
+                $0.matches(self)
+            }
+            .first // sorting implies that .first is .max
+        guard let matching = sortedProperties.first else {
+            reportResult(.unknown)
+            return
+        }
+        NSLog("SystemExtensionManager: matching = \(matching.localDescription)")
+        let result: Result = matching.isAwaitingUserApproval ? .needsApproval : matching.isEnabled ? .success : .unknown
+        reportResult(result)
+    }
+
+    public func request(_ request: OSSystemExtensionRequest, actionForReplacingExtension existing: OSSystemExtensionProperties, withExtension ext: OSSystemExtensionProperties) -> OSSystemExtensionRequest.ReplacementAction {
+        .replace
+    }
+
+    public func request(_ request: OSSystemExtensionRequest, didFinishWithResult result: OSSystemExtensionRequest.Result) {
+        reportResult(.success)
+    }
+
+    public func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {
+        reportResult(.needsApproval)
+    }
+
+    public func requestRequiresRestart(_ request: OSSystemExtensionRequest) {
+        reportResult(.requiresRestart)
+    }
+
+    public func request(_ request: OSSystemExtensionRequest, didFailWithError error: Error) {
+        reportError(error)
+    }
+}
+
+private extension SystemExtensionManager {
+    func reportResult(_ result: Result) {
+        guard let continuation = pendingContinuation else {
+            return
+        }
+        self.result = result
+        continuation.resume(returning: result)
+        pendingContinuation = nil
+    }
+
+    func reportError(_ error: Error) {
+        guard let continuation = pendingContinuation else {
+            return
+        }
+        result = .unknown
+        continuation.resume(throwing: error)
+        pendingContinuation = nil
+    }
+}
+
+private extension OSSystemExtensionProperties {
+    static func sorted(lhs: OSSystemExtensionProperties, rhs: OSSystemExtensionProperties) -> Bool {
+        lhs.rank < rhs.rank
+    }
+
+    func matches(_ manager: SystemExtensionManager) -> Bool {
+        bundleIdentifier == manager.identifier &&
+        bundleShortVersion == manager.version &&
+        bundleVersion == "\(manager.build)"
+    }
+
+    var rank: Int {
+        if isEnabled {
+            return .min
+        } else if isAwaitingUserApproval {
+            return 1
+        } else {
+            return .max
+        }
+    }
+
+    var localDescription: String {
+        "{\(bundleIdentifier) \(bundleShortVersion) \(bundleVersion), isEnabled=\(isEnabled), isAwaitingUserApproval=\(isAwaitingUserApproval), url=\(url)}"
+    }
+}
+
+#else
+
+extension SystemExtensionManager {
+    public func load() async throws -> Result {
+        assertionFailure("SystemExtensionManager called on non-macOS")
+        return .unknown
+    }
+
+    public func install() async throws -> Result {
+        assertionFailure("SystemExtensionManager called on non-macOS")
+        return .unknown
+    }
+}
+
+#endif

--- a/Packages/App/Sources/CommonUtils/Business/SystemExtensionManager.swift
+++ b/Packages/App/Sources/CommonUtils/Business/SystemExtensionManager.swift
@@ -131,7 +131,7 @@ extension SystemExtensionManager: OSSystemExtensionRequestDelegate {
                 $0.matches(self)
             }
             .first // sorting implies that .first is .max
-        guard let matching = sortedProperties.first else {
+        guard let matching else {
             reportResult(.unknown)
             return
         }

--- a/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -52,6 +52,10 @@ extension AppError: LocalizedError {
         case .permissionDenied:
             return V.permissionDenied
 
+        case .systemExtension(let result):
+            assertionFailure("AppError.systemExtension should be handled in AppCoordinator")
+            return nil
+
         case .generic(let error):
             return error.localizedDescription
         }

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -370,6 +370,12 @@ public enum Strings {
       public static let version = Strings.tr("Localizable", "global.nouns.version", fallback: "Version")
       /// Yes
       public static let yes = Strings.tr("Localizable", "global.nouns.yes", fallback: "Yes")
+      public enum Apple {
+        /// Network Extensions
+        public static let networkExtensions = Strings.tr("Localizable", "global.nouns.apple.network_extensions", fallback: "Network Extensions")
+        /// System Extension
+        public static let systemExtension = Strings.tr("Localizable", "global.nouns.apple.system_extension", fallback: "System Extension")
+      }
     }
   }
   public enum Modules {
@@ -1006,6 +1012,18 @@ public enum Strings {
           public static let support = Strings.tr("Localizable", "views.settings.links.sections.support", fallback: "Support")
           /// Web
           public static let web = Strings.tr("Localizable", "views.settings.links.sections.web", fallback: "Web")
+        }
+      }
+      public enum SystemExtension {
+        /// For the VPN to work, %@ must be enabled as %@.
+        /// 
+        /// Open the macOS Preferences, scroll to '%@', open it and enable %@.
+        public static func message(_ p1: Any, _ p2: Any, _ p3: Any, _ p4: Any) -> String {
+          return Strings.tr("Localizable", "views.settings.system_extension.message", String(describing: p1), String(describing: p2), String(describing: p3), String(describing: p4), fallback: "For the VPN to work, %@ must be enabled as %@.\n\nOpen the macOS Preferences, scroll to '%@', open it and enable %@.")
+        }
+        public enum Buttons {
+          /// Open Preferences
+          public static let `open` = Strings.tr("Localizable", "views.settings.system_extension.buttons.open", fallback: "Open Preferences")
         }
       }
     }

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -75,6 +75,7 @@ extension AppContext {
             preferencesManager: preferencesManager,
             profileManager: profileManager,
             registry: registry,
+            sysexManager: nil,
             tunnel: tunnel
         )
     }()

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Links";
 "views.settings.system_extension.buttons.open" = "Einstellungen öffnen";
+"views.settings.system_extension.message" = "Damit das VPN funktioniert, muss %@ als %@ aktiviert sein.\n\nÖffne die macOS-Einstellungen, scrolle zu „%@“, öffne es und aktiviere %@.";
 "views.settings.title" = "Über";
 "views.ui.connection_status.on_demand_suffix" = " (auf Anfrage)";
 "views.ui.purchase_required.purchase.help" = "Kauf erforderlich";

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Adresse";
 "global.nouns.addresses" = "Adressen";
 "global.nouns.any" = "Jedes";
+"global.nouns.apple.network_extensions" = "Netzwerkerweiterungen";
+"global.nouns.apple.system_extension" = "Systemerweiterung";
 "global.nouns.category" = "Kategorie";
 "global.nouns.certificate" = "Zertifikat";
 "global.nouns.comment" = "Kommentar";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Unterstützung";
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Links";
+"views.settings.system_extension.buttons.open" = "Einstellungen öffnen";
 "views.settings.title" = "Über";
 "views.ui.connection_status.on_demand_suffix" = " (auf Anfrage)";
 "views.ui.purchase_required.purchase.help" = "Kauf erforderlich";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Διεύθυνση";
 "global.nouns.addresses" = "Διευθύνσεις";
 "global.nouns.any" = "Οποιοδήποτε";
+"global.nouns.apple.network_extensions" = "Επεκτάσεις δικτύου";
+"global.nouns.apple.system_extension" = "Επέκταση συστήματος";
 "global.nouns.category" = "Κατηγορία";
 "global.nouns.certificate" = "Πιστοποιητικό";
 "global.nouns.comment" = "Σχόλιο";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Υποστήριξη";
 "views.settings.links.sections.web" = "Ιστός";
 "views.settings.links.title" = "Σύνδεσμοι";
+"views.settings.system_extension.buttons.open" = "Άνοιγμα προτιμήσεων";
 "views.settings.title" = "Σχετικά";
 "views.ui.connection_status.on_demand_suffix" = " (κατ' απαίτηση)";
 "views.ui.purchase_required.purchase.help" = "Απαιτείται αγορά";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Ιστός";
 "views.settings.links.title" = "Σύνδεσμοι";
 "views.settings.system_extension.buttons.open" = "Άνοιγμα προτιμήσεων";
+"views.settings.system_extension.message" = "Για να λειτουργήσει το VPN, το %@ πρέπει να είναι ενεργοποιημένο ως %@.\n\nΆνοιξε τις Προτιμήσεις συστήματος του macOS, κύλησε στο «%@», άνοιξέ το και ενεργοποίησε το %@.";
 "views.settings.title" = "Σχετικά";
 "views.ui.connection_status.on_demand_suffix" = " (κατ' απαίτηση)";
 "views.ui.purchase_required.purchase.help" = "Απαιτείται αγορά";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -40,6 +40,8 @@
 "views.settings.credits.licenses" = "Licenses";
 "views.settings.credits.notices" = "Notices";
 "views.settings.credits.translations" = "Translations";
+"views.settings.system_extension.message" = "For the VPN to work, %@ must be enabled as %@.\n\nOpen the macOS Preferences, scroll to '%@', open it and enable %@.";
+"views.settings.system_extension.buttons.open" = "Open Preferences";
 
 "views.app.installed_profile.none.name" = "No profile";
 "views.app.installed_profile.none.status" = "Tap list to connect";
@@ -308,6 +310,8 @@
 "global.nouns.address" = "Address";
 "global.nouns.addresses" = "Addresses";
 "global.nouns.any" = "Any";
+"global.nouns.apple.network_extensions" = "Network Extensions";
+"global.nouns.apple.system_extension" = "System Extension";
 "global.nouns.category" = "Category";
 "global.nouns.certificate" = "Certificate";
 "global.nouns.comment" = "Comment";
@@ -344,6 +348,7 @@
 "global.nouns.n_seconds" = "%d seconds";
 "global.nouns.name" = "Name";
 "global.nouns.networks" = "Networks";
+
 "global.nouns.no" = "No";
 "global.nouns.no_content" = "No content";
 "global.nouns.no_selection" = "No selection";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Enlaces";
 "views.settings.system_extension.buttons.open" = "Abrir preferencias";
+"views.settings.system_extension.message" = "Para que funcione la VPN, %@ debe estar activado como %@.\n\nAbre las Preferencias del Sistema de macOS, desplázate hasta «%@», ábrelo y activa %@.";
 "views.settings.title" = "Acerca de";
 "views.ui.connection_status.on_demand_suffix" = " (a demanda)";
 "views.ui.purchase_required.purchase.help" = "Compra requerida";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Dirección";
 "global.nouns.addresses" = "Direcciones";
 "global.nouns.any" = "Cualquier";
+"global.nouns.apple.network_extensions" = "Extensiones de red";
+"global.nouns.apple.system_extension" = "Extensión del sistema";
 "global.nouns.category" = "Categoría";
 "global.nouns.certificate" = "Certificado";
 "global.nouns.comment" = "Comentario";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Soporte";
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Enlaces";
+"views.settings.system_extension.buttons.open" = "Abrir preferencias";
 "views.settings.title" = "Acerca de";
 "views.ui.connection_status.on_demand_suffix" = " (a demanda)";
 "views.ui.purchase_required.purchase.help" = "Compra requerida";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Adresse";
 "global.nouns.addresses" = "Adresses";
 "global.nouns.any" = "Tout";
+"global.nouns.apple.network_extensions" = "Extensions réseau";
+"global.nouns.apple.system_extension" = "Extension système";
 "global.nouns.category" = "Catégorie";
 "global.nouns.certificate" = "Certificat";
 "global.nouns.comment" = "Commentaire";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Support";
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Liens";
+"views.settings.system_extension.buttons.open" = "Ouvrir les réglages";
 "views.settings.title" = "À propos";
 "views.ui.connection_status.on_demand_suffix" = " (à la demande)";
 "views.ui.purchase_required.purchase.help" = "Achat requis";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Liens";
 "views.settings.system_extension.buttons.open" = "Ouvrir les réglages";
+"views.settings.system_extension.message" = "Pour que le VPN fonctionne, %@ doit être activé en tant que %@.\n\nOuvrez les Réglages macOS, faites défiler jusqu’à « %@ », ouvrez-le et activez %@.";
 "views.settings.title" = "À propos";
 "views.ui.connection_status.on_demand_suffix" = " (à la demande)";
 "views.ui.purchase_required.purchase.help" = "Achat requis";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Indirizzo";
 "global.nouns.addresses" = "Indirizzi";
 "global.nouns.any" = "Qualsiasi";
+"global.nouns.apple.network_extensions" = "Estensioni di rete";
+"global.nouns.apple.system_extension" = "Estensione di sistema";
 "global.nouns.category" = "Categoria";
 "global.nouns.certificate" = "Certificato";
 "global.nouns.comment" = "Commento";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Supporto";
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Collegamenti";
+"views.settings.system_extension.buttons.open" = "Apri le preferenze";
 "views.settings.title" = "Informazioni";
 "views.ui.connection_status.on_demand_suffix" = " (on-demand)";
 "views.ui.purchase_required.purchase.help" = "Acquisto richiesto";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Collegamenti";
 "views.settings.system_extension.buttons.open" = "Apri le preferenze";
+"views.settings.system_extension.message" = "Per far funzionare la VPN, %@ deve essere abilitato come %@.\n\nApri le Preferenze di Sistema di macOS, scorri fino a “%@”, aprilo e abilita %@.";
 "views.settings.title" = "Informazioni";
 "views.ui.connection_status.on_demand_suffix" = " (on-demand)";
 "views.ui.purchase_required.purchase.help" = "Acquisto richiesto";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Links";
 "views.settings.system_extension.buttons.open" = "Voorkeuren openen";
+"views.settings.system_extension.message" = "Voor een goede werking van de VPN moet %@ ingeschakeld zijn als %@.\n\nOpen de macOS-voorkeuren, scroll naar ‘%@’, open het en schakel %@ in.";
 "views.settings.title" = "Over";
 "views.ui.connection_status.on_demand_suffix" = " (op aanvraag)";
 "views.ui.purchase_required.purchase.help" = "Aankoop vereist";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Adres";
 "global.nouns.addresses" = "Adressen";
 "global.nouns.any" = "Elk";
+"global.nouns.apple.network_extensions" = "Netwerkextensies";
+"global.nouns.apple.system_extension" = "Systeemextensie";
 "global.nouns.category" = "Categorie";
 "global.nouns.certificate" = "Certificaat";
 "global.nouns.comment" = "Opmerking";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Ondersteuning";
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Links";
+"views.settings.system_extension.buttons.open" = "Voorkeuren openen";
 "views.settings.title" = "Over";
 "views.ui.connection_status.on_demand_suffix" = " (op aanvraag)";
 "views.ui.purchase_required.purchase.help" = "Aankoop vereist";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Adres";
 "global.nouns.addresses" = "Adresy";
 "global.nouns.any" = "Dowolny";
+"global.nouns.apple.network_extensions" = "Rozszerzenia sieci";
+"global.nouns.apple.system_extension" = "Rozszerzenie systemu";
 "global.nouns.category" = "Kategoria";
 "global.nouns.certificate" = "Certyfikat";
 "global.nouns.comment" = "Komentarz";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Wsparcie";
 "views.settings.links.sections.web" = "Strona internetowa";
 "views.settings.links.title" = "Linki";
+"views.settings.system_extension.buttons.open" = "Otwórz preferencje";
 "views.settings.title" = "O aplikacji";
 "views.ui.connection_status.on_demand_suffix" = " (na żądanie)";
 "views.ui.purchase_required.purchase.help" = "Wymagana zakup";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Strona internetowa";
 "views.settings.links.title" = "Linki";
 "views.settings.system_extension.buttons.open" = "Otwórz preferencje";
+"views.settings.system_extension.message" = "Aby VPN działało, %@ musi być włączone jako %@.\n\nOtwórz Preferencje systemowe macOS, przewiń do „%@”, otwórz je i włącz %@.";
 "views.settings.title" = "O aplikacji";
 "views.ui.connection_status.on_demand_suffix" = " (na żądanie)";
 "views.ui.purchase_required.purchase.help" = "Wymagana zakup";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Links";
 "views.settings.system_extension.buttons.open" = "Abrir preferências";
+"views.settings.system_extension.message" = "Para o VPN funcionar, %@ precisa estar ativado como %@.\n\nAbra as Preferências do Sistema do macOS, role até “%@”, abra e ative %@.";
 "views.settings.title" = "Sobre";
 "views.ui.connection_status.on_demand_suffix" = " (sob demanda)";
 "views.ui.purchase_required.purchase.help" = "Compra necessária";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Endereço";
 "global.nouns.addresses" = "Endereços";
 "global.nouns.any" = "Qualquer";
+"global.nouns.apple.network_extensions" = "Extensões de rede";
+"global.nouns.apple.system_extension" = "Extensão do sistema";
 "global.nouns.category" = "Categoria";
 "global.nouns.certificate" = "Certificado";
 "global.nouns.comment" = "Comentário";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Suporte";
 "views.settings.links.sections.web" = "Web";
 "views.settings.links.title" = "Links";
+"views.settings.system_extension.buttons.open" = "Abrir preferências";
 "views.settings.title" = "Sobre";
 "views.ui.connection_status.on_demand_suffix" = " (sob demanda)";
 "views.ui.purchase_required.purchase.help" = "Compra necessária";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Адрес";
 "global.nouns.addresses" = "Адреса";
 "global.nouns.any" = "Любой";
+"global.nouns.apple.network_extensions" = "Сетевые расширения";
+"global.nouns.apple.system_extension" = "Системное расширение";
 "global.nouns.category" = "Категория";
 "global.nouns.certificate" = "Сертификат";
 "global.nouns.comment" = "Комментарий";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Поддержка";
 "views.settings.links.sections.web" = "Веб-сайт";
 "views.settings.links.title" = "Ссылки";
+"views.settings.system_extension.buttons.open" = "Открыть настройки";
 "views.settings.title" = "О программе";
 "views.ui.connection_status.on_demand_suffix" = " (по требованию)";
 "views.ui.purchase_required.purchase.help" = "Требуется покупка";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Веб-сайт";
 "views.settings.links.title" = "Ссылки";
 "views.settings.system_extension.buttons.open" = "Открыть настройки";
+"views.settings.system_extension.message" = "Чтобы VPN работал, необходимо включить %@ как %@.\n\nОткройте настройки macOS, прокрутите до «%@», откройте и включите %@.";
 "views.settings.title" = "О программе";
 "views.ui.connection_status.on_demand_suffix" = " (по требованию)";
 "views.ui.purchase_required.purchase.help" = "Требуется покупка";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Adress";
 "global.nouns.addresses" = "Adresser";
 "global.nouns.any" = "Alla";
+"global.nouns.apple.network_extensions" = "Nätverkstillägg";
+"global.nouns.apple.system_extension" = "Systemtillägg";
 "global.nouns.category" = "Kategori";
 "global.nouns.certificate" = "Certifikat";
 "global.nouns.comment" = "Kommentar";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Support";
 "views.settings.links.sections.web" = "Webbplats";
 "views.settings.links.title" = "Länkar";
+"views.settings.system_extension.buttons.open" = "Öppna inställningar";
 "views.settings.title" = "Om";
 "views.ui.connection_status.on_demand_suffix" = " (på begäran)";
 "views.ui.purchase_required.purchase.help" = "Köp krävs";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Webbplats";
 "views.settings.links.title" = "Länkar";
 "views.settings.system_extension.buttons.open" = "Öppna inställningar";
+"views.settings.system_extension.message" = "För att VPN ska fungera måste %@ vara aktiverad som %@.\n\nÖppna macOS-inställningarna, scrolla till ”%@”, öppna det och aktivera %@.";
 "views.settings.title" = "Om";
 "views.ui.connection_status.on_demand_suffix" = " (på begäran)";
 "views.ui.purchase_required.purchase.help" = "Köp krävs";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "Адреса";
 "global.nouns.addresses" = "Адреси";
 "global.nouns.any" = "Будь-який";
+"global.nouns.apple.network_extensions" = "Мережеві розширення";
+"global.nouns.apple.system_extension" = "Системне розширення";
 "global.nouns.category" = "Категорія";
 "global.nouns.certificate" = "Сертифікат";
 "global.nouns.comment" = "Коментар";
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "Підтримка";
 "views.settings.links.sections.web" = "Веб-сторінка";
 "views.settings.links.title" = "Посилання";
+"views.settings.system_extension.buttons.open" = "Відкрити налаштування";
 "views.settings.title" = "Про програму";
 "views.ui.connection_status.on_demand_suffix" = " (за запитом)";
 "views.ui.purchase_required.purchase.help" = "Потрібна покупка";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "Веб-сторінка";
 "views.settings.links.title" = "Посилання";
 "views.settings.system_extension.buttons.open" = "Відкрити налаштування";
+"views.settings.system_extension.message" = "Щоб VPN працював, %@ має бути увімкнено як %@.\n\nВідкрий налаштування macOS, прокрути до «%@», відкрий його та увімкни %@.";
 "views.settings.title" = "Про програму";
 "views.ui.connection_status.on_demand_suffix" = " (за запитом)";
 "views.ui.purchase_required.purchase.help" = "Потрібна покупка";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "global.nouns.address" = "地址";
 "global.nouns.addresses" = "地址";
 "global.nouns.any" = "任何";
+"global.nouns.apple.network_extensions" = "网络扩展"
+"global.nouns.apple.system_extension" = "系统扩展"
 "global.nouns.category" = "类别";
 "global.nouns.certificate" = "证书";
 "global.nouns.comment" = "评论"
@@ -323,6 +325,7 @@
 "views.settings.links.sections.support" = "支持";
 "views.settings.links.sections.web" = "网页";
 "views.settings.links.title" = "链接";
+"views.settings.system_extension.buttons.open" = "打开偏好设置"
 "views.settings.title" = "关于";
 "views.ui.connection_status.on_demand_suffix" = "（按需）";
 "views.ui.purchase_required.purchase.help" = "需要购买";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "views.settings.links.sections.web" = "网页";
 "views.settings.links.title" = "链接";
 "views.settings.system_extension.buttons.open" = "打开偏好设置"
+"views.settings.system_extension.message" = "要使 VPN 正常工作，必须将 %@ 启用为 %@。\n\n打开 macOS 偏好设置，滚动到“%@”，打开并启用 %@。"
 "views.settings.title" = "关于";
 "views.ui.connection_status.on_demand_suffix" = "（按需）";
 "views.ui.purchase_required.purchase.help" = "需要购买";

--- a/Packages/App/Sources/UILibrary/Views/Theme/Theme+Modifiers.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/Theme+Modifiers.swift
@@ -71,15 +71,7 @@ extension View {
 
     public func themeNavigationStack(
         closable: Bool = false,
-        onClose: (() -> Void)? = nil,
-        path: Binding<NavigationPath> = .constant(NavigationPath())
-    ) -> some View {
-        modifier(ThemeNavigationStackModifier(closable: closable, onClose: onClose, path: path))
-    }
-
-    public func themeNavigationStack(
-        closable: Bool = false,
-        closeTitle: String,
+        closeTitle: String? = nil,
         onClose: (() -> Void)? = nil,
         path: Binding<NavigationPath> = .constant(NavigationPath())
     ) -> some View {

--- a/Packages/App/Sources/UILibrary/Views/Theme/Theme+Modifiers.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/Theme+Modifiers.swift
@@ -77,6 +77,15 @@ extension View {
         modifier(ThemeNavigationStackModifier(closable: closable, onClose: onClose, path: path))
     }
 
+    public func themeNavigationStack(
+        closable: Bool = false,
+        closeTitle: String,
+        onClose: (() -> Void)? = nil,
+        path: Binding<NavigationPath> = .constant(NavigationPath())
+    ) -> some View {
+        modifier(ThemeNavigationStackModifier(closable: closable, closeTitle: closeTitle, onClose: onClose, path: path))
+    }
+
     @ViewBuilder
     public func themeNavigationStack(
         if condition: Bool,

--- a/Packages/App/Sources/UILibrary/Views/Theme/ThemeCloseLabel.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/ThemeCloseLabel.swift
@@ -26,14 +26,17 @@
 import SwiftUI
 
 public struct ThemeCloseLabel: View {
-    public init() {
+    private let title: String
+
+    public init(title: String? = nil) {
+        self.title = title ?? Strings.Global.Actions.cancel
     }
 
     public var body: some View {
 #if os(iOS) || os(tvOS)
         ThemeImage(.close)
 #else
-        Text(Strings.Global.Actions.cancel)
+        Text(title)
 #endif
     }
 }

--- a/Packages/App/Sources/UILibrary/Views/Theme/ThemeNavigationStackModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/ThemeNavigationStackModifier.swift
@@ -32,6 +32,8 @@ struct ThemeNavigationStackModifier: ViewModifier {
 
     let closable: Bool
 
+    var closeTitle: String?
+
     let onClose: (() -> Void)?
 
     @Binding
@@ -50,7 +52,7 @@ struct ThemeNavigationStackModifier: ViewModifier {
                                     dismiss()
                                 }
                             } label: {
-                                ThemeCloseLabel()
+                                ThemeCloseLabel(title: closeTitle)
                             }
                         }
                     }

--- a/Passepartout/App/AppDelegate.swift
+++ b/Passepartout/App/AppDelegate.swift
@@ -36,12 +36,7 @@ final class AppDelegate: NSObject {
             store: UserDefaultsStore(.standard),
             fallback: AppPreferenceValues()
         )
-        let ctx: PartoutLoggerContext
-        do {
-            ctx = try PartoutLogger.register(for: .app, with: kvStore.preferences)
-        } catch {
-            fatalError("Starting multiple app processes? \(error)")
-        }
+        let ctx = PartoutLogger.register(for: .app, with: kvStore.preferences)
         if AppCommandLine.contains(.uiTesting) {
             pp_log_g(.app, .info, "UI tests: mock AppContext")
             return .forUITesting

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -78,6 +78,7 @@ extension AppContext {
             preferencesManager: preferencesManager,
             profileManager: profileManager,
             registry: dependencies.registry,
+            sysexManager: nil,
             tunnel: tunnel
         )
     }

--- a/Passepartout/Config.xcconfig
+++ b/Passepartout/Config.xcconfig
@@ -27,7 +27,7 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 MARKETING_VERSION = 3.4.0
-CURRENT_PROJECT_VERSION = 3838
+CURRENT_PROJECT_VERSION = 3841
 
 // tweak these based on app and team
 CFG_APP_ID = com.algoritmico.ios.Passepartout

--- a/scripts/generate-notarized-dmg.sh
+++ b/scripts/generate-notarized-dmg.sh
@@ -7,8 +7,9 @@ cd $cwd/..
 set -e
 platform="macOS"
 arch="arm64"
-ci/xcode-archive.sh $platform 1 $arch
-ci/xcode-export.sh $platform 1
+developer_id="1"
+ci/xcode-archive.sh $platform $developer_id $arch
+ci/xcode-export.sh $platform $developer_id
 ci/dmg-generate.sh $arch
 ci/dmg-sign.sh $arch $gpg_fingerprint $gpg_passphrase
 ci/dmg-notarize.sh $arch $apple_id $apple_password

--- a/scripts/generate-notarized-dmg.sh
+++ b/scripts/generate-notarized-dmg.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cwd=`dirname $0`
+source $cwd/env.sh
+source $cwd/env.secrets.sh
+cd $cwd/..
+
+set -e
+platform="macOS"
+arch="arm64"
+ci/xcode-archive.sh $platform 1 $arch
+ci/xcode-export.sh $platform 1
+ci/dmg-generate.sh $arch
+ci/dmg-sign.sh $arch $gpg_fingerprint $gpg_passphrase
+ci/dmg-notarize.sh $arch $apple_id $apple_password


### PR DESCRIPTION
Add SystemExtensionManager to install the tunnel System Extension and check its status. Present a short informative modal when a user action is required in the Mac Preferences, and in the Troubleshooting section.

Fixes #1388 