### PR TITLE
tvOS: Import profiles via QR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ fastlane/**/review_information
 fastlane/**/trade_representative_contact_information
 build/
 dist/
-l10n/
+/l10n/
 tmp/
 screenshots/html/*/0*.png
 screenshots/results/

--- a/Packages/App/Package.swift
+++ b/Packages/App/Package.swift
@@ -58,10 +58,15 @@ let package = Package(
         .library(
             name: "UILibrary",
             targets: ["UILibrary"]
+        ),
+        .library(
+            name: "WebLibrary",
+            targets: ["WebLibrary"]
         )
     ],
     dependencies: [
-        .package(path: "../../submodules/partout")
+        .package(path: "../../submodules/partout"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.83.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -124,7 +129,10 @@ let package = Package(
         ),
         .target(
             name: "AppUITV",
-            dependencies: ["UILibrary"]
+            dependencies: [
+                "UILibrary",
+                "WebLibrary"
+            ]
         ),
         .target(
             name: "AppUITVWrapper",
@@ -190,6 +198,17 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .target(
+            name: "WebLibrary",
+            dependencies: [
+                "CommonLibrary",
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio")
+            ],
+            resources: [
+                .process("Resources")
+            ]
+        ),
         .testTarget(
             name: "AppUIMainTests",
             dependencies: ["AppUIMain"]
@@ -205,6 +224,10 @@ let package = Package(
         .testTarget(
             name: "UILibraryTests",
             dependencies: ["UILibrary"]
+        ),
+        .testTarget(
+            name: "WebLibraryTests",
+            dependencies: ["WebLibrary"]
         )
     ]
 )

--- a/Packages/App/Sources/AppUIMain/Business/ProfileImporter.swift
+++ b/Packages/App/Sources/AppUIMain/Business/ProfileImporter.swift
@@ -120,16 +120,7 @@ private extension ProfileImporter {
                 url.stopAccessingSecurityScopedResource()
             }
         }
-
-        let module = try importer.module(fromURL: url, object: passphrase)
-        let onDemandModule = OnDemandModule.Builder().tryBuild()
-
-        var builder = Profile.Builder()
-        builder.name = url.lastPathComponent
-        builder.modules = [module, onDemandModule]
-        builder.activeModulesIds = Set(builder.modules.map(\.id))
-        let profile = try builder.tryBuild()
-
+        let profile = try importer.profile(from: url, passphrase: passphrase)
         try await profileManager.save(profile)
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -51,6 +51,8 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
 
     private let registry: Registry
 
+    private let uploadManager: UploadManager
+
     @State
     private var isImporting = false
 
@@ -81,11 +83,13 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
     public init(
         profileManager: ProfileManager,
         tunnel: ExtendedTunnel,
-        registry: Registry
+        registry: Registry,
+        uploadManager: UploadManager
     ) {
         self.profileManager = profileManager
         self.tunnel = tunnel
         self.registry = registry
+        self.uploadManager = uploadManager
     }
 
     public var body: some View {
@@ -420,7 +424,8 @@ private extension Profile {
     AppCoordinator(
         profileManager: .forPreviews,
         tunnel: .forPreviews,
-        registry: Registry()
+        registry: Registry(),
+        uploadManager: UploadManager()
     )
     .withMockEnvironment()
 }

--- a/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -74,6 +74,11 @@ public struct AppCoordinator: View, AppCoordinatorConforming {
                         Text(Strings.Global.Nouns.connection)
                     }
 
+                profilesView
+                    .tabItem {
+                        Text(Strings.Global.Nouns.profiles)
+                    }
+
 //                searchView
 //                    .tabItem {
 //                        ThemeImage(.search)
@@ -109,6 +114,14 @@ private extension AppCoordinator {
                     onProviderEntityRequired($0, force: false)
                 }
             )
+        )
+    }
+
+    var profilesView: some View {
+        ProfilesView(
+            profileManager: profileManager,
+            uploadManager: uploadManager,
+            registry: registry
         )
     }
 

--- a/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -39,6 +39,8 @@ public struct AppCoordinator: View, AppCoordinatorConforming {
 
     private let registry: Registry
 
+    private let uploadManager: UploadManager
+
     @State
     private var paywallReason: PaywallReason?
 
@@ -204,7 +206,8 @@ extension AppCoordinator {
     AppCoordinator(
         profileManager: .forPreviews,
         tunnel: .forPreviews,
-        registry: Registry()
+        registry: Registry(),
+        uploadManager: UploadManager()
     )
     .withMockEnvironment()
 }

--- a/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -51,19 +51,25 @@ public struct AppCoordinator: View, AppCoordinatorConforming {
     @StateObject
     private var errorHandler: ErrorHandler = .default()
 
-    public init(profileManager: ProfileManager, tunnel: ExtendedTunnel, registry: Registry) {
+    public init(
+        profileManager: ProfileManager,
+        tunnel: ExtendedTunnel,
+        registry: Registry,
+        uploadManager: UploadManager
+    ) {
         self.profileManager = profileManager
         self.tunnel = tunnel
         self.registry = registry
+        self.uploadManager = uploadManager
     }
 
     public var body: some View {
         debugChanges()
         return NavigationStack {
             TabView {
-                profileView
+                connectionView
                     .tabItem {
-                        Text(Strings.Global.Nouns.profile)
+                        Text(Strings.Global.Nouns.connection)
                     }
 
 //                searchView
@@ -87,8 +93,8 @@ public struct AppCoordinator: View, AppCoordinatorConforming {
 }
 
 private extension AppCoordinator {
-    var profileView: some View {
-        ProfileView(
+    var connectionView: some View {
+        ConnectionView(
             profileManager: profileManager,
             tunnel: tunnel,
             interactiveManager: interactiveManager,

--- a/Packages/App/Sources/AppUITV/Views/Connection/ActiveProfileView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Connection/ActiveProfileView.swift
@@ -45,7 +45,7 @@ struct ActiveProfileView: View {
     var isSwitching: Bool
 
     @FocusState.Binding
-    var focusedField: ProfileView.Field?
+    var focusedField: ConnectionView.Field?
 
     @ObservedObject
     var errorHandler: ErrorHandler
@@ -219,7 +219,7 @@ private struct ContentPreview: View {
     private var isSwitching = false
 
     @FocusState
-    private var focusedField: ProfileView.Field?
+    private var focusedField: ConnectionView.Field?
 
     var body: some View {
         ActiveProfileView(

--- a/Packages/App/Sources/AppUITV/Views/Connection/ActiveTunnelButton.swift
+++ b/Packages/App/Sources/AppUITV/Views/Connection/ActiveTunnelButton.swift
@@ -39,7 +39,7 @@ struct ActiveTunnelButton: View {
     let profile: Profile?
 
     @FocusState.Binding
-    var focusedField: ProfileView.Field?
+    var focusedField: ConnectionView.Field?
 
     let errorHandler: ErrorHandler
 

--- a/Packages/App/Sources/AppUITV/Views/Connection/ConnectionProfilesView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Connection/ConnectionProfilesView.swift
@@ -1,5 +1,5 @@
 //
-//  ProfileListView.swift
+//  ConnectionProfilesView.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 11/1/24.
@@ -27,8 +27,9 @@ import CommonLibrary
 import CommonUtils
 import SwiftUI
 import UIAccessibility
+import WebLibrary
 
-struct ProfileListView: View {
+struct ConnectionProfilesView: View {
 
     @ObservedObject
     var profileManager: ProfileManager
@@ -37,7 +38,7 @@ struct ProfileListView: View {
     var tunnel: ExtendedTunnel
 
     @FocusState.Binding
-    var focusedField: ProfileView.Field?
+    var focusedField: ConnectionView.Field?
 
     @ObservedObject
     var errorHandler: ErrorHandler
@@ -60,13 +61,13 @@ struct ProfileListView: View {
     }
 }
 
-private extension ProfileListView {
+private extension ConnectionProfilesView {
     var allPreviews: [ProfilePreview] {
         profileManager.previews
     }
 
     var headerView: some View {
-        Text(Strings.Views.App.Tv.header(Strings.Unlocalized.appName, Strings.Unlocalized.appleTV))
+        Text(Strings.Views.Tv.ConnectionProfiles.header(Strings.Unlocalized.appName, Strings.Unlocalized.appleTV))
             .textCase(.none)
             .foregroundStyle(.primary)
             .font(.body)
@@ -118,10 +119,10 @@ private struct ContentPreview: View {
     let profileManager: ProfileManager
 
     @FocusState
-    var focusedField: ProfileView.Field?
+    var focusedField: ConnectionView.Field?
 
     var body: some View {
-        ProfileListView(
+        ConnectionProfilesView(
             profileManager: profileManager,
             tunnel: .forPreviews,
             focusedField: $focusedField,

--- a/Packages/App/Sources/AppUITV/Views/Connection/ConnectionView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Connection/ConnectionView.swift
@@ -1,5 +1,5 @@
 //
-//  ProfileView.swift
+//  ConnectionView.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 10/31/24.
@@ -28,7 +28,7 @@ import CommonUtils
 import SwiftUI
 import UILibrary
 
-struct ProfileView: View, Routable {
+struct ConnectionView: View, Routable {
     enum Field: Hashable {
         case connect
 
@@ -88,7 +88,7 @@ struct ProfileView: View, Routable {
     }
 }
 
-private extension ProfileView {
+private extension ConnectionView {
     var activeProfile: Profile? {
         guard let id = tunnel.activeProfile?.id else {
             return nil
@@ -109,7 +109,7 @@ private extension ProfileView {
 
     var sidePanelView: some View {
         ZStack {
-            listView
+            profilesListView
                 .padding(.horizontal)
                 .opaque(!interactiveManager.isPresented)
 
@@ -137,8 +137,8 @@ private extension ProfileView {
         }
     }
 
-    var listView: some View {
-        ProfileListView(
+    var profilesListView: some View {
+        ConnectionProfilesView(
             profileManager: profileManager,
             tunnel: tunnel,
             focusedField: $focusedField,
@@ -148,7 +148,7 @@ private extension ProfileView {
     }
 }
 
-private extension ProfileView {
+private extension ConnectionView {
     func onTunnelActiveProfile(
         old: TunnelActiveProfile?,
         new: TunnelActiveProfile?
@@ -187,7 +187,7 @@ private extension ProfileView {
 // MARK: -
 
 #Preview("List") {
-    ProfileView(
+    ConnectionView(
         profileManager: .forPreviews,
         tunnel: .forPreviews,
         interactiveManager: InteractiveManager(),
@@ -198,7 +198,7 @@ private extension ProfileView {
 }
 
 #Preview("Empty") {
-    ProfileView(
+    ConnectionView(
         profileManager: ProfileManager(profiles: []),
         tunnel: .forPreviews,
         interactiveManager: InteractiveManager(),

--- a/Packages/App/Sources/AppUITV/Views/Profiles/ProfilesView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profiles/ProfilesView.swift
@@ -1,0 +1,203 @@
+//
+//  ProfilesView.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/6/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import CommonUtils
+import SwiftUI
+
+struct ProfilesView: View {
+
+    @EnvironmentObject
+    private var theme: Theme
+
+    @ObservedObject
+    var profileManager: ProfileManager
+
+    @ObservedObject
+    var uploadManager: UploadManager
+
+    let registry: Registry
+
+    @FocusState
+    private var detail: Detail?
+
+    @StateObject
+    private var errorHandler: ErrorHandler = .default()
+
+    var body: some View {
+        HStack {
+            masterView
+            detailView
+        }
+        .background(theme.primaryGradient)
+        .withErrorHandler(errorHandler)
+    }
+}
+
+private extension ProfilesView {
+    var masterView: some View {
+        List {
+            importSection
+            if profileManager.hasProfiles {
+                profilesSection
+            }
+        }
+        .themeList()
+        .frame(maxWidth: .infinity)
+    }
+
+    var detailView: some View {
+        DetailView(
+            detail: detail,
+            uploadManager: uploadManager,
+            registry: registry,
+            profileManager: profileManager,
+            errorHandler: errorHandler
+        )
+        .frame(maxWidth: .infinity)
+    }
+
+    var importSection: some View {
+        webUploaderButton
+            .themeSection(header: Strings.Global.Actions.import)
+    }
+
+    var webUploaderButton: some View {
+        Toggle(Strings.Views.Tv.Profiles.importLocal, isOn: isUploaderEnabled)
+            .focused($detail, equals: .import)
+    }
+
+    var profilesSection: some View {
+        ForEach(profileManager.previews, id: \.id, content: row(forProfilePreview:))
+            .themeSection(header: Strings.Global.Nouns.profiles)
+    }
+
+    func row(forProfilePreview preview: ProfilePreview) -> some View {
+        Button {
+            //
+        } label: {
+            HStack {
+                Text(preview.name)
+                Spacer()
+                if profileManager.isRemotelyShared(profileWithId: preview.id) {
+                    ThemeImage(.cloudOn)
+                }
+            }
+        }
+        .contextMenu {
+            if !profileManager.isRemotelyShared(profileWithId: preview.id) {
+                Button(Strings.Global.Actions.delete, role: .destructive) {
+                    deleteProfile(withId: preview.id)
+                }
+            }
+        }
+        .focused($detail, equals: .profiles)
+    }
+}
+
+private extension ProfilesView {
+    var isUploaderEnabled: Binding<Bool> {
+        Binding {
+            uploadManager.isStarted
+        } set: {
+            if $0 {
+                do {
+                    try uploadManager.start()
+                } catch {
+                    pp_log_g(.app, .error, "Unable to start web uploader: \(error)")
+                    errorHandler.handle(error)
+                }
+            } else {
+                uploadManager.stop()
+            }
+       }
+    }
+
+    func deleteProfile(withId profileId: Profile.ID) {
+        Task {
+            await profileManager.remove(withId: profileId)
+        }
+    }
+}
+
+// MARK: - Detail
+
+private enum Detail {
+    case `import`
+
+    case profiles
+}
+
+private struct DetailView: View {
+    let detail: Detail?
+
+    @ObservedObject
+    var uploadManager: UploadManager
+
+    let registry: Registry
+
+    @ObservedObject
+    var profileManager: ProfileManager
+
+    @ObservedObject
+    var errorHandler: ErrorHandler
+
+    var body: some View {
+        VStack {
+            TopSpacer()
+            switch detail {
+            case .import:
+                importView
+            case .profiles:
+                Text(Strings.Views.Tv.Profiles.Detail.profiles)
+            default:
+                Text("") // take space regardless
+            }
+            Spacer()
+        }
+    }
+}
+
+private extension DetailView {
+    var importView: some View {
+        WebUploaderView(
+            uploadManager: uploadManager,
+            registry: registry,
+            profileManager: profileManager,
+            errorHandler: errorHandler
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ProfilesView(
+        profileManager: .forPreviews,
+        uploadManager: .forPreviews,
+        registry: Registry()
+    )
+    .withMockEnvironment()
+}

--- a/Packages/App/Sources/AppUITV/Views/Profiles/WebUploaderView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Profiles/WebUploaderView.swift
@@ -1,0 +1,127 @@
+//
+//  WebUploaderView.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/5/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import CommonUtils
+import SwiftUI
+
+struct WebUploaderView: View {
+
+    @ObservedObject
+    var uploadManager: UploadManager
+
+    let registry: Registry
+
+    @ObservedObject
+    var profileManager: ProfileManager
+
+    @ObservedObject
+    var errorHandler: ErrorHandler
+
+    var body: some View {
+        VStack {
+            if let website = uploadManager.website {
+                view(forWebsite: website)
+            } else {
+                Text(Strings.Views.Tv.WebUploader.toggle)
+            }
+        }
+        .task(handleUploadedFile)
+        .onDisappear {
+            uploadManager.stop()
+        }
+    }
+}
+
+private extension WebUploaderView {
+    func view(forWebsite website: UploadManager.Website) -> some View {
+        VStack {
+            Text(Strings.Views.Tv.WebUploader.qr)
+            QRCodeView(text: website.url.absoluteString)
+                .frame(width: 400)
+                .padding(.vertical)
+
+            VStack {
+                Text(website.url.absoluteString)
+                    .fontWeight(.bold)
+
+                if let passcode = website.passcode {
+                    HStack(spacing: .zero) {
+                        Text("\(Strings.Global.Nouns.passcode): ")
+                        Text(passcode)
+                            .fontWeight(.bold)
+                    }
+                }
+            }
+            .font(.title3)
+
+            Spacer()
+        }
+    }
+}
+
+private extension WebUploaderView {
+
+    @Sendable
+    func handleUploadedFile() async {
+        for await file in uploadManager.files {
+            pp_log_g(.App.web, .info, "Uploaded: \(file.name), \(file.contents.count) bytes")
+            do {
+                var profile = try registry.profile(
+                    from: file.contents,
+                    withName: file.name,
+                    passphrase: nil
+                )
+                pp_log_g(.App.web, .info, "Import uploaded profile: \(profile)")
+
+                var builder = profile.builder()
+                builder.attributes.isAvailableForTV = true
+                profile = try builder.tryBuild()
+
+                try await profileManager.save(profile, isLocal: true)
+
+                // upload once
+                uploadManager.stop()
+            } catch {
+                pp_log_g(.App.web, .error, "Unable to import uploaded profile: \(error)")
+                errorHandler.handle(error)
+            }
+        }
+    }
+}
+
+// MARK: -
+
+#Preview {
+    WebUploaderView(
+        uploadManager: .forPreviews,
+        registry: Registry(),
+        profileManager: .forPreviews,
+        errorHandler: .default()
+    )
+    .task {
+        try? UploadManager.forPreviews.start()
+    }
+}

--- a/Packages/App/Sources/AppUITV/Views/Settings/SettingsView.swift
+++ b/Packages/App/Sources/AppUITV/Views/Settings/SettingsView.swift
@@ -28,18 +28,6 @@ import CommonUtils
 import SwiftUI
 import UILibrary
 
-enum Detail {
-    case credits
-
-    case donate
-
-    case other
-
-    case purchased
-
-    case version
-}
-
 struct SettingsView: View {
 
     @EnvironmentObject
@@ -82,7 +70,7 @@ private extension SettingsView {
                 BetaSection()
             }
             creditsSection
-            diagnosticsSection
+            troubleshootingSection
         }
         .themeList()
     }
@@ -105,7 +93,7 @@ private extension SettingsView {
         .themeSection(header: Strings.Views.Settings.title)
     }
 
-    var diagnosticsSection: some View {
+    var troubleshootingSection: some View {
         Group {
             NavigationLink(Strings.Views.Diagnostics.Rows.app, value: AppCoordinatorRoute.appLog)
             NavigationLink(Strings.Views.Diagnostics.Rows.tunnel, value: AppCoordinatorRoute.tunnelLog)
@@ -113,8 +101,22 @@ private extension SettingsView {
             Button(Strings.Views.Purchased.title) {}
                 .focused($focus, equals: .purchased)
         }
-        .themeSection(header: Strings.Views.Diagnostics.title)
+        .themeSection(header: Strings.Global.Nouns.troubleshooting)
     }
+}
+
+// MARK: - Detail
+
+private enum Detail {
+    case credits
+
+    case donate
+
+    case other
+
+    case purchased
+
+    case version
 }
 
 private struct DetailView: View {
@@ -142,7 +144,7 @@ private struct DetailView: View {
     }
 }
 
-// MARK: -
+// MARK: - Preview
 
 #Preview {
     SettingsView(tunnel: .forPreviews)

--- a/Packages/App/Sources/AppUITV/Views/UI/TopSpacer.swift
+++ b/Packages/App/Sources/AppUITV/Views/UI/TopSpacer.swift
@@ -1,8 +1,8 @@
 //
-//  DonateViewModifier.swift
+//  TopSpacer.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 11/23/24.
+//  Created by Davide De Rosa on 6/6/25.
 //  Copyright (c) 2025 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -25,25 +25,10 @@
 
 import SwiftUI
 
-struct DonateViewModifier: ViewModifier {
-    func body(content: Content) -> some View {
+struct TopSpacer: View {
+    var body: some View {
         VStack {
-            TopSpacer()
-            Text(Strings.Views.Donate.Sections.Main.footer)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.bottom)
-
-            ScrollView {
-                LazyVGrid(columns: columns) {
-                    content
-                }
-            }
         }
-    }
-}
-
-private extension DonateViewModifier {
-    var columns: [GridItem] {
-        [GridItem(.adaptive(minimum: 300))]
+        .frame(height: 60)
     }
 }

--- a/Packages/App/Sources/CommonLibrary/Business/UploadManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/UploadManager.swift
@@ -1,0 +1,93 @@
+//
+//  UploadManager.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/4/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonUtils
+import Foundation
+
+@MainActor
+public final class UploadManager: ObservableObject {
+    public struct Website: Sendable {
+        public let url: URL
+
+        public let passcode: String?
+    }
+
+    public struct File: Sendable {
+        public let name: String
+
+        public let contents: String
+
+        init(name: String, contents: String) {
+            self.name = name
+            self.contents = contents
+        }
+    }
+
+    public typealias PasscodeGenerator = () -> String
+
+    private let webUploader: WebUploader
+
+    private let passcodeGenerator: PasscodeGenerator?
+
+    private let filesStream: PassthroughStream<File>
+
+    public var isStarted: Bool {
+        website != nil
+    }
+
+    @Published
+    public private(set) var website: Website?
+
+    public var files: AsyncStream<File> {
+        filesStream.subscribe()
+    }
+
+    public init(
+        webUploader: WebUploader,
+        passcodeGenerator: PasscodeGenerator? = nil
+    ) {
+        self.webUploader = webUploader
+        self.passcodeGenerator = passcodeGenerator
+        filesStream = PassthroughStream()
+    }
+
+    public func start() throws {
+        let passcode = passcodeGenerator?()
+        let url = try webUploader.start(passcode: passcode) { [weak self] in
+            self?.filesStream.send(File(name: $0, contents: $1))
+        }
+        website = Website(url: url, passcode: passcode)
+    }
+
+    public func stop() {
+        webUploader.stop()
+        website = nil
+    }
+
+    public func destroy() {
+        stop()
+        filesStream.finish()
+    }
+}

--- a/Packages/App/Sources/CommonLibrary/Domain/AppError.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/AppError.swift
@@ -51,6 +51,8 @@ public enum AppError: Error {
 
     case unknown
 
+    case webUploader(Error? = nil)
+
     public init(_ error: Error) {
         if let spError = error as? AppError {
             self = spError

--- a/Packages/App/Sources/CommonLibrary/Domain/Constants.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/Constants.swift
@@ -155,6 +155,12 @@ public struct Constants: Decodable, Sendable {
         public let productsTimeoutInterval: Int
     }
 
+    public struct WebUploader: Decodable, Sendable {
+        public let port: Int
+
+        public let passcodeLength: Int
+    }
+
     public struct Log: Decodable, Sendable {
         public struct Formatter: Decodable, Sendable {
             enum CodingKeys: CodingKey {
@@ -209,6 +215,8 @@ public struct Constants: Decodable, Sendable {
     public let api: API
 
     public let iap: IAP
+
+    public let webUploader: WebUploader
 
     public let log: Log
 }

--- a/Packages/App/Sources/CommonLibrary/Extensions/ModuleImporter+Profile.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/ModuleImporter+Profile.swift
@@ -1,0 +1,49 @@
+//
+//  ModuleImporter+Profile.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/5/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension ModuleImporter {
+    public func profile(from contents: String, withName name: String, passphrase: String?) throws -> Profile {
+        let module = try module(fromContents: contents, object: passphrase)
+        return try Profile(withName: name, importedModule: module)
+    }
+
+    public func profile(from url: URL, passphrase: String?) throws -> Profile {
+        let module = try module(fromURL: url, object: passphrase)
+        return try Profile(withName: url.lastPathComponent, importedModule: module)
+    }
+}
+
+private extension Profile {
+    init(withName name: String, importedModule: Module) throws {
+        let onDemandModule = OnDemandModule.Builder().tryBuild()
+        var builder = Profile.Builder()
+        builder.name = name
+        builder.modules = [importedModule, onDemandModule]
+        builder.activeModulesIds = Set(builder.modules.map(\.id))
+        self = try builder.tryBuild()
+    }
+}

--- a/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
@@ -127,7 +127,8 @@ private extension PartoutLogger.Builder {
             .wireguard,
             .App.iap,
             .App.migration,
-            .App.profiles
+            .App.profiles,
+            .App.web
         ])
 
         setLocalLogger(

--- a/Packages/App/Sources/CommonLibrary/Resources/Constants.json
+++ b/Packages/App/Sources/CommonLibrary/Resources/Constants.json
@@ -53,6 +53,10 @@
     "iap": {
         "productsTimeoutInterval": 10.0
     },
+    "webUploader": {
+        "port": 10000,
+        "passcodeLength": 6
+    },
     "log": {
         "appPath": "app.log",
         "tunnelPath": "tunnel.log",

--- a/Packages/App/Sources/CommonLibrary/Shared.swift
+++ b/Packages/App/Sources/CommonLibrary/Shared.swift
@@ -35,6 +35,8 @@ extension LoggerCategory {
         public static let migration = LoggerCategory(rawValue: "app.migration")
 
         public static let profiles = LoggerCategory(rawValue: "app.profiles")
+
+        public static let web = LoggerCategory(rawValue: "app.web")
     }
 }
 

--- a/Packages/App/Sources/CommonLibrary/Strategy/DummyWebUploader.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/DummyWebUploader.swift
@@ -1,0 +1,49 @@
+//
+//  DummyWebUploader.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/5/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public final class DummyWebUploader: WebUploader {
+    private let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func start(passcode: String?, onReceive: @escaping (String, String) -> Void) throws -> URL {
+//        assertionFailure("DummyWebUploader: start()")
+        return url
+    }
+
+    public func stop() {
+//        assertionFailure("DummyWebUploader: stop()")
+    }
+}
+
+extension UploadManager {
+    public convenience init() {
+        self.init(webUploader: DummyWebUploader(url: URL(fileURLWithPath: "")))
+    }
+}

--- a/Packages/App/Sources/CommonLibrary/Strategy/WebUploader.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/WebUploader.swift
@@ -1,0 +1,32 @@
+//
+//  WebUploader.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/3/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public protocol WebUploader {
+    func start(passcode: String?, onReceive: @escaping (String, String) -> Void) throws -> URL
+
+    func stop()
+}

--- a/Packages/App/Sources/CommonUtils/Extensions/String+QR.swift
+++ b/Packages/App/Sources/CommonUtils/Extensions/String+QR.swift
@@ -1,0 +1,40 @@
+//
+//  String+QR.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/5/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CoreImage.CIFilterBuiltins
+import Foundation
+
+extension String {
+    public func qrImage() -> CGImage? {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        let data = Data(utf8)
+        filter.setValue(data, forKey: "inputMessage")
+        guard let outputImage = filter.outputImage else {
+            return nil
+        }
+        return context.createCGImage(outputImage, from: outputImage.extent)
+    }
+}

--- a/Packages/App/Sources/CommonUtils/Views/QRCodeView.swift
+++ b/Packages/App/Sources/CommonUtils/Views/QRCodeView.swift
@@ -1,0 +1,43 @@
+//
+//  QRCodeView.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/4/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public struct QRCodeView: View {
+    private let text: String
+
+    public init(text: String) {
+        self.text = text
+    }
+
+    public var body: some View {
+        if let cgImage = text.qrImage() {
+            Image(decorative: cgImage, scale: 1.0)
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+        }
+    }
+}

--- a/Packages/App/Sources/UILibrary/Business/AppContext.swift
+++ b/Packages/App/Sources/UILibrary/Business/AppContext.swift
@@ -55,6 +55,8 @@ public final class AppContext: ObservableObject, Sendable {
 
     public let tunnel: ExtendedTunnel
 
+    public let uploadManager: UploadManager
+
     private let onEligibleFeaturesBlock: ((Set<AppFeature>) async -> Void)?
 
     private var launchTask: Task<Void, Error>?
@@ -75,6 +77,7 @@ public final class AppContext: ObservableObject, Sendable {
         registry: Registry,
         sysexManager: SystemExtensionManager?,
         tunnel: ExtendedTunnel,
+        uploadManager: UploadManager,
         onEligibleFeaturesBlock: ((Set<AppFeature>) async -> Void)? = nil
     ) {
         self.apiManager = apiManager
@@ -89,6 +92,7 @@ public final class AppContext: ObservableObject, Sendable {
         self.registry = registry
         self.sysexManager = sysexManager
         self.tunnel = tunnel
+        self.uploadManager = uploadManager
         self.onEligibleFeaturesBlock = onEligibleFeaturesBlock
         subscriptions = []
     }

--- a/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
+++ b/Packages/App/Sources/UILibrary/L10n/AppError+L10n.swift
@@ -67,6 +67,9 @@ extension AppError: LocalizedError {
 
         case .unknown:
             return nil
+
+        case .webUploader:
+            return nil
         }
     }
 }

--- a/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/UILibrary/L10n/SwiftGen+Strings.swift
@@ -206,6 +206,8 @@ public enum Strings {
       public static let enable = Strings.tr("Localizable", "global.actions.enable", fallback: "Enable")
       /// Hide
       public static let hide = Strings.tr("Localizable", "global.actions.hide", fallback: "Hide")
+      /// Import
+      public static let `import` = Strings.tr("Localizable", "global.actions.import", fallback: "Import")
       /// Purchase
       public static let purchase = Strings.tr("Localizable", "global.actions.purchase", fallback: "Purchase")
       /// Reconnect
@@ -320,6 +322,8 @@ public enum Strings {
       public static let onDemand = Strings.tr("Localizable", "global.nouns.on_demand", fallback: "On-demand")
       /// Other
       public static let other = Strings.tr("Localizable", "global.nouns.other", fallback: "Other")
+      /// Passcode
+      public static let passcode = Strings.tr("Localizable", "global.nouns.passcode", fallback: "Passcode")
       /// Password
       public static let password = Strings.tr("Localizable", "global.nouns.password", fallback: "Password")
       /// Port
@@ -332,6 +336,8 @@ public enum Strings {
       public static let products = Strings.tr("Localizable", "global.nouns.products", fallback: "Products")
       /// Profile
       public static let profile = Strings.tr("Localizable", "global.nouns.profile", fallback: "Profile")
+      /// Profiles
+      public static let profiles = Strings.tr("Localizable", "global.nouns.profiles", fallback: "Profiles")
       /// Protocol
       public static let `protocol` = Strings.tr("Localizable", "global.nouns.protocol", fallback: "Protocol")
       /// Provider
@@ -678,12 +684,6 @@ public enum Strings {
           public static let provider = Strings.tr("Localizable", "views.app.toolbar.new_profile.provider", fallback: "Provider")
         }
       }
-      public enum Tv {
-        /// Open %@ on your iOS or macOS device and enable the "%@" toggle of a profile to make it appear here. All devices must be running version 3.0.0 or later for this to work.
-        public static func header(_ p1: Any, _ p2: Any) -> String {
-          return Strings.tr("Localizable", "views.app.tv.header", String(describing: p1), String(describing: p2), fallback: "Open %@ on your iOS or macOS device and enable the \"%@\" toggle of a profile to make it appear here. All devices must be running version 3.0.0 or later for this to work.")
-        }
-      }
     }
     public enum AppMenu {
       public enum Items {
@@ -1025,6 +1025,28 @@ public enum Strings {
           /// Open Preferences
           public static let `open` = Strings.tr("Localizable", "views.settings.system_extension.buttons.open", fallback: "Open Preferences")
         }
+      }
+    }
+    public enum Tv {
+      public enum ConnectionProfiles {
+        /// Open %@ on your iOS or macOS device and enable the "%@" toggle of a profile to make it appear here. Alternatively, you will find other options in the "Profiles" tab.
+        public static func header(_ p1: Any, _ p2: Any) -> String {
+          return Strings.tr("Localizable", "views.tv.connection_profiles.header", String(describing: p1), String(describing: p2), fallback: "Open %@ on your iOS or macOS device and enable the \"%@\" toggle of a profile to make it appear here. Alternatively, you will find other options in the \"Profiles\" tab.")
+        }
+      }
+      public enum Profiles {
+        /// Import local profile
+        public static let importLocal = Strings.tr("Localizable", "views.tv.profiles.import_local", fallback: "Import local profile")
+        public enum Detail {
+          /// Use the long press to present the available actions for a profile. Local profiles can be deleted here, whereas iCloud profiles can only be deleted from the iOS or macOS app.
+          public static let profiles = Strings.tr("Localizable", "views.tv.profiles.detail.profiles", fallback: "Use the long press to present the available actions for a profile. Local profiles can be deleted here, whereas iCloud profiles can only be deleted from the iOS or macOS app.")
+        }
+      }
+      public enum WebUploader {
+        /// Scan the QR with your camera to open a web page where to upload your profile.
+        public static let qr = Strings.tr("Localizable", "views.tv.web_uploader.qr", fallback: "Scan the QR with your camera to open a web page where to upload your profile.")
+        /// Toggle to import a local profile into your TV with a web browser.
+        public static let toggle = Strings.tr("Localizable", "views.tv.web_uploader.toggle", fallback: "Toggle to import a local profile into your TV with a web browser.")
       }
     }
     public enum Ui {

--- a/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
+++ b/Packages/App/Sources/UILibrary/Previews/AppContext+Previews.swift
@@ -65,7 +65,12 @@ extension AppContext {
         let migrationManager = MigrationManager()
         let preferencesManager = PreferencesManager()
         let registry = Registry()
+
+        let dummyUploader = DummyWebUploader(url: URL(string: "http://127.0.0.1:9000")!)
+        let uploadManager = UploadManager(webUploader: dummyUploader, passcodeGenerator: { "123456" })
+
         let distributionTarget: DistributionTarget = .appStore
+
         return AppContext(
             apiManager: apiManager,
             distributionTarget: distributionTarget,
@@ -76,7 +81,8 @@ extension AppContext {
             profileManager: profileManager,
             registry: registry,
             sysexManager: nil,
-            tunnel: tunnel
+            tunnel: tunnel,
+            uploadManager: uploadManager
         )
     }()
 }
@@ -104,5 +110,11 @@ extension ExtendedTunnel {
 extension APIManager {
     public static var forPreviews: APIManager {
         AppContext.forPreviews.apiManager
+    }
+}
+
+extension UploadManager {
+    public static var forPreviews: UploadManager {
+        AppContext.forPreviews.uploadManager
     }
 }

--- a/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/de.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Bearbeiten";
 "global.actions.enable" = "Aktivieren";
 "global.actions.hide" = "Verbergen";
+"global.actions.import" = "Importieren";
 "global.actions.purchase" = "Kaufen";
 "global.actions.reconnect" = "Erneut verbinden";
 "global.actions.remove" = "Löschen";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "On-Demand";
 "global.nouns.other" = "Andere";
+"global.nouns.passcode" = "Code";
 "global.nouns.password" = "Passwort";
 "global.nouns.port" = "Port";
 "global.nouns.preferences" = "Einstellungen";
 "global.nouns.private_key" = "Privater Schlüssel";
 "global.nouns.products" = "Produkte"; // German
 "global.nouns.profile" = "Profil";
+"global.nouns.profiles" = "Profile";
 "global.nouns.protocol" = "Protokoll";
 "global.nouns.provider" = "Anbieter";
 "global.nouns.public_key" = "Öffentlicher Schlüssel";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Profile migrieren";
 "views.app.toolbar.new_profile.empty" = "Leeres Profil";
 "views.app.toolbar.new_profile.provider" = "Anbieter";
-"views.app.tv.header" = "Öffnen Sie %@ auf Ihrem iOS- oder macOS-Gerät und aktivieren Sie den Schalter \"%@\" in einem Profil, damit es hier angezeigt wird. Alle Geräte müssen Version 3.0.0 oder neuer ausführen, damit dies funktioniert.";
 "views.diagnostics.alerts.report_issue.email" = "Das Gerät ist nicht zum Senden von E-Mails konfiguriert.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Serverkonfiguration";
 "views.diagnostics.report_issue.title" = "Problem melden";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Einstellungen öffnen";
 "views.settings.system_extension.message" = "Damit das VPN funktioniert, muss sich die App im Verzeichnis /Programme befinden und %@ muss als %@ aktiviert sein.\n\nÖffne die macOS-Einstellungen, scrolle zu „%@“, öffne es und aktiviere %@.";
 "views.settings.title" = "Über";
+"views.tv.connection_profiles.header" = "Öffne %@ auf deinem iOS- oder macOS-Gerät und aktiviere den „%@“-Schalter eines Profils, damit es hier erscheint. Alternativ findest du weitere Optionen im Tab „Profile“.";
+"views.tv.profiles.detail.profiles" = "Nutze den Langdruck, um die verfügbaren Aktionen für ein Profil anzuzeigen. Lokale Profile können hier gelöscht werden, iCloud-Profile jedoch nur in der iOS- oder macOS-App.";
+"views.tv.profiles.import_local" = "Lokales Profil importieren";
+"views.tv.web_uploader.qr" = "Scanne den QR-Code mit deiner Kamera, um eine Webseite zu öffnen, auf der du dein Profil hochladen kannst.";
+"views.tv.web_uploader.toggle" = "Umschalten, um ein lokales Profil über einen Webbrowser auf deinen Fernseher zu importieren.";
 "views.ui.connection_status.on_demand_suffix" = " (auf Anfrage)";
 "views.ui.purchase_required.purchase.help" = "Kauf erforderlich";
 "views.ui.purchase_required.restricted.help" = "Funktion eingeschränkt";

--- a/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/el.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Επεξεργασία";
 "global.actions.enable" = "Ενεργοποίηση";
 "global.actions.hide" = "Απόκρυψη";
+"global.actions.import" = "Εισαγωγή";
 "global.actions.purchase" = "Αγορά";
 "global.actions.reconnect" = "Επανασύνδεση";
 "global.actions.remove" = "Κατάργηση";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "Κατ' απαίτηση";
 "global.nouns.other" = "Άλλο";
+"global.nouns.passcode" = "Κωδικός";
 "global.nouns.password" = "Κωδικός πρόσβασης";
 "global.nouns.port" = "Θύρα";
 "global.nouns.preferences" = "Προτιμήσεις";
 "global.nouns.private_key" = "Ιδιωτικό κλειδί";
 "global.nouns.products" = "Προϊόντα"; // Greek
 "global.nouns.profile" = "Προφίλ";
+"global.nouns.profiles" = "Προφίλ";
 "global.nouns.protocol" = "Πρωτόκολλο";
 "global.nouns.provider" = "Πάροχος";
 "global.nouns.public_key" = "Δημόσιο κλειδί";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Μεταφορά προφίλ";
 "views.app.toolbar.new_profile.empty" = "Κενό προφίλ";
 "views.app.toolbar.new_profile.provider" = "Πάροχος";
-"views.app.tv.header" = "Ανοίξτε το %@ στη συσκευή σας iOS ή macOS και ενεργοποιήστε τον διακόπτη \"%@\" σε ένα προφίλ για να εμφανιστεί εδώ. Όλες οι συσκευές πρέπει να εκτελούν την έκδοση 3.0.0 ή νεότερη για να λειτουργήσει.";
 "views.diagnostics.alerts.report_issue.email" = "Η συσκευή δεν είναι ρυθμισμένη για αποστολή email.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Διαμόρφωση διακομιστή";
 "views.diagnostics.report_issue.title" = "Αναφορά προβλήματος";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Άνοιγμα προτιμήσεων";
 "views.settings.system_extension.message" = "Για να λειτουργήσει το VPN, η εφαρμογή πρέπει να βρίσκεται στον φάκελο /Applications και το %@ πρέπει να είναι ενεργοποιημένο ως %@.\n\nΆνοιξε τις Προτιμήσεις του macOS, κύλησε στο «%@», άνοιξέ το και ενεργοποίησε το %@.";
 "views.settings.title" = "Σχετικά";
+"views.tv.connection_profiles.header" = "Άνοιξε το %@ στη συσκευή σου iOS ή macOS και ενεργοποίησε την εναλλαγή \"%@\" σε ένα προφίλ για να εμφανιστεί εδώ. Εναλλακτικά, θα βρεις άλλες επιλογές στην καρτέλα \"Προφίλ\".";
+"views.tv.profiles.detail.profiles" = "Χρησιμοποίησε παρατεταμένο πάτημα για να εμφανίσεις τις διαθέσιμες ενέργειες για ένα προφίλ. Τα τοπικά προφίλ μπορούν να διαγραφούν εδώ, ενώ τα iCloud προφίλ μόνο από την εφαρμογ iOS ή macOS.";
+"views.tv.profiles.import_local" = "Εισαγωγή τοπικού προφίλ";
+"views.tv.web_uploader.qr" = "Σάρωσε το QR με την κάμερά σου για να ανοίξεις μια σελίδα όπου μπορείς να ανεβάσεις το προφίλ σου.";
+"views.tv.web_uploader.toggle" = "Εναλλαγή για εισαγωγή τοπικού προφίλ στην τηλεόρασή σου μέσω web browser.";
 "views.ui.connection_status.on_demand_suffix" = " (κατ' απαίτηση)";
 "views.ui.purchase_required.purchase.help" = "Απαιτείται αγορά";
 "views.ui.purchase_required.restricted.help" = "Η λειτουργία είναι περιορισμένη";
@@ -335,3 +342,4 @@
 "views.version.extra" = "Το %@ είναι ένα έργο που συντηρείται από τον/την %@.\n\nΟ πηγαίος κώδικας είναι διαθέσιμος δημόσια στο GitHub υπό την άδεια GPLv3. Μπορείτε να βρείτε τους συνδέσμους στην αρχική σελίδα.";
 "views.vpn.category.any" = "Όλες οι κατηγορίες";
 "views.vpn.no_servers" = "Δεν υπάρχουν διακομιστές";
+"views.web_uploader.message" = "Σάρωσε αυτόν τον QR για να ανοίξεις μια σελίδα αποστολής του προφίλ σου.";

--- a/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/en.lproj/Localizable.strings
@@ -53,7 +53,6 @@
 "views.app.toolbar.new_profile.provider" = "Provider";
 "views.app.toolbar.import_profile" = "Import profile";
 "views.app.toolbar.migrate_profiles" = "Migrate profiles";
-"views.app.tv.header" = "Open %@ on your iOS or macOS device and enable the \"%@\" toggle of a profile to make it appear here. All devices must be running version 3.0.0 or later for this to work.";
 
 "views.app.profile_context.connect_to" = "Connect to";
 
@@ -154,6 +153,12 @@
 
 "views.vpn.category.any" = "All categories";
 "views.vpn.no_servers" = "No servers";
+
+"views.tv.connection_profiles.header" = "Open %@ on your iOS or macOS device and enable the \"%@\" toggle of a profile to make it appear here. Alternatively, you will find other options in the \"Profiles\" tab.";
+"views.tv.profiles.import_local" = "Import local profile";
+"views.tv.profiles.detail.profiles" = "Use the long press to present the available actions for a profile. Local profiles can be deleted here, whereas iCloud profiles can only be deleted from the iOS or macOS app.";
+"views.tv.web_uploader.toggle" = "Toggle to import a local profile into your TV with a web browser.";
+"views.tv.web_uploader.qr" = "Scan the QR with your camera to open a web page where to upload your profile.";
 
 // MARK: Views (Modules)
 
@@ -296,6 +301,7 @@
 "global.actions.edit" = "Edit";
 "global.actions.enable" = "Enable";
 "global.actions.hide" = "Hide";
+"global.actions.import" = "Import";
 "global.actions.purchase" = "Purchase";
 "global.actions.remove" = "Delete";
 "global.actions.reconnect" = "Reconnect";
@@ -348,7 +354,6 @@
 "global.nouns.n_seconds" = "%d seconds";
 "global.nouns.name" = "Name";
 "global.nouns.networks" = "Networks";
-
 "global.nouns.no" = "No";
 "global.nouns.no_content" = "No content";
 "global.nouns.no_selection" = "No selection";
@@ -356,12 +361,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "On-demand";
 "global.nouns.other" = "Other";
+"global.nouns.passcode" = "Passcode";
 "global.nouns.password" = "Password";
 "global.nouns.port" = "Port";
 "global.nouns.preferences" = "Preferences";
 "global.nouns.private_key" = "Private key";
 "global.nouns.products" = "Products";
 "global.nouns.profile" = "Profile";
+"global.nouns.profiles" = "Profiles";
 "global.nouns.protocol" = "Protocol";
 "global.nouns.provider" = "Provider";
 "global.nouns.public_key" = "Public key";

--- a/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/es.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Editar";
 "global.actions.enable" = "Habilitar";
 "global.actions.hide" = "Ocultar";
+"global.actions.import" = "Importar";
 "global.actions.purchase" = "Comprar";
 "global.actions.reconnect" = "Reconectar";
 "global.actions.remove" = "Eliminar";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "Bajo demanda";
 "global.nouns.other" = "Otro";
+"global.nouns.passcode" = "Código";
 "global.nouns.password" = "Contraseña";
 "global.nouns.port" = "Puerto";
 "global.nouns.preferences" = "Preferencias";
 "global.nouns.private_key" = "Clave privada";
 "global.nouns.products" = "Productos"; // Spanish
 "global.nouns.profile" = "Perfil";
+"global.nouns.profiles" = "Perfiles";
 "global.nouns.protocol" = "Protocolo";
 "global.nouns.provider" = "Proveedor";
 "global.nouns.public_key" = "Clave pública";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Migrar perfiles";
 "views.app.toolbar.new_profile.empty" = "Perfil vacío";
 "views.app.toolbar.new_profile.provider" = "Proveedor";
-"views.app.tv.header" = "Abre %@ en tu dispositivo iOS o macOS y activa el interruptor \"%@\" de un perfil para que aparezca aquí. Todos los dispositivos deben ejecutar la versión 3.0.0 o posterior para que esto funcione.";
 "views.diagnostics.alerts.report_issue.email" = "El dispositivo no está configurado para enviar correos electrónicos.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Configuración del servidor";
 "views.diagnostics.report_issue.title" = "Informar problema";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Abrir preferencias";
 "views.settings.system_extension.message" = "Para que funcione la VPN, la app debe estar en el directorio /Applications y %@ debe estar activado como %@.\n\nAbre las Preferencias del Sistema de macOS, desplázate hasta «%@», ábrelo y activa %@.";
 "views.settings.title" = "Acerca de";
+"views.tv.connection_profiles.header" = "Abre %@ en tu dispositivo iOS o macOS y activa el interruptor \"%@\" de un perfil para que aparezca aquí. Alternativamente, encontrarás otras opciones en la pestaña \"Perfiles\".";
+"views.tv.profiles.detail.profiles" = "Usa la pulsación larga para mostrar las acciones disponibles para un perfil. Los perfiles locales pueden eliminarse aquí, mientras que los de iCloud solo desde la app iOS o macOS.";
+"views.tv.profiles.import_local" = "Importar perfil local";
+"views.tv.web_uploader.qr" = "Escanea el código QR con la cámara para abrir una página web donde subir tu perfil.";
+"views.tv.web_uploader.toggle" = "Activa para importar un perfil local a tu TV mediante un navegador web.";
 "views.ui.connection_status.on_demand_suffix" = " (a demanda)";
 "views.ui.purchase_required.purchase.help" = "Compra requerida";
 "views.ui.purchase_required.restricted.help" = "Función restringida";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ es un proyecto mantenido por %@.\n\nEl código fuente está disponible públicamente en GitHub bajo la GPLv3, puedes encontrar los enlaces en la página principal.";
 "views.vpn.category.any" = "Todas las categorías";
 "views.vpn.no_servers" = "No hay servidores";
+"views.web_uploader.message" = "Escanea este código QR para abrir una página web donde subir tu perfil.";

--- a/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/fr.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Modifier";
 "global.actions.enable" = "Activer";
 "global.actions.hide" = "Cacher";
+"global.actions.import" = "Importer";
 "global.actions.purchase" = "Acheter";
 "global.actions.reconnect" = "Reconnecter";
 "global.actions.remove" = "Supprimer";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "À la demande";
 "global.nouns.other" = "Autre";
+"global.nouns.passcode" = "Code";
 "global.nouns.password" = "Mot de passe";
 "global.nouns.port" = "Port";
 "global.nouns.preferences" = "Préférences";
 "global.nouns.private_key" = "Clé privée";
 "global.nouns.products" = "Produits"; // French
 "global.nouns.profile" = "Profil";
+"global.nouns.profiles" = "Profils";
 "global.nouns.protocol" = "Protocole";
 "global.nouns.provider" = "Fournisseur";
 "global.nouns.public_key" = "Clé publique";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Migrer les profils";
 "views.app.toolbar.new_profile.empty" = "Profil vide";
 "views.app.toolbar.new_profile.provider" = "Fournisseur";
-"views.app.tv.header" = "Ouvrez %@ sur votre appareil iOS ou macOS et activez l’interrupteur \"%@\" d’un profil pour qu’il apparaisse ici. Tous les appareils doivent exécuter la version 3.0.0 ou ultérieure pour que cela fonctionne.";
 "views.diagnostics.alerts.report_issue.email" = "L'appareil n'est pas configuré pour envoyer des e-mails.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Configuration du serveur";
 "views.diagnostics.report_issue.title" = "Signaler un problème";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Ouvrir les réglages";
 "views.settings.system_extension.message" = "Pour que le VPN fonctionne, lapp doit se trouver dans le dossier /Applications, et %@ doit être activé en tant que %@.\n\nOuvrez les Réglages macOS, faites défiler jusqu’à « %@ », ouvrez-le et activez %@.";
 "views.settings.title" = "À propos";
+"views.tv.connection_profiles.header" = "Ouvre %@ sur ton appareil iOS ou macOS et active l’option \"%@\" d’un profil pour qu’il apparaisse ici. Sinon, tu trouveras d’autres options dans l’onglet « Profils ».";
+"views.tv.profiles.detail.profiles" = "Utilisez la pression longue pour afficher les actions disponibles pour un profil. Les profils locaux peuvent être supprimés ici, tandis que les profils iCloud uniquement depuis l’application iOS ou macOS.";
+"views.tv.profiles.import_local" = "Importer un profil local";
+"views.tv.web_uploader.qr" = "Scannez le QR avec votre appareil photo pour ouvrir une page web où importer votre profil.";
+"views.tv.web_uploader.toggle" = "Basculez pour importer un profil local sur votre TV via un navigateur web.";
 "views.ui.connection_status.on_demand_suffix" = " (à la demande)";
 "views.ui.purchase_required.purchase.help" = "Achat requis";
 "views.ui.purchase_required.restricted.help" = "Fonction restreinte";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ est un projet maintenu par %@.\n\nLe code source est disponible publiquement sur GitHub sous la licence GPLv3, vous pouvez trouver les liens sur la page d'accueil.";
 "views.vpn.category.any" = "Toutes les catégories";
 "views.vpn.no_servers" = "Aucun serveur";
+"views.web_uploader.message" = "Scannez ce QR code pour ouvrir une page web où importer votre profil.";

--- a/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/it.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Modifica";
 "global.actions.enable" = "Abilita";
 "global.actions.hide" = "Nascondi";
+"global.actions.import" = "Importa";
 "global.actions.purchase" = "Acquista";
 "global.actions.reconnect" = "Riconnetti";
 "global.actions.remove" = "Elimina";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "On-demand";
 "global.nouns.other" = "Altro";
+"global.nouns.passcode" = "Codice";
 "global.nouns.password" = "Password";
 "global.nouns.port" = "Porta";
 "global.nouns.preferences" = "Preferenze";
 "global.nouns.private_key" = "Chiave privata";
 "global.nouns.products" = "Prodotti"; // Italian
 "global.nouns.profile" = "Profilo";
+"global.nouns.profiles" = "Profili";
 "global.nouns.protocol" = "Protocollo";
 "global.nouns.provider" = "Provider";
 "global.nouns.public_key" = "Chiave pubblica";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Migra profili";
 "views.app.toolbar.new_profile.empty" = "Profilo vuoto";
 "views.app.toolbar.new_profile.provider" = "Provider";
-"views.app.tv.header" = "Apri %@ sul tuo dispositivo iOS o macOS e abilita l'interruttore \"%@\" di un profilo per farlo apparire qui. Tutti i dispositivi devono eseguire la versione 3.0.0 o successiva affinché funzioni.";
 "views.diagnostics.alerts.report_issue.email" = "Il dispositivo non è configurato per inviare e-mail.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Configurazione del server";
 "views.diagnostics.report_issue.title" = "Segnala problema";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Apri le preferenze";
 "views.settings.system_extension.message" = "Per far funzionare la VPN, l’app deve trovarsi nella directory /Applications e %@ deve essere abilitato come %@.\n\nApri le Preferenze di Sistema di macOS, scorri fino a “%@”, aprilo e abilita %@.";
 "views.settings.title" = "Informazioni";
+"views.tv.connection_profiles.header" = "Apri %@ sul tuo dispositivo iOS o macOS e attiva l'interruttore \"%@\" di un profilo per farlo comparire qui. In alternativa, troverai altre opzioni nella scheda \"Profili\".";
+"views.tv.profiles.detail.profiles" = "Usa la pressione prolungata per mostrare le azioni disponibili per un profilo. I profili locali possono essere eliminati qui, mentre i profili iCloud solo dall’app iOS o macOS.";
+"views.tv.profiles.import_local" = "Importa profilo locale";
+"views.tv.web_uploader.qr" = "Scansiona il QR con la fotocamera per aprire una pagina web dove caricare il tuo profilo.";
+"views.tv.web_uploader.toggle" = "Attiva per importare un profilo locale sulla tua TV tramite browser web.";
 "views.ui.connection_status.on_demand_suffix" = " (on-demand)";
 "views.ui.purchase_required.purchase.help" = "Acquisto richiesto";
 "views.ui.purchase_required.restricted.help" = "Funzionalità ristretta";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ è un progetto mantenuto da %@.\n\nIl codice sorgente è pubblicamente disponibile su GitHub sotto la licenza GPLv3, puoi trovare i link nella home page.";
 "views.vpn.category.any" = "Tutte le categorie";
 "views.vpn.no_servers" = "Nessun server";
+"views.web_uploader.message" = "Scansiona questo QR per aprire una pagina web dove caricare il tuo profilo.";

--- a/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/nl.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Bewerken";
 "global.actions.enable" = "Inschakelen";
 "global.actions.hide" = "Verbergen";
+"global.actions.import" = "Importeren";
 "global.actions.purchase" = "Aankopen";
 "global.actions.reconnect" = "Opnieuw verbinden";
 "global.actions.remove" = "Verwijderen";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "Op aanvraag";
 "global.nouns.other" = "Anders";
+"global.nouns.passcode" = "Toegangscode";
 "global.nouns.password" = "Wachtwoord";
 "global.nouns.port" = "Poort";
 "global.nouns.preferences" = "Voorkeuren";
 "global.nouns.private_key" = "Privésleutel";
 "global.nouns.products" = "Producten"; // Dutch
 "global.nouns.profile" = "Profiel";
+"global.nouns.profiles" = "Profielen";
 "global.nouns.protocol" = "Protocol";
 "global.nouns.provider" = "Provider";
 "global.nouns.public_key" = "Publieke sleutel";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Profielen migreren";
 "views.app.toolbar.new_profile.empty" = "Leeg profiel";
 "views.app.toolbar.new_profile.provider" = "Provider";
-"views.app.tv.header" = "Open %@ op je iOS- of macOS-apparaat en schakel de \"%@\"-schakelaar van een profiel in om het hier te laten verschijnen. Alle apparaten moeten versie 3.0.0 of nieuwer draaien om dit te laten werken.";
 "views.diagnostics.alerts.report_issue.email" = "Het apparaat is niet geconfigureerd om e-mails te verzenden.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Serverconfiguratie";
 "views.diagnostics.report_issue.title" = "Probleem melden";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Voorkeuren openen";
 "views.settings.system_extension.message" = "Voor een goede werking van de VPN moet de app in de map /Applications staan en moet %@ ingeschakeld zijn als %@.\n\nOpen de macOS-voorkeuren, scroll naar ‘%@’, open het en schakel %@ in.";
 "views.settings.title" = "Over";
+"views.tv.connection_profiles.header" = "Open %@ op je iOS- of macOS-apparaat en schakel de \"%@\"-optie van een profiel in om het hier te laten verschijnen. Alternatief vind je andere opties in het tabblad \"Profielen\".";
+"views.tv.profiles.detail.profiles" = "Gebruik de lange druk om beschikbare acties voor een profiel te tonen. Lokale profielen kunnen hier worden verwijderd, terwijl iCloud-profielen alleen in de iOS- of macOS-app kunnen worden verwijderd.";
+"views.tv.profiles.import_local" = "Lokaal profiel importeren";
+"views.tv.web_uploader.qr" = "Scan de QR-code met je camera om een webpagina te openen waarop je je profiel kunt uploaden.";
+"views.tv.web_uploader.toggle" = "Schakel om een lokaal profiel via een webbrowser op je TV te importeren.";
 "views.ui.connection_status.on_demand_suffix" = " (op aanvraag)";
 "views.ui.purchase_required.purchase.help" = "Aankoop vereist";
 "views.ui.purchase_required.restricted.help" = "Functie is beperkt";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ is een project onderhouden door %@.\n\nDe broncode is openbaar beschikbaar op GitHub onder de GPLv3-licentie. Je kunt links vinden op de startpagina.";
 "views.vpn.category.any" = "Alle categorieën";
 "views.vpn.no_servers" = "Geen servers";
+"views.web_uploader.message" = "Scan deze QR-code om een webpagina te openen om je profiel te uploaden.";

--- a/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pl.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Edytuj";
 "global.actions.enable" = "Włącz";
 "global.actions.hide" = "Ukryj";
+"global.actions.import" = "Importuj";
 "global.actions.purchase" = "Zakup";
 "global.actions.reconnect" = "Ponowne połączenie";
 "global.actions.remove" = "Usuń";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "Na żądanie";
 "global.nouns.other" = "Inne";
+"global.nouns.passcode" = "Kod dostępu";
 "global.nouns.password" = "Hasło";
 "global.nouns.port" = "Port";
 "global.nouns.preferences" = "Preferencje";
 "global.nouns.private_key" = "Klucz prywatny";
 "global.nouns.products" = "Produkty"; // Polish
 "global.nouns.profile" = "Profil";
+"global.nouns.profiles" = "Profile";
 "global.nouns.protocol" = "Protokół";
 "global.nouns.provider" = "Dostawca";
 "global.nouns.public_key" = "Klucz publiczny";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Przenieś profile";
 "views.app.toolbar.new_profile.empty" = "Pusty profil";
 "views.app.toolbar.new_profile.provider" = "Dostawca";
-"views.app.tv.header" = "Otwórz %@ na swoim urządzeniu iOS lub macOS i włącz przełącznik \"%@\" w profilu, aby pojawił się tutaj. Wszystkie urządzenia muszą mieć wersję 3.0.0 lub nowszą, aby to działało.";
 "views.diagnostics.alerts.report_issue.email" = "Urządzenie nie jest skonfigurowane do wysyłania wiadomości e-mail.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Konfiguracja serwera";
 "views.diagnostics.report_issue.title" = "Zgłoś problem";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Otwórz preferencje";
 "views.settings.system_extension.message" = "Aby VPN działało, aplikacja musi znajdować się w katalogu /Applications, a %@ musi być włączone jako %@.\n\nOtwórz Preferencje systemowe macOS, przewiń do „%@”, otwórz je i włącz %@.";
 "views.settings.title" = "O aplikacji";
+"views.tv.connection_profiles.header" = "Otwórz %@ na swoim urządzeniu z iOS lub macOS i włącz przełącznik \"%@\" w profilu, aby pojawił się tutaj. Alternatywnie znajdziesz inne opcje na karcie „Profile”.";
+"views.tv.profiles.detail.profiles" = "Użyj długiego naciśnięcia, aby wyświetlić dostępne akcje dla profilu. Lokalne profile można usuwać tutaj, natomiast profile iCloud tylko z aplikacji iOS lub macOS.";
+"views.tv.profiles.import_local" = "Importuj lokalny profil";
+"views.tv.web_uploader.qr" = "Zeskanuj kod QR aparatem, aby otworzyć stronę, na której możesz przesłać swój profil.";
+"views.tv.web_uploader.toggle" = "Przełącz, aby zaimportować lokalny profil na swój telewizor za pomocą przeglądarki internetowej.";
 "views.ui.connection_status.on_demand_suffix" = " (na żądanie)";
 "views.ui.purchase_required.purchase.help" = "Wymagana zakup";
 "views.ui.purchase_required.restricted.help" = "Funkcja jest ograniczona";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ to projekt utrzymywany przez %@.\n\nKod źródłowy jest dostępny publicznie na GitHub pod licencją GPLv3. Linki można znaleźć na stronie głównej.";
 "views.vpn.category.any" = "Wszystkie kategorie";
 "views.vpn.no_servers" = "Brak serwerów";
+"views.web_uploader.message" = "Zeskanuj ten kod QR, aby otworzyć stronę do przesłania profilu.";

--- a/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/pt.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Editar";
 "global.actions.enable" = "Ativar";
 "global.actions.hide" = "Ocultar";
+"global.actions.import" = "Importar";
 "global.actions.purchase" = "Comprar";
 "global.actions.reconnect" = "Reconectar";
 "global.actions.remove" = "Remover";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "Sob demanda";
 "global.nouns.other" = "Outro";
+"global.nouns.passcode" = "Código";
 "global.nouns.password" = "Senha";
 "global.nouns.port" = "Porta";
 "global.nouns.preferences" = "Preferências";
 "global.nouns.private_key" = "Chave privada";
 "global.nouns.products" = "Produtos"; // Portuguese
 "global.nouns.profile" = "Perfil";
+"global.nouns.profiles" = "Perfis";
 "global.nouns.protocol" = "Protocolo";
 "global.nouns.provider" = "Provedor";
 "global.nouns.public_key" = "Chave pública";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Migrar perfis";
 "views.app.toolbar.new_profile.empty" = "Perfil vazio";
 "views.app.toolbar.new_profile.provider" = "Provedor";
-"views.app.tv.header" = "Abra %@ no seu dispositivo iOS ou macOS e ative a opção \"%@\" de um perfil para que ele apareça aqui. Todos os dispositivos devem estar executando a versão 3.0.0 ou posterior para que isso funcione.";
 "views.diagnostics.alerts.report_issue.email" = "O dispositivo não está configurado para enviar e-mails.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Configuração do servidor";
 "views.diagnostics.report_issue.title" = "Relatar problema";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Abrir preferências";
 "views.settings.system_extension.message" = "Para que o VPN funcione, o app deve estar no diretório /Applications e %@ deve estar ativado como %@.\n\nAbra as Preferências do macOS, role até “%@”, abra e ative %@.";
 "views.settings.title" = "Sobre";
+"views.tv.connection_profiles.header" = "Abra o %@ no seu dispositivo iOS ou macOS e ative a opção \"%@\" de um perfil para que ele apareça aqui. Alternativamente, você encontrará outras opções na aba \"Perfis\".";
+"views.tv.profiles.detail.profiles" = "Use a pressão prolongada para apresentar as ações disponíveis para um perfil. Perfis locais podem ser excluídos aqui, enquanto perfis do iCloud só podem ser excluídos pelo app iOS ou macOS.";
+"views.tv.profiles.import_local" = "Importar perfil local";
+"views.tv.web_uploader.qr" = "Digitalize o QR com a câmera para abrir uma página da web onde enviar seu perfil.";
+"views.tv.web_uploader.toggle" = "Alterne para importar um perfil local na sua TV via navegador web.";
 "views.ui.connection_status.on_demand_suffix" = " (sob demanda)";
 "views.ui.purchase_required.purchase.help" = "Compra necessária";
 "views.ui.purchase_required.restricted.help" = "Recurso restrito";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ é um projeto mantido por %@.\n\nO código-fonte está disponível publicamente no GitHub sob a licença GPLv3, você pode encontrar os links na página inicial.";
 "views.vpn.category.any" = "Todas as categorias";
 "views.vpn.no_servers" = "Nenhum servidor";
+"views.web_uploader.message" = "Escaneie este QR para abrir uma página da web onde carregar seu perfil.";

--- a/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/ru.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Редактировать";
 "global.actions.enable" = "Включить";
 "global.actions.hide" = "Скрыть";
+"global.actions.import" = "Импорт";
 "global.actions.purchase" = "Купить";
 "global.actions.reconnect" = "Переподключение";
 "global.actions.remove" = "Удалить";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "ОК";
 "global.nouns.on_demand" = "По требованию";
 "global.nouns.other" = "Другой";
+"global.nouns.passcode" = "Код";
 "global.nouns.password" = "Пароль";
 "global.nouns.port" = "Порт";
 "global.nouns.preferences" = "Настройки";
 "global.nouns.private_key" = "Приватный ключ";
 "global.nouns.products" = "Продукты"; // Russian
 "global.nouns.profile" = "Профиль";
+"global.nouns.profiles" = "Профили";
 "global.nouns.protocol" = "Протокол";
 "global.nouns.provider" = "Поставщик";
 "global.nouns.public_key" = "Публичный ключ";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Миграция профилей";
 "views.app.toolbar.new_profile.empty" = "Пустой профиль";
 "views.app.toolbar.new_profile.provider" = "Поставщик";
-"views.app.tv.header" = "Откройте %@ на своем устройстве iOS или macOS и включите переключатель \"%@\" в профиле, чтобы он появился здесь. Все устройства должны использовать версию 3.0.0 или новее, чтобы это работало.";
 "views.diagnostics.alerts.report_issue.email" = "Устройство не настроено для отправки электронной почты.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Конфигурация сервера";
 "views.diagnostics.report_issue.title" = "Сообщить о проблеме";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Открыть настройки";
 "views.settings.system_extension.message" = "Чтобы VPN работал, приложение должно находиться в каталоге /Applications, а %@ должно быть включено как %@.\n\nОткройте настройки macOS, прокрутите до «%@», откройте и включите %@.";
 "views.settings.title" = "О программе";
+"views.tv.connection_profiles.header" = "Откройте %@ на устройстве iOS или macOS и включите переключатель \"%@\" у профиля, чтобы он появился здесь. Также вы найдете другие опции на вкладке «Профили».";
+"views.tv.profiles.detail.profiles" = "Используйте длительное нажатие, чтобы показать доступные действия для профиля. Локальные профили можно удалить здесь, а профили iCloud — только из приложений iOS или macOS.";
+"views.tv.profiles.import_local" = "Импорт локального профиля";
+"views.tv.web_uploader.qr" = "Сканируйте QR-код камерой, чтобы открыть веб-страницу для загрузки профиля.";
+"views.tv.web_uploader.toggle" = "Переключите, чтобы импортировать локальный профиль на телевизор через веб-браузер.";
 "views.ui.connection_status.on_demand_suffix" = " (по требованию)";
 "views.ui.purchase_required.purchase.help" = "Требуется покупка";
 "views.ui.purchase_required.restricted.help" = "Функция ограничена";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ — проект, поддерживаемый %@.\n\nИсходный код доступен на GitHub под лицензией GPLv3, ссылки можно найти на домашней странице.";
 "views.vpn.category.any" = "Все категории";
 "views.vpn.no_servers" = "Нет серверов";
+"views.web_uploader.message" = "Отсканируйте этот QR-код, чтобы открыть веб-страницу для загрузки профиля.";

--- a/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/sv.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Redigera";
 "global.actions.enable" = "Aktivera";
 "global.actions.hide" = "Dölj";
+"global.actions.import" = "Importera";
 "global.actions.purchase" = "Köp";
 "global.actions.reconnect" = "Återanslut";
 "global.actions.remove" = "Ta bort";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "OK";
 "global.nouns.on_demand" = "På begäran";
 "global.nouns.other" = "Annan";
+"global.nouns.passcode" = "Lsenkod";
 "global.nouns.password" = "Lösenord";
 "global.nouns.port" = "Port";
 "global.nouns.preferences" = "Inställningar";
 "global.nouns.private_key" = "Privat nyckel";
 "global.nouns.products" = "Produkter"; // Swedish
 "global.nouns.profile" = "Profil";
+"global.nouns.profiles" = "Profiler";
 "global.nouns.protocol" = "Protokoll";
 "global.nouns.provider" = "Leverantör";
 "global.nouns.public_key" = "Offentlig nyckel";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Migrera profiler";
 "views.app.toolbar.new_profile.empty" = "Tom profil";
 "views.app.toolbar.new_profile.provider" = "Leverantör";
-"views.app.tv.header" = "Öppna %@ på din iOS- eller macOS-enhet och aktivera \"%@\"-växeln i en profil för att den ska visas här. Alla enheter måste köra version 3.0.0 eller senare för att detta ska fungera.";
 "views.diagnostics.alerts.report_issue.email" = "Enheten är inte konfigurerad för att skicka e-post.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Serverkonfiguration";
 "views.diagnostics.report_issue.title" = "Rapportera problem";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Öppna inställningar";
 "views.settings.system_extension.message" = "För att VPN ska fungera måste appen ligga i mappen /Applications och %@ vara aktiverad som %@.\n\nÖppna macOS-inställningarna, scrolla till ”%@”, öppna det och aktivera %@.";
 "views.settings.title" = "Om";
+"views.tv.connection_profiles.header" = "Öppna %@ på din iOS- eller macOS-enhet och aktivera växeln \"%@\" för en profil så visas den här. Alternativt hittar du andra alternativ i fliken \"Profiler\".";
+"views.tv.profiles.detail.profiles" = "Använd långt tryck för att visa tillgängliga åtgärder för en profil. Lokala profiler kan raderas här, medan iCloud-profiler endast kan tas bort från iOS- eller macOS-appen.";
+"views.tv.profiles.import_local" = "Importera lokal profil";
+"views.tv.web_uploader.qr" = "Skanna QR-koden med din kamera för att öppna en webbsida där du kan ladda upp din profil.";
+"views.tv.web_uploader.toggle" = "Växla för att importera en lokal profil till din TV via en webbläsare.";
 "views.ui.connection_status.on_demand_suffix" = " (på begäran)";
 "views.ui.purchase_required.purchase.help" = "Köp krävs";
 "views.ui.purchase_required.restricted.help" = "Funktionen är begränsad";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ är ett projekt som underhålls av %@.\n\nKällkoden är offentligt tillgänglig på GitHub under GPLv3-licensen. Du hittar länkar på hemsidan.";
 "views.vpn.category.any" = "Alla kategorier";
 "views.vpn.no_servers" = "Inga servrar";
+"views.web_uploader.message" = "Skanna denna QR-kod för att öppna en webbsida där du kan ladda upp din profil.";

--- a/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/uk.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "Редагувати";
 "global.actions.enable" = "Увімкнути";
 "global.actions.hide" = "Приховати";
+"global.actions.import" = "Імпортувати";
 "global.actions.purchase" = "Купити";
 "global.actions.reconnect" = "Повторне підключення";
 "global.actions.remove" = "Видалити";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "ОК";
 "global.nouns.on_demand" = "За запитом";
 "global.nouns.other" = "Інше";
+"global.nouns.passcode" = "Код";
 "global.nouns.password" = "Пароль";
 "global.nouns.port" = "Порт";
 "global.nouns.preferences" = "Налаштування";
 "global.nouns.private_key" = "Приватний ключ";
 "global.nouns.products" = "Продукти"; // Ukrainian
 "global.nouns.profile" = "Профіль";
+"global.nouns.profiles" = "Профілі";
 "global.nouns.protocol" = "Протокол";
 "global.nouns.provider" = "Постачальник";
 "global.nouns.public_key" = "Публічний ключ";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "Перенести профілі";
 "views.app.toolbar.new_profile.empty" = "Порожній профіль";
 "views.app.toolbar.new_profile.provider" = "Постачальник";
-"views.app.tv.header" = "Відкрийте %@ на своєму пристрої iOS або macOS і увімкніть перемикач \"%@\" у профілі, щоб він з’явився тут. Усі пристрої повинні використовувати версію 3.0.0 або новішу, щоб це працювало.";
 "views.diagnostics.alerts.report_issue.email" = "Пристрій не налаштований на надсилання електронних листів.";
 "views.diagnostics.openvpn.rows.server_configuration" = "Конфігурація сервера";
 "views.diagnostics.report_issue.title" = "Повідомити про проблему";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "Відкрити налаштування";
 "views.settings.system_extension.message" = "Щоб VPN працював, програма має бути в каталозі /Applications, а %@ має бути увімкнено як %@.\n\nВідкрий налаштування macOS, прокрути до «%@», ідкрий його та увімкни %@.";
 "views.settings.title" = "Про програму";
+"views.tv.connection_profiles.header" = "Відкрий %@ на своєму пристрої iOS або macOS і увімкни перемикач \"%@\" у профілі, щоб він з’явився тут. Або знайдеш інші опції на вкладці «Профілі».";
+"views.tv.profiles.detail.profiles" = "Використовуйте тривале натискання, щоб показати доступні дії для профілю. Локальні профілі можна видалити тут, тоді як профілі iCloud — лише в додатку iOS або macOS.";
+"views.tv.profiles.import_local" = "Імпортувати локальний профіль";
+"views.tv.web_uploader.qr" = "Скануйте QR камерою, щоб відкрити вебсторінку для завантаження профілю.";
+"views.tv.web_uploader.toggle" = "Перемикач для імпорту локального профілю на телевізор через веб-браузер.";
 "views.ui.connection_status.on_demand_suffix" = " (за запитом)";
 "views.ui.purchase_required.purchase.help" = "Потрібна покупка";
 "views.ui.purchase_required.restricted.help" = "Функція обмежена";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ є проектом, який підтримується %@.\n\nВихідний код доступний публічно на GitHub під ліцензією GPLv3. Посилання можна знайти на домашній сторінці.";
 "views.vpn.category.any" = "Усі категорії";
 "views.vpn.no_servers" = "Немає серверів";
+"views.web_uploader.message" = "Скануйте цей QR-код, щоб відкрити вебсторінку для завантаження профілю.";

--- a/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/UILibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 "global.actions.edit" = "编辑";
 "global.actions.enable" = "启用";
 "global.actions.hide" = "隐藏";
+"global.actions.import" = "导入";
 "global.actions.purchase" = "购买";
 "global.actions.reconnect" = "重新连接";
 "global.actions.remove" = "删除";
@@ -121,12 +122,14 @@
 "global.nouns.ok" = "确定";
 "global.nouns.on_demand" = "按需";
 "global.nouns.other" = "其他";
+"global.nouns.passcode" = "验证码";
 "global.nouns.password" = "密码";
 "global.nouns.port" = "端口";
 "global.nouns.preferences" = "偏好设置";
 "global.nouns.private_key" = "私钥";
 "global.nouns.products" = "产品"; // Chinese (Simplified)
 "global.nouns.profile" = "配置文件";
+"global.nouns.profiles" = "配置文件";
 "global.nouns.protocol" = "协议";
 "global.nouns.provider" = "提供商";
 "global.nouns.public_key" = "公钥";
@@ -233,7 +236,6 @@
 "views.app.toolbar.migrate_profiles" = "迁移配置文件";
 "views.app.toolbar.new_profile.empty" = "空配置文件";
 "views.app.toolbar.new_profile.provider" = "提供商";
-"views.app.tv.header" = "在您的 iOS 或 macOS 设备上打开 %@，并启用配置文件的“%@”开关，使其显示在此处。所有设备必须运行 3.0.0 或更高版本才能正常工作。";
 "views.diagnostics.alerts.report_issue.email" = "设备未配置为发送电子邮件。";
 "views.diagnostics.openvpn.rows.server_configuration" = "服务器配置";
 "views.diagnostics.report_issue.title" = "报告问题";
@@ -328,6 +330,11 @@
 "views.settings.system_extension.buttons.open" = "打开偏好设置"
 "views.settings.system_extension.message" = "要使 VPN 正常工作，应用程序必须位于 /Applications 目录中，并且必须将 %@ 启用为 %@。\n\n打开 macOS 偏好设置，滚动到“%@”，打开并启用 %@。"
 "views.settings.title" = "关于";
+"views.tv.connection_profiles.header" = "在你的 iOS 或 macOS 设备上打开 %@ 并启用某个配置文件的“%@”开关以在此处显示。或者，你可以在“配置文件”标签页找到其他选项。";
+"views.tv.profiles.detail.profiles" = "长按以显示可用的配置文件操作。本地配置文件可以在这里删除，而 iCloud 配置文件只能在 iOS 或 macOS 应用中删除。";
+"views.tv.profiles.import_local" = "导入本地配置文件";
+"views.tv.web_uploader.qr" = "使用相机扫描此二维码，打开网页以上传你的配置文件。";
+"views.tv.web_uploader.toggle" = "切换以通过网页浏览器将本地配置文件导入电视。";
 "views.ui.connection_status.on_demand_suffix" = "（按需）";
 "views.ui.purchase_required.purchase.help" = "需要购买";
 "views.ui.purchase_required.restricted.help" = "功能受限";
@@ -335,3 +342,4 @@
 "views.version.extra" = "%@ 是由 %@ 维护的项目。\n\n源代码在 GitHub 上公开提供，遵循 GPLv3 许可协议，您可以在主页找到相关链接。";
 "views.vpn.category.any" = "所有类别";
 "views.vpn.no_servers" = "无服务器";
+"views.web_uploader.message" = "扫描此二维码，打开网页上传您的配置文件。";

--- a/Packages/App/Sources/UILibrary/Views/Theme/ThemeEmptyMessageModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Theme/ThemeEmptyMessageModifier.swift
@@ -33,16 +33,17 @@ struct ThemeEmptyMessageModifier: ViewModifier {
     let fullScreen: Bool
 
     func body(content: Content) -> some View {
-        VStack {
-            if fullScreen {
-                Spacer()
-            }
-            content
-                .font(theme.emptyMessageFont)
-                .foregroundStyle(theme.emptyMessageColor)
-            if fullScreen {
-                Spacer()
-            }
+        if fullScreen {
+            innerView(content: content)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            innerView(content: content)
         }
+    }
+
+    private func innerView(content: Content) -> some View {
+        content
+            .font(theme.emptyMessageFont)
+            .foregroundStyle(theme.emptyMessageColor)
     }
 }

--- a/Packages/App/Sources/WebLibrary/HTMLTemplate.swift
+++ b/Packages/App/Sources/WebLibrary/HTMLTemplate.swift
@@ -62,7 +62,6 @@ struct HTMLTemplate {
         }
 
         result += html[lastRangeEnd...]
-
         return result
     }
 }

--- a/Packages/App/Sources/WebLibrary/HTMLTemplate.swift
+++ b/Packages/App/Sources/WebLibrary/HTMLTemplate.swift
@@ -1,0 +1,68 @@
+//
+//  HTMLTemplate.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/6/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+struct HTMLTemplate {
+    private static let keyPattern: NSRegularExpression = {
+        do {
+            let pattern = #"#\{([^}]+)\}"#
+            return try NSRegularExpression(pattern: pattern)
+        } catch {
+            fatalError("Unable to create web uploader template regular expression")
+        }
+    }()
+
+    private let html: String
+
+    init(html: String) {
+        self.html = html
+    }
+
+    func withLocalizedKeys(in bundle: Bundle) -> String {
+        let range = NSRange(html.startIndex..., in: html)
+        var result = ""
+        var lastRangeEnd = html.startIndex
+
+        Self.keyPattern.enumerateMatches(in: html, range: range) { match, _, _ in
+            guard let match = match,
+                  let fullRange = Range(match.range(at: 0), in: html),
+                  let keyRange = Range(match.range(at: 1), in: html) else {
+                return
+            }
+
+            result += html[lastRangeEnd..<fullRange.lowerBound]
+            let key = String(html[keyRange])
+            let localized = bundle.localizedString(forKey: key, value: key, table: "Localizable")
+
+            result += localized
+            lastRangeEnd = fullRange.upperBound
+        }
+
+        result += html[lastRangeEnd...]
+
+        return result
+    }
+}

--- a/Packages/App/Sources/WebLibrary/MultipartForm.swift
+++ b/Packages/App/Sources/WebLibrary/MultipartForm.swift
@@ -1,0 +1,83 @@
+//
+//  MultipartForm.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/6/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+final class MultipartForm: Sendable {
+    struct Field: Sendable {
+        let filename: String?
+
+        let value: String
+    }
+
+    let fields: [String: Field]
+
+    init?(body: String) {
+        guard let boundaryLine = body.components(separatedBy: "\r\n").first,
+              boundaryLine.starts(with: "--") else {
+            return nil
+        }
+
+        let boundary = boundaryLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = body.components(separatedBy: boundary)
+            .dropFirst()
+            .dropLast()
+
+        var fields: [String: Field] = [:]
+        for part in parts {
+            let trimmedPart = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let headerRange = trimmedPart.range(of: "\r\n\r\n") else {
+                continue
+            }
+            let headerText = trimmedPart[..<headerRange.lowerBound]
+            let bodyText = trimmedPart[headerRange.upperBound...]
+
+            let headers = headerText.components(separatedBy: "\r\n")
+            var name: String?
+            var filename: String?
+
+            for header in headers where header.lowercased().starts(with: "content-disposition:") {
+                let components = header.components(separatedBy: ";").map { $0.trimmingCharacters(in: .whitespaces) }
+                for comp in components {
+                    if comp.starts(with: "name=") {
+                        name = comp.replacingOccurrences(of: "name=", with: "")
+                            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                    } else if comp.starts(with: "filename=") {
+                        filename = comp.replacingOccurrences(of: "filename=", with: "")
+                            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                    }
+                }
+            }
+            guard let name else {
+                continue
+            }
+            guard let value = String(bodyText.utf8) else {
+                continue
+            }
+            fields[name] = Field(filename: filename, value: value)
+        }
+        self.fields = fields
+    }
+}

--- a/Packages/App/Sources/WebLibrary/NIOWebUploader.swift
+++ b/Packages/App/Sources/WebLibrary/NIOWebUploader.swift
@@ -1,0 +1,149 @@
+//
+//  NIOWebUploader.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/3/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import Foundation
+import NIO
+import NIOHTTP1
+
+public final class NIOWebUploader: WebUploader, @unchecked Sendable {
+    private let port: Int
+
+    private var group: MultiThreadedEventLoopGroup?
+
+    private var channel: Channel?
+
+    public init(port: Int) {
+        self.port = port
+    }
+
+    public func start(passcode: String?, onReceive: @escaping (String, String) -> Void) throws -> URL {
+        guard group == nil, channel == nil else {
+            pp_log_g(.App.web, .error, "Web server is already started")
+            throw AppError.webUploader()
+        }
+
+        group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        let bootstrap = ServerBootstrap(group: group!)
+            .serverChannelOption(.backlog, value: 256)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(NIOWebUploaderHandler(passcode: passcode) {
+                        onReceive($0, $1)
+                    })
+                }
+            }
+            .childChannelOption(.socketOption(.so_reuseaddr), value: 1)
+
+        guard let host = firstIPv4Address(withInterfacePrefix: "en") else {
+            pp_log_g(.App.web, .error, "Web server has no IPv4 Ethernet addresses to listen on")
+            throw AppError.webUploader()
+        }
+        do {
+            channel = try bootstrap.bind(host: host, port: port).wait()
+        } catch {
+            pp_log_g(.App.web, .error, "Web server could not bind: \(error)")
+            group = nil
+            channel = nil
+            throw AppError.webUploader(error)
+        }
+        guard let address = channel?.localAddress?.ipAddress else {
+            pp_log_g(.App.web, .error, "Web server has no bound IP address")
+            throw AppError.webUploader()
+        }
+        guard let url = URL(string: "http://\(address):\(port)") else {
+            pp_log_g(.App.web, .error, "Web server URL could not be built")
+            throw AppError.webUploader()
+        }
+        pp_log_g(.App.web, .notice, "Web server did start: \(url)")
+        return url
+    }
+
+    public func stop() {
+        guard let channel, let group else {
+            pp_log_g(.App.web, .error, "Web server is not started")
+            return
+        }
+        do {
+            try channel.close().wait()
+            try group.syncShutdownGracefully()
+            self.channel = nil
+            self.group = nil
+            pp_log_g(.App.web, .notice, "Web server did stop")
+        } catch {
+            pp_log_g(.App.web, .error, "Unable to stop web server: \(error)")
+        }
+    }
+}
+
+private extension NIOWebUploader {
+    func firstIPv4Address(withInterfacePrefix prefix: String) -> String? {
+        var firstAddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&firstAddr) == 0, let firstAddr else {
+            return nil
+        }
+
+        var ipAddress: String?
+        var ptr = firstAddr
+
+        while let cIfName = ptr.pointee.ifa_name {
+            let addr = ptr.pointee.ifa_addr.pointee
+            if addr.sa_family == UInt8(AF_INET) {
+                let ifName = String(cString: cIfName)
+
+                // exclude loopback and down interfaces
+                let flags = ptr.pointee.ifa_flags
+                let isUp = (flags & UInt32(IFF_UP)) != 0
+                let isLoopback = (flags & UInt32(IFF_LOOPBACK)) != 0
+
+                if isUp && !isLoopback {
+                    var cIPAddress = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    var addrCopy = ptr.pointee.ifa_addr.pointee
+                    getnameinfo(
+                        &addrCopy,
+                        socklen_t(ptr.pointee.ifa_addr.pointee.sa_len),
+                        &cIPAddress,
+                        socklen_t(cIPAddress.count),
+                        nil,
+                        0,
+                        NI_NUMERICHOST
+                    )
+                    if ifName.hasPrefix(prefix) {
+                        ipAddress = String(cString: cIPAddress)
+                        break
+                    }
+                }
+            }
+            guard let next = ptr.pointee.ifa_next else {
+                break
+            }
+            ptr = next
+        }
+
+        freeifaddrs(firstAddr)
+        return ipAddress
+    }
+}

--- a/Packages/App/Sources/WebLibrary/NIOWebUploaderHandler.swift
+++ b/Packages/App/Sources/WebLibrary/NIOWebUploaderHandler.swift
@@ -33,19 +33,18 @@ final class NIOWebUploaderHandler {
 
     typealias OutboundOut = HTTPServerResponsePart
 
-    private static let htmlTemplate: HTMLTemplate = {
+    private static let html: String = {
         do {
             guard let path = Bundle.module.path(forResource: "web_uploader", ofType: "html") else {
                 throw AppError.notFound
             }
-            let html = try String(contentsOfFile: path)
-            return HTMLTemplate(html: html)
+            let contents = try String(contentsOfFile: path)
+            let template = HTMLTemplate(html: contents)
+            return template.withLocalizedKeys(in: .module)
         } catch {
             fatalError("Unable to load web uploader HTML template")
         }
     }()
-
-    private let html: String
 
     private let passcode: String?
 
@@ -56,7 +55,6 @@ final class NIOWebUploaderHandler {
     private var bodyBuffer: ByteBuffer?
 
     init(passcode: String?, onReceive: @escaping (String, String) -> Void) {
-        html = Self.htmlTemplate.withLocalizedKeys(in: .module)
         self.passcode = passcode
         self.onReceive = onReceive
     }
@@ -102,7 +100,7 @@ private extension NIOWebUploaderHandler {
         guard uri == "/" else {
             return false
         }
-        sendHTMLResponse(context, html: html)
+        sendHTMLResponse(context, html: Self.html)
         return true
     }
 

--- a/Packages/App/Sources/WebLibrary/NIOWebUploaderHandler.swift
+++ b/Packages/App/Sources/WebLibrary/NIOWebUploaderHandler.swift
@@ -1,0 +1,164 @@
+//
+//  NIOWebUploaderHandler.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/6/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonLibrary
+import Foundation
+import NIO
+import NIOHTTP1
+
+final class NIOWebUploaderHandler {
+    typealias InboundIn = HTTPServerRequestPart
+
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private static let htmlTemplate: HTMLTemplate = {
+        do {
+            guard let path = Bundle.module.path(forResource: "web_uploader", ofType: "html") else {
+                throw AppError.notFound
+            }
+            let html = try String(contentsOfFile: path)
+            return HTMLTemplate(html: html)
+        } catch {
+            fatalError("Unable to load web uploader HTML template")
+        }
+    }()
+
+    private let html: String
+
+    private let passcode: String?
+
+    private let onReceive: (String, String) -> Void
+
+    private var requestHead: HTTPRequestHead?
+
+    private var bodyBuffer: ByteBuffer?
+
+    init(passcode: String?, onReceive: @escaping (String, String) -> Void) {
+        html = Self.htmlTemplate.withLocalizedKeys(in: .module)
+        self.passcode = passcode
+        self.onReceive = onReceive
+    }
+}
+
+// MARK: - ChannelInboundHandler
+
+extension NIOWebUploaderHandler: ChannelInboundHandler {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let reqPart = unwrapInboundIn(data)
+        switch reqPart {
+        case .head(let head):
+            requestHead = head
+            bodyBuffer = context.channel.allocator.buffer(capacity: 0)
+        case .body(var chunk):
+            bodyBuffer?.writeBuffer(&chunk)
+        case .end:
+            guard let requestHead else {
+                return
+            }
+            var isHandled = false
+            switch requestHead.method {
+            case .GET:
+                isHandled = handleGET(context, uri: requestHead.uri)
+            case .POST:
+                isHandled = handlePOST(context, uri: requestHead.uri)
+            default:
+                break
+            }
+            if !isHandled {
+                sendTextResponse(context, with: .notFound)
+            }
+            self.requestHead = nil
+            bodyBuffer = nil
+        }
+    }
+}
+
+// MARK: - Routes
+
+private extension NIOWebUploaderHandler {
+    func handleGET(_ context: ChannelHandlerContext, uri: String) -> Bool {
+        guard uri == "/" else {
+            return false
+        }
+        sendHTMLResponse(context, html: html)
+        return true
+    }
+
+    func handlePOST(_ context: ChannelHandlerContext, uri: String) -> Bool {
+        guard uri == "/upload" else {
+            return false
+        }
+        guard let buffer = bodyBuffer,
+              let body = buffer.getString(at: 0, length: buffer.readableBytes),
+              let form = MultipartForm(body: body) else {
+            sendTextResponse(context, with: .badRequest)
+            return true
+        }
+        if let passcode {
+            guard let formPasscode = form.fields["passcode"]?.value,
+                  formPasscode.uppercased() == passcode.uppercased() else {
+                sendTextResponse(context, with: .forbidden)
+                return true
+            }
+        }
+        guard let file = form.fields["file"], let filename = file.filename else {
+            sendTextResponse(context, with: .badRequest)
+            return true
+        }
+        sendTextResponse(context, with: .ok)
+        onReceive(filename, file.value)
+        return true
+    }
+}
+
+// MARK: - Helpers
+
+extension NIOWebUploaderHandler {
+    func sendTextResponse(
+        _ context: ChannelHandlerContext,
+        with status: HTTPResponseStatus,
+        text: String = ""
+    ) {
+        var response = HTTPResponseHead(version: .http1_1, status: status)
+        response.headers.add(name: "Content-Type", value: "text/plain")
+        let bufferOut = context.channel.allocator.buffer(string: text)
+        context.write(wrapOutboundOut(.head(response)), promise: nil)
+        context.write(wrapOutboundOut(.body(.byteBuffer(bufferOut))), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+    }
+
+    func sendHTMLResponse(
+        _ context: ChannelHandlerContext,
+        html: String
+    ) {
+        var response = HTTPResponseHead(version: .http1_1, status: .ok)
+        response.headers.add(name: "Content-Type", value: "text/html")
+        response.headers.add(name: "Content-Length", value: "\(html.utf8.count)")
+        let buffer = context.channel.allocator.buffer(string: html)
+        context.write(wrapOutboundOut(.head(response)), promise: nil)
+        context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+    }
+}

--- a/Packages/App/Sources/WebLibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Upload fehlgeschlagen:";
+"web_uploader.errors.incorrect_passcode" = "Falscher Code!";
+"web_uploader.file.browse" = "Durchsuchen";
+"web_uploader.file.no_selection" = "Keine Datei ausgewählt";
+"web_uploader.file.prompt" = "Wähle eine Konfigurationsdatei zum Senden aus";
+"web_uploader.passcode.prompt" = "Gib den auf deinem Fernseher angezeigten Code ein";
+"web_uploader.submit" = "Hochladen";
+"web_uploader.success" = "Upload abgeschlossen!";
+"web_uploader.title" = "Auf Apple TV hochladen";

--- a/Packages/App/Sources/WebLibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/el.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Η αποστολή απέτυχε:";
+"web_uploader.errors.incorrect_passcode" = "Λανθασμένος κωδικός!";
+"web_uploader.file.browse" = "Αναζήτηση";
+"web_uploader.file.no_selection" = "Δεν επιλέχθηκε αρχείο";
+"web_uploader.file.prompt" = "Επιλέξτε ένα αρχείο ρυθμίσεων για αποστολή";
+"web_uploader.passcode.prompt" = "Εισάγετε τον κωδικό που εμφανίζεται στην τηλεόρασή σας";
+"web_uploader.submit" = "Αποστολή";
+"web_uploader.success" = "Η αποστολ ολοκληρώθηκε!";
+"web_uploader.title" = "Αποστολή στο Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.title" = "Upload to Apple TV";
+"web_uploader.passcode.prompt" = "Enter the passcode displayed on your TV";
+"web_uploader.file.prompt" = "Select a configuration file to send";
+"web_uploader.file.browse" = "Browse";
+"web_uploader.file.no_selection" = "No file chosen";
+"web_uploader.success" = "Upload complete!";
+"web_uploader.errors.generic" = "Upload failed:";
+"web_uploader.errors.incorrect_passcode" = "Incorrect passcode!";
+"web_uploader.submit" = "Upload";

--- a/Packages/App/Sources/WebLibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Error al subir:";
+"web_uploader.errors.incorrect_passcode" = "¡Código incorrecto!";
+"web_uploader.file.browse" = "Examinar";
+"web_uploader.file.no_selection" = "Ningún archivo seleccionado";
+"web_uploader.file.prompt" = "Selecciona un archivo de configuración para enviar";
+"web_uploader.passcode.prompt" = "Introduce el código que aparece en tu TV";
+"web_uploader.submit" = "Subir";
+"web_uploader.success" = "¡Subida completada!";
+"web_uploader.title" = "Subir a Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Échec du téléversement :";
+"web_uploader.errors.incorrect_passcode" = "Code incorrect !";
+"web_uploader.file.browse" = "Parcourir";
+"web_uploader.file.no_selection" = "Aucun fichier sélectionné";
+"web_uploader.file.prompt" = "Sélectionnez un fichier de configuration à envoyer";
+"web_uploader.passcode.prompt" = "Saisissez le code affiché sur votre téléviseur";
+"web_uploader.submit" = "Téléverser";
+"web_uploader.success" = "Téléversement terminé !";
+"web_uploader.title" = "Téléverser vers Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Caricamento non riuscito:";
+"web_uploader.errors.incorrect_passcode" = "Codice errato!";
+"web_uploader.file.browse" = "Sfoglia";
+"web_uploader.file.no_selection" = "Nessun file selezionato";
+"web_uploader.file.prompt" = "Seleziona un file di configurazione da inviare";
+"web_uploader.passcode.prompt" = "Inserisci il codice visualizzato sulla tua TV";
+"web_uploader.submit" = "Carica";
+"web_uploader.success" = "Caricamento completato!";
+"web_uploader.title" = "Carica su Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/nl.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Upload mislukt:";
+"web_uploader.errors.incorrect_passcode" = "Verkeerde code!";
+"web_uploader.file.browse" = "Bladeren";
+"web_uploader.file.no_selection" = "Geen bestand gekozen";
+"web_uploader.file.prompt" = "Selecteer een configuratiebestand om te verzenden";
+"web_uploader.passcode.prompt" = "Voer de code in die op je tv wordt weergegeven";
+"web_uploader.submit" = "Uploaden";
+"web_uploader.success" = "Upload voltooid!";
+"web_uploader.title" = "Uploaden naar Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Nie udało się przesłać:";
+"web_uploader.errors.incorrect_passcode" = "Nieprawidłowy kod!";
+"web_uploader.file.browse" = "Przeglądaj";
+"web_uploader.file.no_selection" = "Nie wybrano pliku";
+"web_uploader.file.prompt" = "Wybierz plik konfiguracyjny do wysłania";
+"web_uploader.passcode.prompt" = "Wprowadź kod wyświetlany na telewizorze";
+"web_uploader.submit" = "Wyślij";
+"web_uploader.success" = "Przesyłanie zakończone!";
+"web_uploader.title" = "Wyślij do Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Falha no envio:";
+"web_uploader.errors.incorrect_passcode" = "Código incorreto!";
+"web_uploader.file.browse" = "Procurar";
+"web_uploader.file.no_selection" = "Nenhum arquivo selecionado";
+"web_uploader.file.prompt" = "Selecione um arquivo de configuração para enviar";
+"web_uploader.passcode.prompt" = "Digite o código exibido na sua TV";
+"web_uploader.submit" = "Enviar";
+"web_uploader.success" = "Envio concluído!";
+"web_uploader.title" = "Enviar para Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/ru.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Ошибка загрузки:";
+"web_uploader.errors.incorrect_passcode" = "Неверный код!";
+"web_uploader.file.browse" = "Обзор";
+"web_uploader.file.no_selection" = "Файл не выбран";
+"web_uploader.file.prompt" = "Выберите файл конфигурации для отправки";
+"web_uploader.passcode.prompt" = "Введите код, отображаемый на вашем телевизоре";
+"web_uploader.submit" = "Загрузить";
+"web_uploader.success" = "Загрузка завершена!";
+"web_uploader.title" = "Загрузить на Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/sv.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Uppladdning misslyckades:";
+"web_uploader.errors.incorrect_passcode" = "Fel kod!";
+"web_uploader.file.browse" = "Bläddra";
+"web_uploader.file.no_selection" = "Ingen fil vald";
+"web_uploader.file.prompt" = "Välj en konfigurationsfil att skicka";
+"web_uploader.passcode.prompt" = "Ange koden som visas på din TV";
+"web_uploader.submit" = "Ladda upp";
+"web_uploader.success" = "Uppladdningen klar!";
+"web_uploader.title" = "Ladda upp till Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "Помилка завантаження:";
+"web_uploader.errors.incorrect_passcode" = "Неправильний код!";
+"web_uploader.file.browse" = "Огляд";
+"web_uploader.file.no_selection" = "Файл не вибрано";
+"web_uploader.file.prompt" = "Виберіть файл конфігурації для надсилання";
+"web_uploader.passcode.prompt" = "Введіть код, що відображається на телевізорі";
+"web_uploader.submit" = "Завантажити";
+"web_uploader.success" = "Завантаження завершено!";
+"web_uploader.title" = "Завантажити на Apple TV";

--- a/Packages/App/Sources/WebLibrary/Resources/web_uploader.html
+++ b/Packages/App/Sources/WebLibrary/Resources/web_uploader.html
@@ -1,0 +1,137 @@
+<!--
+"web_uploader.title" = "Upload to Apple TV";
+"web_uploader.passcode.prompt" = "Enter the passcode displayed on your TV";
+"web_uploader.file.prompt" = "Select a configuration file to send";
+"web_uploader.file.browse" = "Browse";
+"web_uploader.file.no_selection" = "No file chosen";
+"web_uploader.success" = "Upload complete!";
+"web_uploader.errors.generic" = "Upload failed:";
+"web_uploader.errors.incorrect_passcode" = "Incorrect passcode!";
+-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Passepartout — Upload</title>
+        <style type="text/css">
+            body {
+                font-family: sans-serif;
+                background-color: #515d71;
+                color: #fff;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            }
+
+            h1 {
+                color: #f0d192;
+            }
+
+            form {
+            }
+
+            label {
+                display: block;
+                margin-bottom: 1rem;
+            }
+
+            input {
+                width: 100%;
+                font-size: 1rem;
+                border: none;
+                box-sizing: border-box;
+                margin-bottom: 1rem;
+            }
+
+            input, #upload-file-label {
+                border-radius: 0.3rem;
+            }
+
+            input[type="text"] {
+                padding: 0.5rem;
+            }
+
+            #upload-file-box {
+                display: flex;
+                align-items: baseline;
+                gap: 0.5rem;
+            }
+
+            #upload-file {
+                display: none;
+            }
+
+            #upload-file-label {
+                cursor: pointer;
+                background-color: #ccc;
+                color: #000;
+                padding: 0.5rem 1rem;
+            }
+
+            #upload-file-name {
+            }
+
+            #upload-submit {
+                cursor: pointer;
+                background-color: #2563eb;
+                color: #fff;
+                font-weight: bold;
+                margin-top: 1rem;
+                padding: 0.75rem;
+                transition: background-color 0.2s ease-in-out;
+            }
+
+            #upload-submit:hover {
+                background-color: #1d4ed8;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Passepartout</h1>
+        <h2>#{web_uploader.title}</h2>
+        <form id="upload-form" method="POST" action="/upload" enctype="multipart/form-data">
+            <label for="upload-passcode">#{web_uploader.passcode.prompt}:</label>
+            <input id="upload-passcode" name="passcode" type="text" /><br />
+            <label for="upload-file">#{web_uploader.file.prompt}:</label>
+            <div id="upload-file-box">
+                <input id="upload-file" name="file" type="file" />
+                <label id="upload-file-label" for="upload-file">#{web_uploader.file.browse}</label>
+                <span id="upload-file-name">#{web_uploader.file.no_selection}</span>
+            </div>
+            <input id="upload-submit" type="submit" value="#{web_uploader.submit}" /><br />
+        </form>
+        <script>
+            document.getElementById("upload-form").addEventListener("submit", async function (e) {
+                e.preventDefault();
+                const formData = new FormData(this);
+                const response = await fetch("/upload", {
+                    method: "POST",
+                    body: formData
+                });
+                if (response.status == 400) {
+                    alert("#{web_uploader.file.no_selection}!");
+                    return;
+                }
+                if (response.status == 403) {
+                    alert("#{web_uploader.errors.incorrect_passcode}");
+                    return;
+                }
+                if (!response.ok) {
+                    alert(`#{web_uploader.errors.generic}: ${response.status} ${response.statusText}`);
+                    return;
+                }
+                alert("#{web_uploader.success}");
+            });
+            document.getElementById("upload-passcode").addEventListener("input", function (e) {
+                e.target.value = e.target.value.toUpperCase();
+            });
+
+            let uploadFile = document.getElementById("upload-file");
+            uploadFile.addEventListener("change", function(e) {
+                let uploadFileName = document.getElementById("upload-file-name");
+                uploadFileName.textContent = uploadFile.files.length ? uploadFile.files[0].name : "#{web_uploader.file.no_selection}";
+            });
+        </script>
+    </body>
+</html>

--- a/Packages/App/Sources/WebLibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/WebLibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"web_uploader.errors.generic" = "上传失败：";
+"web_uploader.errors.incorrect_passcode" = "验证码错误！";
+"web_uploader.file.browse" = "浏览";
+"web_uploader.file.no_selection" = "未选择文件";
+"web_uploader.file.prompt" = "选择一个配置文件进行发送";
+"web_uploader.passcode.prompt" = "请输入您电视上显示的验证码";
+"web_uploader.submit" = "上传";
+"web_uploader.success" = "上传完成！";
+"web_uploader.title" = "上传到 Apple TV";

--- a/Packages/App/Tests/CommonLibraryTests/Business/UploadManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/UploadManagerTests.swift
@@ -1,0 +1,70 @@
+//
+//  UploadManagerTests.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/4/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@testable import CommonLibrary
+import Foundation
+import XCTest
+
+final class UploadManagerTests: XCTestCase {
+}
+
+@MainActor
+extension UploadManagerTests {
+    func test_givenUploader_whenStart_thenReceivesFiles() async throws {
+        let webUploader = MockWebUploader(file: UploadManager.File(name: "name", contents: "contents"))
+        let sut = UploadManager(webUploader: webUploader)
+        let stream = sut.files
+        let expReceive = expectation(description: "UploadReceive")
+        let expEnd = expectation(description: "UploadEnd")
+        Task {
+            for await file in stream {
+                XCTAssertEqual(file.name, "name")
+                XCTAssertEqual(file.contents, "contents")
+                expReceive.fulfill()
+            }
+            expEnd.fulfill()
+        }
+        try sut.start()
+        await fulfillment(of: [expReceive])
+        sut.destroy()
+        await fulfillment(of: [expEnd])
+    }
+}
+
+private final class MockWebUploader: WebUploader {
+    private let file: UploadManager.File
+
+    init(file: UploadManager.File) {
+        self.file = file
+    }
+
+    func start(passcode: String?, onReceive: @escaping (String, String) -> Void) throws -> URL {
+        onReceive(file.name, file.contents)
+        return URL(fileURLWithPath: "")
+    }
+
+    func stop() {
+    }
+}

--- a/Packages/App/Tests/WebLibraryTests/HTMLTemplateTests.swift
+++ b/Packages/App/Tests/WebLibraryTests/HTMLTemplateTests.swift
@@ -1,0 +1,39 @@
+//
+//  HTMLTemplateTests.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 9/12/24.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import WebLibrary
+import XCTest
+
+final class HTMLTemplateTests: XCTestCase {
+    func test_givenTemplate_whenInjectKey_thenReturnsLocalizedHTML() throws {
+        let html = """
+Hey show some #{web_uploader.success}
+"""
+        let sut = HTMLTemplate(html: html)
+        let localized = sut.withLocalizedKeys(in: .module)
+        XCTAssertEqual(localized, "Hey show some Upload complete!")
+    }
+}

--- a/Packages/App/Tests/WebLibraryTests/MultipartFormTests.swift
+++ b/Packages/App/Tests/WebLibraryTests/MultipartFormTests.swift
@@ -1,0 +1,56 @@
+//
+//  MultipartFormTests.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 9/12/24.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import WebLibrary
+import XCTest
+
+final class MultipartFormTests: XCTestCase {
+    func test_givenBody_whenParseForm_thenReturnsFields() throws {
+        let passcode = "123"
+        let fileName = "some-filename.txt"
+        let fileContents = "This is the file content"
+
+        let body = """
+------WebKitFormBoundaryUtFggDFvBDn88T9z\r
+Content-Disposition: form-data; name=\"passcode\"\r
+\r
+\(passcode)\r
+------WebKitFormBoundaryUtFggDFvBDn88T9z\r
+Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r
+Content-Type: application/octet-stream\r
+\r
+\(fileContents)\r
+------WebKitFormBoundaryUtFggDFvBDn88T9z--\r
+"""
+
+        let sut = try XCTUnwrap(MultipartForm(body: body))
+
+        XCTAssertNil(sut.fields["passcode"]?.filename)
+        XCTAssertEqual(sut.fields["passcode"]?.value, passcode)
+        XCTAssertEqual(sut.fields["file"]?.filename, fileName)
+        XCTAssertEqual(sut.fields["file"]?.value, fileContents)
+    }
+}

--- a/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Passepartout.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,42 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "wg-go-apple",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/passepartoutvpn/wg-go-apple",

--- a/Passepartout/App/App.entitlements
+++ b/Passepartout/App/App.entitlements
@@ -32,6 +32,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(CFG_KEYCHAIN_GROUP_ID)</string>

--- a/Passepartout/App/AppMac.entitlements
+++ b/Passepartout/App/AppMac.entitlements
@@ -8,6 +8,8 @@
 	</array>
 	<key>com.apple.developer.networking.wifi-info</key>
 	<true/>
+	<key>com.apple.developer.system-extension.install</key>
+	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>
@@ -18,11 +20,11 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(CFG_KEYCHAIN_GROUP_ID)</string>
 	</array>
-	<key>com.apple.developer.system-extension.install</key>
-	<true/>
 </dict>
 </plist>

--- a/Passepartout/App/Context/AppContext+Testing.swift
+++ b/Passepartout/App/Context/AppContext+Testing.swift
@@ -68,6 +68,7 @@ extension AppContext {
         )
         let migrationManager = MigrationManager()
         let preferencesManager = PreferencesManager()
+        let uploadManager = UploadManager()
 
         return AppContext(
             apiManager: apiManager,
@@ -79,7 +80,8 @@ extension AppContext {
             profileManager: profileManager,
             registry: dependencies.registry,
             sysexManager: nil,
-            tunnel: tunnel
+            tunnel: tunnel,
+            uploadManager: uploadManager
         )
     }
 }

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -76,7 +76,8 @@ extension PassepartoutApp {
         AppCoordinator(
             profileManager: context.profileManager,
             tunnel: context.tunnel,
-            registry: context.registry
+            registry: context.registry,
+            uploadManager: context.uploadManager
         )
     }
 }

--- a/Passepartout/Passepartout.xctestplan
+++ b/Passepartout/Passepartout.xctestplan
@@ -13,6 +13,31 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Passepartout.xcodeproj",
+        "identifier" : "0E3FF4AD2CE3AF6F00BFF640",
+        "name" : "PassepartoutTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Packages\/App",
+        "identifier" : "WebLibraryTests",
+        "name" : "WebLibraryTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Packages\/App",
+        "identifier" : "AppUIMainTests",
+        "name" : "AppUIMainTests"
+      }
+    },
+    {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Packages\/App",
         "identifier" : "CommonLibraryTests",
@@ -22,30 +47,17 @@
     {
       "parallelizable" : true,
       "target" : {
-        "containerPath" : "container:Passepartout.xcodeproj",
-        "identifier" : "0E3FF4AD2CE3AF6F00BFF640",
-        "name" : "PassepartoutTests"
-      }
-    },
-    {
-      "target" : {
         "containerPath" : "container:Packages\/App",
-        "identifier" : "AppUIMainTests",
-        "name" : "AppUIMainTests"
+        "identifier" : "LegacyV2Tests",
+        "name" : "LegacyV2Tests"
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Packages\/App",
         "identifier" : "UILibraryTests",
         "name" : "UILibraryTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:Packages\/App",
-        "identifier" : "LegacyV2Tests",
-        "name" : "LegacyV2Tests"
       }
     }
   ],

--- a/scripts/import-translations.sh
+++ b/scripts/import-translations.sh
@@ -39,9 +39,12 @@ echo "Files have been created in the '$translations_input_path' directory."
 
 for lang in `ls $translations_input_path`; do
     input_path="$translations_input_path/$lang"
-    output_path="$translations_output_path/$lang.lproj/Localizable.strings"
+    output_dir="$translations_output_path/$lang.lproj"
+    output_path="$output_dir/Localizable.strings"
     keys_path="$output_path.keys"
     tmp_path="$output_path.tmp"
+
+    mkdir -p "$output_dir"
 
     # remove keys
     sed -E 's/^"(.*)" = .*$/"\1"/' $input_path >$keys_path


### PR DESCRIPTION
Add a "Profiles" tab dedicated to profile management on the TV. Here, local profiles can be imported by scanning a QR code that opens a basic web upload page. The HTTP server is implemented with SwiftNIO.

For being a plain HTTP context, encryption would be desirable, but JavaScript encryption is [only available in HTTPS contexts](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt). Therefore, a passcode is required at least for minimal authentication.

Do not mirror the remote repository on TV because it can now manage local-only profiles.

Closes #455 