### PR TITLE
Entitle for products based on the original purchase date

### DIFF
--- a/Packages/App/Sources/CommonIAP/Domain/AppRelease.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppRelease.swift
@@ -1,0 +1,47 @@
+//
+//  AppRelease.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/7/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonUtils
+import Foundation
+
+public struct AppRelease: Sendable {
+    private let name: String
+
+    fileprivate let date: Date
+
+    public init(_ name: String, on string: String) {
+        guard let date = string.asISO8601Date else {
+            fatalError("Unable to parse ISO date for \(name)")
+        }
+        self.name = name
+        self.date = date
+    }
+}
+
+extension OriginalPurchase {
+    public func isBefore(_ release: AppRelease) -> Bool {
+        purchaseDate < release.date
+    }
+}

--- a/Packages/App/Sources/CommonIAP/Strategy/FakeAppProductHelper.swift
+++ b/Packages/App/Sources/CommonIAP/Strategy/FakeAppProductHelper.swift
@@ -28,7 +28,7 @@ import CommonUtils
 import Foundation
 
 public actor FakeAppProductHelper: AppProductHelper {
-    private let build: Int
+    private let purchase: OriginalPurchase
 
     public private(set) var products: [AppProduct: InAppProduct]
 
@@ -38,7 +38,7 @@ public actor FakeAppProductHelper: AppProductHelper {
 
     // set .max to skip entitled products
     public init(build: Int = .max) {
-        self.build = build
+        purchase = OriginalPurchase(buildNumber: build)
         products = [:]
         receiptReader = FakeAppReceiptReader()
         didUpdateSubject = PassthroughSubject()
@@ -61,7 +61,7 @@ public actor FakeAppProductHelper: AppProductHelper {
                 native: $1
             )
         }
-        await receiptReader.setReceipt(withBuild: build, identifiers: [])
+        await receiptReader.setReceipt(withPurchase: purchase, identifiers: [])
         didUpdateSubject.send()
         return products
     }

--- a/Packages/App/Sources/CommonIAP/Strategy/FakeAppReceiptReader.swift
+++ b/Packages/App/Sources/CommonIAP/Strategy/FakeAppReceiptReader.swift
@@ -34,15 +34,23 @@ public actor FakeAppReceiptReader: AppReceiptReader {
     }
 
     public func setReceipt(withBuild build: Int, products: Set<AppProduct>, cancelledProducts: Set<AppProduct> = []) {
+        setReceipt(withPurchase: OriginalPurchase(buildNumber: build), products: products, cancelledProducts: cancelledProducts)
+    }
+
+    public func setReceipt(withPurchase purchase: OriginalPurchase, products: Set<AppProduct>, cancelledProducts: Set<AppProduct> = []) {
         setReceipt(
-            withBuild: build,
+            withPurchase: purchase,
             identifiers: Set(products.map(\.rawValue)),
             cancelledIdentifiers: Set(cancelledProducts.map(\.rawValue))
         )
     }
 
     public func setReceipt(withBuild build: Int, identifiers: Set<String>, cancelledIdentifiers: Set<String> = []) {
-        localReceipt = InAppReceipt(originalBuildNumber: build, purchaseReceipts: identifiers.map {
+        setReceipt(withPurchase: OriginalPurchase(buildNumber: build), identifiers: identifiers, cancelledIdentifiers: cancelledIdentifiers)
+    }
+
+    public func setReceipt(withPurchase purchase: OriginalPurchase, identifiers: Set<String>, cancelledIdentifiers: Set<String> = []) {
+        localReceipt = InAppReceipt(originalPurchase: purchase, purchaseReceipts: identifiers.map {
             .init(
                 productIdentifier: $0,
                 expirationDate: nil,
@@ -90,7 +98,7 @@ extension FakeAppReceiptReader {
             originalPurchaseDate: nil
         ))
         let newReceipt = InAppReceipt(
-            originalBuildNumber: localReceipt.originalBuildNumber,
+            originalPurchase: localReceipt.originalPurchase,
             purchaseReceipts: purchaseReceipts
         )
         self.localReceipt = newReceipt

--- a/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
@@ -50,7 +50,7 @@ public final class IAPManager: ObservableObject {
 
     private(set) var userLevel: AppUserLevel
 
-    public private(set) var purchasedAppBuild: Int?
+    public private(set) var originalPurchase: OriginalPurchase?
 
     public private(set) var purchasedProducts: Set<AppProduct>
 
@@ -190,20 +190,18 @@ private extension IAPManager {
     func asyncReloadReceipt() async {
         pp_log_g(.App.iap, .notice, "Start reloading in-app receipt...")
 
-        var purchasedAppBuild: Int?
+        var originalPurchase: OriginalPurchase?
         var purchasedProducts: Set<AppProduct> = []
         var eligibleFeatures: Set<AppFeature> = []
 
         if let receipt = await receiptReader.receipt(at: userLevel) {
-            if let originalBuildNumber = receipt.originalBuildNumber {
-                purchasedAppBuild = originalBuildNumber
-            }
+            originalPurchase = receipt.originalPurchase
 
-            if let purchasedAppBuild {
-                pp_log_g(.App.iap, .info, "Original purchased build: \(purchasedAppBuild)")
+            if let originalPurchase {
+                pp_log_g(.App.iap, .info, "Original purchase: \(originalPurchase)")
 
                 // assume some purchases by build number
-                let entitled = productsAtBuild?(purchasedAppBuild) ?? []
+                let entitled = productsAtBuild?(originalPurchase) ?? []
                 pp_log_g(.App.iap, .notice, "Entitled features: \(entitled.map(\.rawValue))")
 
                 entitled.forEach {
@@ -261,11 +259,11 @@ private extension IAPManager {
         }
 
         pp_log_g(.App.iap, .notice, "Finished reloading in-app receipt for user level \(userLevel)")
-        pp_log_g(.App.iap, .notice, "\tPurchased build number: \(purchasedAppBuild?.description ?? "unknown")")
+        pp_log_g(.App.iap, .notice, "\tOriginal purchase: \(String(describing: originalPurchase))")
         pp_log_g(.App.iap, .notice, "\tPurchased products: \(purchasedProducts.map(\.rawValue))")
         pp_log_g(.App.iap, .notice, "\tEligible features: \(eligibleFeatures)")
 
-        self.purchasedAppBuild = purchasedAppBuild
+        self.originalPurchase = originalPurchase
         self.purchasedProducts = purchasedProducts
         self.eligibleFeatures = eligibleFeatures // @Published -> objectWillChange.send()
     }

--- a/Packages/App/Sources/CommonLibrary/Business/UploadManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/UploadManager.swift
@@ -38,11 +38,6 @@ public final class UploadManager: ObservableObject {
         public let name: String
 
         public let contents: String
-
-        init(name: String, contents: String) {
-            self.name = name
-            self.contents = contents
-        }
     }
 
     public typealias PasscodeGenerator = () -> String

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -49,26 +49,27 @@ extension AppProduct: AppFeatureProviding {
 #endif
 
         case .Features.appleTV:
-            var eligible: [AppFeature] = [.appleTV, .sharing]
-#if os(tvOS)
-            // include "Essentials" to cope with BuildProducts
-            // limitations
+
             //
-            // some old iOS users are acknowledged certain
-            // purchases based on the build number of their first
-            // download, e.g. "Essentials iOS". unfortunately,
-            // that build number is not the same on tvOS, so
-            // those purchases do not exist and the TV may complain
-            // about missing features other than .appleTV
+            // some old iOS users were acknowledged certain
+            // purchases, e.g. "Essentials iOS", based on the build
+            // number of their first download, because the app used
+            // to be paid rather than freemium in the past. those
+            // conditions appeared in Dependencies.productsAtBuild()
             //
-            // we avoid this by relying on iOS/macOS eligibility
-            // alone while only requiring .appleTV on tvOS
+            // unfortunately, the build number is not unique across
+            // platforms, so those features artificially made available
+            // on iOS via the build number were not eligible on other
+            // platforms. this led the tvOS app to complain about
+            // unpaid features
             //
-            // this is a solid workaround as long as profiles are
-            // not editable on tvOS
-            eligible.append(contentsOf: AppProduct.Essentials.iOS_macOS.features)
-#endif
-            return eligible
+            // now that .productsAtBuild() uses the original purchase
+            // date as condition, which is cross-platform, there should
+            // be no need for workarounds. those old iOS purchasers
+            // should now see their artificial in-app purchase propagated
+            // to the tvOS app
+            //
+            return [.appleTV, .sharing]
 
         case .Complete.OneTime.lifetime, .Complete.Recurring.monthly, .Complete.Recurring.yearly:
             return AppFeature.allCases

--- a/Packages/App/Sources/CommonUtils/Extensions/String+Extensions.swift
+++ b/Packages/App/Sources/CommonUtils/Extensions/String+Extensions.swift
@@ -67,6 +67,18 @@ extension String {
 }
 
 extension String {
+    private static let iso8601: ISO8601DateFormatter = {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = .withFullDate
+        return fmt
+    }()
+
+    public var asISO8601Date: Date? {
+        Self.iso8601.date(from: self)
+    }
+}
+
+extension String {
     public var asCountryCodeEmoji: String {
         Self.emoji(forCountryCode: self)
     }

--- a/Packages/App/Sources/CommonUtils/IAP/InApp.swift
+++ b/Packages/App/Sources/CommonUtils/IAP/InApp.swift
@@ -89,17 +89,20 @@ public struct InAppReceipt: Sendable {
         }
     }
 
-    public let originalBuildNumber: Int?
+    public let originalPurchase: OriginalPurchase?
 
     public let purchaseReceipts: [PurchaseReceipt]?
 
-    public init(originalBuildNumber: Int?, purchaseReceipts: [PurchaseReceipt]?) {
-        self.originalBuildNumber = originalBuildNumber
+    public init(originalPurchase: OriginalPurchase?, purchaseReceipts: [PurchaseReceipt]?) {
+        self.originalPurchase = originalPurchase
         self.purchaseReceipts = purchaseReceipts
     }
 
-    public func withBuildNumber(_ buildNumber: Int) -> Self {
-        .init(originalBuildNumber: buildNumber, purchaseReceipts: purchaseReceipts)
+    public func withOriginalPurchase(_ purchase: OriginalPurchase) -> Self {
+        .init(
+            originalPurchase: purchase,
+            purchaseReceipts: purchaseReceipts
+        )
     }
 }
 

--- a/Packages/App/Sources/CommonUtils/IAP/OriginalPurchase.swift
+++ b/Packages/App/Sources/CommonUtils/IAP/OriginalPurchase.swift
@@ -1,8 +1,8 @@
 //
-//  BuildProducts.swift
+//  OriginalPurchase.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 4/26/22.
+//  Created by Davide De Rosa on 6/7/25.
 //  Copyright (c) 2025 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -25,4 +25,13 @@
 
 import Foundation
 
-public typealias BuildProducts<ProductType> = @Sendable (_ purchase: OriginalPurchase) -> Set<ProductType> where ProductType: Hashable
+public struct OriginalPurchase: Sendable {
+    public let buildNumber: Int
+
+    public let purchaseDate: Date
+
+    public init(buildNumber: Int, purchaseDate: Date = .distantFuture) {
+        self.buildNumber = buildNumber
+        self.purchaseDate = purchaseDate
+    }
+}

--- a/Packages/App/Sources/CommonUtils/IAP/OriginalPurchase.swift
+++ b/Packages/App/Sources/CommonUtils/IAP/OriginalPurchase.swift
@@ -26,11 +26,14 @@
 import Foundation
 
 public struct OriginalPurchase: Sendable {
+    public let isSandbox: Bool
+
     public let buildNumber: Int
 
     public let purchaseDate: Date
 
-    public init(buildNumber: Int, purchaseDate: Date = .distantFuture) {
+    public init(isSandbox: Bool = false, buildNumber: Int, purchaseDate: Date = .distantFuture) {
+        self.isSandbox = isSandbox
         self.buildNumber = buildNumber
         self.purchaseDate = purchaseDate
     }

--- a/Packages/App/Sources/CommonUtils/IAP/StoreKitReceiptReader.swift
+++ b/Packages/App/Sources/CommonUtils/IAP/StoreKitReceiptReader.swift
@@ -94,6 +94,7 @@ private extension StoreKitReceiptReader {
 private extension AppTransaction {
     var originalPurchase: OriginalPurchase {
         OriginalPurchase(
+            isSandbox: [.sandbox, .xcode].contains(environment),
             buildNumber: Int(originalAppVersion) ?? .max,
             purchaseDate: originalPurchaseDate
         )

--- a/Packages/App/Sources/CommonUtils/IAP/StoreKitReceiptReader.swift
+++ b/Packages/App/Sources/CommonUtils/IAP/StoreKitReceiptReader.swift
@@ -46,30 +46,30 @@ public final class StoreKitReceiptReader: InAppReceiptReader, Sendable {
                 )
             }
 
-        return InAppReceipt(originalBuildNumber: result.build, purchaseReceipts: purchaseReceipts)
+        return InAppReceipt(originalPurchase: result.purchase, purchaseReceipts: purchaseReceipts)
     }
 }
 
 private extension StoreKitReceiptReader {
-    func entitlements() async -> (build: Int?, txs: [Transaction]) {
+    func entitlements() async -> (purchase: OriginalPurchase?, txs: [Transaction]) {
         async let build = Task {
             let startDate = Date()
             logger.debug("Start fetching original build number...")
-            let originalBuildNumber: Int?
+            let originalPurchase: OriginalPurchase?
             do {
                 switch try await AppTransaction.shared {
                 case .verified(let tx):
                     logger.debug("Fetched AppTransaction: \(tx)")
-                    originalBuildNumber = Int(tx.originalAppVersion)
+                    originalPurchase = tx.originalPurchase
                 default:
-                    originalBuildNumber = nil
+                    originalPurchase = nil
                 }
             } catch {
-                originalBuildNumber = nil
+                originalPurchase = nil
             }
             let elapsed = -startDate.timeIntervalSinceNow
             logger.debug("Fetched original build number: \(elapsed)")
-            return originalBuildNumber
+            return originalPurchase
         }
         async let txs = Task {
             let startDate = Date()
@@ -88,5 +88,14 @@ private extension StoreKitReceiptReader {
             return transactions
         }
         return await (build.value, txs.value)
+    }
+}
+
+private extension AppTransaction {
+    var originalPurchase: OriginalPurchase {
+        OriginalPurchase(
+            buildNumber: Int(originalAppVersion) ?? .max,
+            purchaseDate: originalPurchaseDate
+        )
     }
 }

--- a/Packages/App/Sources/CommonUtils/IAP/StoreKitReceiptReader.swift
+++ b/Packages/App/Sources/CommonUtils/IAP/StoreKitReceiptReader.swift
@@ -59,6 +59,7 @@ private extension StoreKitReceiptReader {
             do {
                 switch try await AppTransaction.shared {
                 case .verified(let tx):
+                    logger.debug("Fetched AppTransaction: \(tx)")
                     originalBuildNumber = Int(tx.originalAppVersion)
                 default:
                     originalBuildNumber = nil

--- a/Packages/App/Sources/UILibrary/Views/Settings/PurchasedView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/PurchasedView.swift
@@ -108,8 +108,8 @@ private extension PurchasedView {
             Group {
                 ThemeRow(Strings.Views.Purchased.Rows.buildNumber, value: purchase.buildNumber.description)
                     .scrollableOnTV()
-//                ThemeRow(Strings.Views.Purchased.Rows.purchaseDate, value: purchase.purchaseDate)
-//                    .scrollableOnTV()
+                ThemeRow(Strings.Views.Purchased.Rows.downloadDate, value: purchase.purchaseDate.description)
+                    .scrollableOnTV()
             }
             .themeSection(header: Strings.Views.Purchased.Sections.Download.header)
         }

--- a/Packages/App/Sources/UILibrary/Views/Settings/PurchasedView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Settings/PurchasedView.swift
@@ -69,7 +69,7 @@ public struct PurchasedView: View {
 
 private extension PurchasedView {
     var isEmpty: Bool {
-        iapManager.purchasedAppBuild == nil && iapManager.purchasedProducts.isEmpty && iapManager.eligibleFeatures.isEmpty
+        iapManager.originalPurchase == nil && iapManager.purchasedProducts.isEmpty && iapManager.eligibleFeatures.isEmpty
     }
 
     var allFeatures: [AppFeature] {
@@ -104,10 +104,12 @@ private extension PurchasedView {
     }
 
     var downloadSection: some View {
-        iapManager.purchasedAppBuild.map { build in
+        iapManager.originalPurchase.map { purchase in
             Group {
-                ThemeRow(Strings.Views.Purchased.Rows.buildNumber, value: build.description)
+                ThemeRow(Strings.Views.Purchased.Rows.buildNumber, value: purchase.buildNumber.description)
                     .scrollableOnTV()
+//                ThemeRow(Strings.Views.Purchased.Rows.purchaseDate, value: purchase.purchaseDate)
+//                    .scrollableOnTV()
             }
             .themeSection(header: Strings.Views.Purchased.Sections.Download.header)
         }

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -86,8 +86,8 @@ extension IAPManagerTests {
     func test_givenBuildProducts_whenOlder_thenEssentialsVersion() async {
         let reader = FakeAppReceiptReader()
         await reader.setReceipt(withBuild: olderBuildNumber, identifiers: [])
-        let sut = IAPManager(receiptReader: reader) { build in
-            if build <= self.defaultBuildNumber {
+        let sut = IAPManager(receiptReader: reader) { purchase in
+            if purchase.buildNumber <= self.defaultBuildNumber {
                 return [.Essentials.iOS_macOS]
             }
             return []
@@ -99,8 +99,8 @@ extension IAPManagerTests {
     func test_givenBuildProducts_whenNewer_thenFreeVersion() async {
         let reader = FakeAppReceiptReader()
         await reader.setReceipt(withBuild: newerBuildNumber, products: [])
-        let sut = IAPManager(receiptReader: reader) { build in
-            if build <= self.defaultBuildNumber {
+        let sut = IAPManager(receiptReader: reader) { purchase in
+            if purchase.buildNumber <= self.defaultBuildNumber {
                 return [.Essentials.iOS_macOS]
             }
             return []

--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		0E2306222DC2C2DC002D70D7 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8195592CFDA75200CC8FFD /* Dependencies.swift */; };
 		0E2306232DC2C2DC002D70D7 /* Dependencies+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8DFD492D05FE5A00531CDE /* Dependencies+CoreData.swift */; };
 		0E2306242DC2C2DC002D70D7 /* Dependencies+IAPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8DFD4B2D05FE5A00531CDE /* Dependencies+IAPManager.swift */; };
+		0E2BA91D2DF46C0C0000F169 /* AppRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */; };
+		0E2BA91E2DF46C0C0000F169 /* AppRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */; };
+		0E2BA91F2DF46C0C0000F169 /* AppRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */; };
 		0E3E22962CE53510005135DF /* AppUIMain in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, macos, ); productRef = 0E3E22952CE53510005135DF /* AppUIMain */; };
 		0E3E22982CE53510005135DF /* AppUITV in Frameworks */ = {isa = PBXBuildFile; platformFilters = (tvos, ); productRef = 0E3E22972CE53510005135DF /* AppUITV */; };
 		0E3FF4BA2CE3AFBC00BFF640 /* Profiles.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 0E3FF4B72CE3AFBC00BFF640 /* Profiles.sqlite */; };
@@ -128,6 +131,7 @@
 		0E29E7202D0B7D06003294CA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AppPlist.strings; sourceTree = "<group>"; };
 		0E29E7212D0B7D09003294CA /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AppPlist.strings; sourceTree = "<group>"; };
 		0E29E7262D0B7D75003294CA /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AppPlist.strings; sourceTree = "<group>"; };
+		0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRelease.swift; sourceTree = "<group>"; };
 		0E3DC7CF2D347FAA003F1C4B /* Demo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Demo.xcodeproj; sourceTree = "<group>"; };
 		0E3FF4AE2CE3AF6F00BFF640 /* PassepartoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PassepartoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E3FF4B72CE3AFBC00BFF640 /* Profiles.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = Profiles.sqlite; sourceTree = "<group>"; };
@@ -364,6 +368,7 @@
 		0E7E3D612B9345FD002BBDB4 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */,
 				0E8195592CFDA75200CC8FFD /* Dependencies.swift */,
 				0E8DFD492D05FE5A00531CDE /* Dependencies+CoreData.swift */,
 				0E8DFD4B2D05FE5A00531CDE /* Dependencies+IAPManager.swift */,
@@ -806,6 +811,7 @@
 				0E8DFD502D05FE5A00531CDE /* Dependencies+Processors.swift in Sources */,
 				0E8DFD512D05FE5A00531CDE /* Dependencies+CoreData.swift in Sources */,
 				0E7C3CCD2C9AF44600B72E69 /* AppDelegate.swift in Sources */,
+				0E2BA91D2DF46C0C0000F169 /* AppRelease.swift in Sources */,
 				0ED61CFA2CD04192008FE259 /* App+iOS.swift in Sources */,
 				0E7E3D6B2B9345FD002BBDB4 /* PassepartoutApp.swift in Sources */,
 				0EAEC8A92D05DB8D001AA50C /* DefaultAppProcessor.swift in Sources */,
@@ -858,6 +864,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0E2BA91F2DF46C0C0000F169 /* AppRelease.swift in Sources */,
 				0E81955B2CFDA7BF00CC8FFD /* Dependencies.swift in Sources */,
 				0EAEC8AA2D05DB8D001AA50C /* DefaultTunnelProcessor.swift in Sources */,
 				0E94EE582B93554B00588243 /* PacketTunnelProvider.swift in Sources */,
@@ -884,6 +891,7 @@
 				0E2306242DC2C2DC002D70D7 /* Dependencies+IAPManager.swift in Sources */,
 				0E23061E2DC2C2CB002D70D7 /* Dependencies+Partout.swift in Sources */,
 				0E23061F2DC2C2CB002D70D7 /* DefaultTunnelProcessor.swift in Sources */,
+				0E2BA91E2DF46C0C0000F169 /* AppRelease.swift in Sources */,
 				0E2306142DC2BF6B002D70D7 /* main.swift in Sources */,
 				0E2306162DC2C00B002D70D7 /* PacketTunnelProvider.swift in Sources */,
 			);

--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -17,9 +17,9 @@
 		0E2306222DC2C2DC002D70D7 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8195592CFDA75200CC8FFD /* Dependencies.swift */; };
 		0E2306232DC2C2DC002D70D7 /* Dependencies+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8DFD492D05FE5A00531CDE /* Dependencies+CoreData.swift */; };
 		0E2306242DC2C2DC002D70D7 /* Dependencies+IAPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8DFD4B2D05FE5A00531CDE /* Dependencies+IAPManager.swift */; };
-		0E2BA91D2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */; };
-		0E2BA91E2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */; };
-		0E2BA91F2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */; };
+		0E2BA91D2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift */; };
+		0E2BA91E2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift */; };
+		0E2BA91F2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift */; };
 		0E3E22962CE53510005135DF /* AppUIMain in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, macos, ); productRef = 0E3E22952CE53510005135DF /* AppUIMain */; };
 		0E3E22982CE53510005135DF /* AppUITV in Frameworks */ = {isa = PBXBuildFile; platformFilters = (tvos, ); productRef = 0E3E22972CE53510005135DF /* AppUITV */; };
 		0E3FF4BA2CE3AFBC00BFF640 /* Profiles.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 0E3FF4B72CE3AFBC00BFF640 /* Profiles.sqlite */; };
@@ -131,7 +131,7 @@
 		0E29E7202D0B7D06003294CA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AppPlist.strings; sourceTree = "<group>"; };
 		0E29E7212D0B7D09003294CA /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AppPlist.strings; sourceTree = "<group>"; };
 		0E29E7262D0B7D75003294CA /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AppPlist.strings; sourceTree = "<group>"; };
-		0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppRelease+Eligibility.swift"; sourceTree = "<group>"; };
+		0E2BA91C2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppRelease+BusinessChanges.swift"; sourceTree = "<group>"; };
 		0E3DC7CF2D347FAA003F1C4B /* Demo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Demo.xcodeproj; sourceTree = "<group>"; };
 		0E3FF4AE2CE3AF6F00BFF640 /* PassepartoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PassepartoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E3FF4B72CE3AFBC00BFF640 /* Profiles.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = Profiles.sqlite; sourceTree = "<group>"; };
@@ -368,7 +368,7 @@
 		0E7E3D612B9345FD002BBDB4 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */,
+				0E2BA91C2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift */,
 				0E8195592CFDA75200CC8FFD /* Dependencies.swift */,
 				0E8DFD492D05FE5A00531CDE /* Dependencies+CoreData.swift */,
 				0E8DFD4B2D05FE5A00531CDE /* Dependencies+IAPManager.swift */,
@@ -811,7 +811,7 @@
 				0E8DFD502D05FE5A00531CDE /* Dependencies+Processors.swift in Sources */,
 				0E8DFD512D05FE5A00531CDE /* Dependencies+CoreData.swift in Sources */,
 				0E7C3CCD2C9AF44600B72E69 /* AppDelegate.swift in Sources */,
-				0E2BA91D2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */,
+				0E2BA91D2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift in Sources */,
 				0ED61CFA2CD04192008FE259 /* App+iOS.swift in Sources */,
 				0E7E3D6B2B9345FD002BBDB4 /* PassepartoutApp.swift in Sources */,
 				0EAEC8A92D05DB8D001AA50C /* DefaultAppProcessor.swift in Sources */,
@@ -864,7 +864,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0E2BA91F2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */,
+				0E2BA91F2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift in Sources */,
 				0E81955B2CFDA7BF00CC8FFD /* Dependencies.swift in Sources */,
 				0EAEC8AA2D05DB8D001AA50C /* DefaultTunnelProcessor.swift in Sources */,
 				0E94EE582B93554B00588243 /* PacketTunnelProvider.swift in Sources */,
@@ -891,7 +891,7 @@
 				0E2306242DC2C2DC002D70D7 /* Dependencies+IAPManager.swift in Sources */,
 				0E23061E2DC2C2CB002D70D7 /* Dependencies+Partout.swift in Sources */,
 				0E23061F2DC2C2CB002D70D7 /* DefaultTunnelProcessor.swift in Sources */,
-				0E2BA91E2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */,
+				0E2BA91E2DF46C0C0000F169 /* AppRelease+BusinessChanges.swift in Sources */,
 				0E2306142DC2BF6B002D70D7 /* main.swift in Sources */,
 				0E2306162DC2C00B002D70D7 /* PacketTunnelProvider.swift in Sources */,
 			);

--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -17,9 +17,9 @@
 		0E2306222DC2C2DC002D70D7 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8195592CFDA75200CC8FFD /* Dependencies.swift */; };
 		0E2306232DC2C2DC002D70D7 /* Dependencies+CoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8DFD492D05FE5A00531CDE /* Dependencies+CoreData.swift */; };
 		0E2306242DC2C2DC002D70D7 /* Dependencies+IAPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8DFD4B2D05FE5A00531CDE /* Dependencies+IAPManager.swift */; };
-		0E2BA91D2DF46C0C0000F169 /* AppRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */; };
-		0E2BA91E2DF46C0C0000F169 /* AppRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */; };
-		0E2BA91F2DF46C0C0000F169 /* AppRelease.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */; };
+		0E2BA91D2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */; };
+		0E2BA91E2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */; };
+		0E2BA91F2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */; };
 		0E3E22962CE53510005135DF /* AppUIMain in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, macos, ); productRef = 0E3E22952CE53510005135DF /* AppUIMain */; };
 		0E3E22982CE53510005135DF /* AppUITV in Frameworks */ = {isa = PBXBuildFile; platformFilters = (tvos, ); productRef = 0E3E22972CE53510005135DF /* AppUITV */; };
 		0E3FF4BA2CE3AFBC00BFF640 /* Profiles.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 0E3FF4B72CE3AFBC00BFF640 /* Profiles.sqlite */; };
@@ -131,7 +131,7 @@
 		0E29E7202D0B7D06003294CA /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AppPlist.strings; sourceTree = "<group>"; };
 		0E29E7212D0B7D09003294CA /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AppPlist.strings; sourceTree = "<group>"; };
 		0E29E7262D0B7D75003294CA /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AppPlist.strings; sourceTree = "<group>"; };
-		0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRelease.swift; sourceTree = "<group>"; };
+		0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppRelease+Eligibility.swift"; sourceTree = "<group>"; };
 		0E3DC7CF2D347FAA003F1C4B /* Demo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Demo.xcodeproj; sourceTree = "<group>"; };
 		0E3FF4AE2CE3AF6F00BFF640 /* PassepartoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PassepartoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E3FF4B72CE3AFBC00BFF640 /* Profiles.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = Profiles.sqlite; sourceTree = "<group>"; };
@@ -368,7 +368,7 @@
 		0E7E3D612B9345FD002BBDB4 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				0E2BA91C2DF46C0C0000F169 /* AppRelease.swift */,
+				0E2BA91C2DF46C0C0000F169 /* AppRelease+Eligibility.swift */,
 				0E8195592CFDA75200CC8FFD /* Dependencies.swift */,
 				0E8DFD492D05FE5A00531CDE /* Dependencies+CoreData.swift */,
 				0E8DFD4B2D05FE5A00531CDE /* Dependencies+IAPManager.swift */,
@@ -811,7 +811,7 @@
 				0E8DFD502D05FE5A00531CDE /* Dependencies+Processors.swift in Sources */,
 				0E8DFD512D05FE5A00531CDE /* Dependencies+CoreData.swift in Sources */,
 				0E7C3CCD2C9AF44600B72E69 /* AppDelegate.swift in Sources */,
-				0E2BA91D2DF46C0C0000F169 /* AppRelease.swift in Sources */,
+				0E2BA91D2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */,
 				0ED61CFA2CD04192008FE259 /* App+iOS.swift in Sources */,
 				0E7E3D6B2B9345FD002BBDB4 /* PassepartoutApp.swift in Sources */,
 				0EAEC8A92D05DB8D001AA50C /* DefaultAppProcessor.swift in Sources */,
@@ -864,7 +864,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0E2BA91F2DF46C0C0000F169 /* AppRelease.swift in Sources */,
+				0E2BA91F2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */,
 				0E81955B2CFDA7BF00CC8FFD /* Dependencies.swift in Sources */,
 				0EAEC8AA2D05DB8D001AA50C /* DefaultTunnelProcessor.swift in Sources */,
 				0E94EE582B93554B00588243 /* PacketTunnelProvider.swift in Sources */,
@@ -891,7 +891,7 @@
 				0E2306242DC2C2DC002D70D7 /* Dependencies+IAPManager.swift in Sources */,
 				0E23061E2DC2C2CB002D70D7 /* Dependencies+Partout.swift in Sources */,
 				0E23061F2DC2C2CB002D70D7 /* DefaultTunnelProcessor.swift in Sources */,
-				0E2BA91E2DF46C0C0000F169 /* AppRelease.swift in Sources */,
+				0E2BA91E2DF46C0C0000F169 /* AppRelease+Eligibility.swift in Sources */,
 				0E2306142DC2BF6B002D70D7 /* main.swift in Sources */,
 				0E2306162DC2C00B002D70D7 /* PacketTunnelProvider.swift in Sources */,
 			);

--- a/Passepartout/Shared/AppRelease+BusinessChanges.swift
+++ b/Passepartout/Shared/AppRelease+BusinessChanges.swift
@@ -1,5 +1,5 @@
 //
-//  AppRelease+Eligibility.swift
+//  AppRelease+BusinessChanges.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 6/7/25.

--- a/Passepartout/Shared/AppRelease+Eligibility.swift
+++ b/Passepartout/Shared/AppRelease+Eligibility.swift
@@ -1,5 +1,5 @@
 //
-//  AppRelease.swift
+//  AppRelease+Eligibility.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 6/7/25.
@@ -23,29 +23,11 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CommonUtils
+import CommonLibrary
 import Foundation
 
-struct AppRelease {
+extension AppRelease {
     static let freemium = AppRelease("freemium", on: "2019-09-05")
 
     static let v2 = AppRelease("v2", on: "2022-10-02")
-
-    private let name: String
-
-    fileprivate let date: Date
-
-    private init(_ name: String, on string: String) {
-        guard let date = string.asISO8601Date else {
-            fatalError("Unable to parse ISO date for \(name)")
-        }
-        self.name = name
-        self.date = date
-    }
-}
-
-extension OriginalPurchase {
-    func isBefore(_ release: AppRelease) -> Bool {
-        purchaseDate < release.date
-    }
 }

--- a/Passepartout/Shared/AppRelease.swift
+++ b/Passepartout/Shared/AppRelease.swift
@@ -1,0 +1,51 @@
+//
+//  AppRelease.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/7/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonUtils
+import Foundation
+
+struct AppRelease {
+    static let freemium = AppRelease("freemium", on: "2019-09-05")
+
+    static let v2 = AppRelease("v2", on: "2022-10-02")
+
+    private let name: String
+
+    fileprivate let date: Date
+
+    private init(_ name: String, on string: String) {
+        guard let date = string.asISO8601Date else {
+            fatalError("Unable to parse ISO date for \(name)")
+        }
+        self.name = name
+        self.date = date
+    }
+}
+
+extension OriginalPurchase {
+    func isBefore(_ release: AppRelease) -> Bool {
+        purchaseDate < release.date
+    }
+}

--- a/Passepartout/Shared/Dependencies+IAPManager.swift
+++ b/Passepartout/Shared/Dependencies+IAPManager.swift
@@ -51,16 +51,16 @@ extension Dependencies {
     }
 
     nonisolated func productsAtBuild() -> BuildProducts<AppProduct> {
-        {
+        { purchase in
 #if os(iOS)
-            if $0 <= 2016 {
+            if purchase.buildNumber <= 2016 {
                 return [.Essentials.iOS]
-            } else if $0 <= 3000 {
+            } else if purchase.buildNumber <= 3000 {
                 return [.Features.networkSettings]
             }
             return []
 #elseif os(macOS)
-            if $0 <= 3000 {
+            if purchase.buildNumber <= 3000 {
                 return [.Features.networkSettings]
             }
             return []

--- a/Passepartout/Shared/Dependencies+IAPManager.swift
+++ b/Passepartout/Shared/Dependencies+IAPManager.swift
@@ -52,6 +52,9 @@ extension Dependencies {
 
     nonisolated func productsAtBuild() -> BuildProducts<AppProduct> {
         { purchase in
+            guard !purchase.isSandbox else {
+                return []
+            }
 #if os(iOS)
             if purchase.buildNumber <= 2016 {
                 return [.Essentials.iOS]

--- a/Passepartout/Shared/Dependencies+IAPManager.swift
+++ b/Passepartout/Shared/Dependencies+IAPManager.swift
@@ -56,14 +56,14 @@ extension Dependencies {
                 return []
             }
 #if os(iOS)
-            if purchase.buildNumber <= 2016 {
+            if purchase.isBefore(.freemium) {
                 return [.Essentials.iOS]
-            } else if purchase.buildNumber <= 3000 {
+            } else if purchase.isBefore(.v2) {
                 return [.Features.networkSettings]
             }
             return []
 #elseif os(macOS)
-            if purchase.buildNumber <= 3000 {
+            if purchase.isBefore(.v2) {
                 return [.Features.networkSettings]
             }
             return []


### PR DESCRIPTION
The [original build number](https://developer.apple.com/documentation/storekit/apptransaction/originalappversion) proved to be platform-specific, which makes it impossible to recognize artificial purchases across multiple platforms based on the build number of the first purchase. This is necessary to acknowledge some features to the old pre-freemium iOS purchasers.

Example: if I bought the iOS app at build 1000 (paid), and I got the tvOS app at build 2000 (freemium), the tvOS receipt will return 2000 as the purchased build number, not 1000. Therefore, if I want to grant some features to users who purchased a build number before 2000, those features will be available on iOS, but not on tvOS where the build number is 2000.

Use the [original purchase date](https://developer.apple.com/documentation/storekit/apptransaction/originalpurchasedate) in the hope that it makes business model eligibility cross-platform. The author of [this post](https://lucas.love/til/change-the-business-model-of-an-app-store-app) confirms that the [official Apple advice](https://developer.apple.com/documentation/storekit/supporting-business-model-changes-by-using-the-app-transaction) is wrong.

Related to #1083 and #1156