### PR TITLE
Extend paywall with individual purchases

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -102,12 +102,12 @@ public struct AppCoordinator: View, AppCoordinatorConforming, SizeClassProviding
         ))
         .modifier(PaywallModifier(
             reason: $paywallReason,
-            otherTitle: Strings.Views.Paywall.Alerts.Confirmation.editProfile,
-            onOtherAction: { profile in
-                guard let profile else {
-                    return
-                }
-                onEditProfile(profile.localizedPreview)
+            onAction: { profile in
+                // FIXME: ###, connect anyway
+//                guard let profile else {
+//                    return
+//                }
+//                onEditProfile(profile.localizedPreview)
             },
             onCancel: onCancelPaywall
         ))

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -195,7 +195,6 @@ private extension ProfileCoordinator {
             setLater(PaywallReason(
                 nil,
                 requiredFeatures: requiredFeatures,
-                suggestedProducts: nil,
                 action: .save
             )) {
                 paywallReason = $0

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileCoordinator.swift
@@ -71,7 +71,12 @@ struct ProfileCoordinator: View {
 
     var body: some View {
         contentView
-            .modifier(PaywallModifier(reason: $paywallReason))
+            .modifier(PaywallModifier(
+                reason: $paywallReason,
+                onAction: { _ in
+                    saveAnyway()
+                }
+            ))
             .themeModal(item: $modalRoute, content: modalDestination)
             .environment(\.dismissProfile, onDismiss)
             .withErrorHandler(errorHandler)
@@ -151,6 +156,12 @@ private extension ProfileCoordinator {
 // MARK: - Actions
 
 private extension ProfileCoordinator {
+    func saveAnyway() {
+        Task {
+            try await commitEditing(verifying: false, dismissing: true)
+        }
+    }
+
     func addNewModule(_ moduleType: ModuleType) {
         let module = moduleType.newModule(with: registry)
         withAnimation(theme.animation(for: .modules)) {

--- a/Packages/App/Sources/AppUIMain/Views/Profile/ProfileStorageSection.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/ProfileStorageSection.swift
@@ -73,12 +73,7 @@ private extension ProfileStorageSection {
     var sharingPurchaseButton: some View {
         PurchaseRequiredView(
             requiring: sharingRequirements,
-            reason: $paywallReason,
-            suggesting: {
-                var products = iapManager.suggestedProducts()
-                products.insert(.Features.appleTV)
-                return products
-            }()
+            reason: $paywallReason
         )
     }
 
@@ -96,12 +91,7 @@ private extension ProfileStorageSection {
     var tvPurchaseButton: some View {
         PurchaseRequiredView(
             requiring: tvRequirements,
-            reason: $paywallReason,
-            suggesting: {
-                var products = iapManager.suggestedProducts(filter: .onlyComplete)
-                products.insert(.Features.appleTV)
-                return products
-            }()
+            reason: $paywallReason
         )
     }
 }

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -147,10 +147,6 @@ private extension ModuleListView {
         return features
     }
 
-    var suggestedGeneralProducts: Set<AppProduct> {
-        iapManager.suggestedProducts(for: [.appleTV])
-    }
-
     func moveModules(from offsets: IndexSet, to newOffset: Int) {
         profileEditor.moveModules(from: offsets, to: newOffset)
         // XXX: selection is lost after move, reset as a workaround

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -64,8 +64,7 @@ struct ModuleListView: View, Routable {
                         Text(Strings.Global.Nouns.general)
                         PurchaseRequiredView(
                             requiring: requiredGeneralFeatures,
-                            reason: $paywallReason,
-                            suggesting: suggestedGeneralProducts
+                            reason: $paywallReason
                         )
                     }
                 }

--- a/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Profile/macOS/ModuleListView+macOS.swift
@@ -148,9 +148,7 @@ private extension ModuleListView {
     }
 
     var suggestedGeneralProducts: Set<AppProduct> {
-        var products = iapManager.suggestedProducts()
-        products.insert(.Features.appleTV)
-        return products
+        iapManager.suggestedProducts(for: [.appleTV])
     }
 
     func moveModules(from offsets: IndexSet, to newOffset: Int) {

--- a/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUITV/Views/App/AppCoordinator.swift
@@ -201,7 +201,7 @@ extension AppCoordinator {
         pp_log_g(.app, .info, "Present paywall")
         paywallContinuation = continuation
 
-        setLater(.init(nil, requiredFeatures: features, action: .connect)) {
+        setLater(.init(profile, requiredFeatures: features, action: .connect)) {
             paywallReason = $0
         }
     }

--- a/Packages/App/Sources/CommonIAP/Domain/AppFeature.swift
+++ b/Packages/App/Sources/CommonIAP/Domain/AppFeature.swift
@@ -44,7 +44,7 @@ public enum AppFeature: String, CaseIterable {
 }
 
 extension AppFeature {
-    public static let essentialFeatures: [AppFeature] = [
+    public static let essentialFeatures: Set<AppFeature> = [
         .dns,
         .httpProxy,
         .onDemand,

--- a/Packages/App/Sources/CommonIAP/Strategy/FakeAppProductHelper.swift
+++ b/Packages/App/Sources/CommonIAP/Strategy/FakeAppProductHelper.swift
@@ -54,12 +54,7 @@ public actor FakeAppProductHelper: AppProductHelper {
 
     public func fetchProducts(timeout: Int) async throws -> [AppProduct: InAppProduct] {
         products = AppProduct.all.reduce(into: [:]) {
-            $0[$1] = InAppProduct(
-                productIdentifier: $1.rawValue,
-                localizedTitle: $1.rawValue,
-                localizedPrice: "€10.0",
-                native: $1
-            )
+            $0[$1] = $1.asFakeIAP
         }
         await receiptReader.setReceipt(withPurchase: purchase, identifiers: [])
         didUpdateSubject.send()
@@ -74,5 +69,16 @@ public actor FakeAppProductHelper: AppProductHelper {
 
     public func restorePurchases() async throws {
         didUpdateSubject.send()
+    }
+}
+
+extension AppProduct {
+    public var asFakeIAP: InAppProduct {
+        InAppProduct(
+            productIdentifier: rawValue,
+            localizedTitle: rawValue,
+            localizedPrice: "€10.0",
+            native: self
+        )
     }
 }

--- a/Packages/App/Sources/CommonIAP/Strategy/FakeAppReceiptReader.swift
+++ b/Packages/App/Sources/CommonIAP/Strategy/FakeAppReceiptReader.swift
@@ -87,10 +87,7 @@ extension FakeAppReceiptReader {
         expirationDate: Date? = nil,
         cancellationDate: Date? = nil
     ) async {
-        guard let localReceipt else {
-            fatalError("Call setReceipt() first")
-        }
-        var purchaseReceipts = localReceipt.purchaseReceipts ?? []
+        var purchaseReceipts = localReceipt?.purchaseReceipts ?? []
         purchaseReceipts.append(.init(
             productIdentifier: identifier,
             expirationDate: expirationDate,
@@ -98,7 +95,7 @@ extension FakeAppReceiptReader {
             originalPurchaseDate: nil
         ))
         let newReceipt = InAppReceipt(
-            originalPurchase: localReceipt.originalPurchase,
+            originalPurchase: localReceipt?.originalPurchase,
             purchaseReceipts: purchaseReceipts
         )
         self.localReceipt = newReceipt

--- a/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/IAPManager.swift
@@ -182,6 +182,17 @@ extension IAPManager {
     public var isPayingUser: Bool {
         !purchasedProducts.isEmpty
     }
+
+    public var didPurchaseComplete: Bool {
+        purchasedProducts.contains(where: \.isComplete)
+    }
+
+    public func didPurchase(_ purchasable: [InAppProduct]) -> Bool {
+        let products = purchasable.compactMap {
+            AppProduct(rawValue: $0.productIdentifier)
+        }
+        return purchasedProducts.contains(products)
+    }
 }
 
 // MARK: - Receipt

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -27,7 +27,7 @@ import CommonIAP
 import Foundation
 
 extension AppFeature {
-    public func individualProducts(for platform: IAPManager.Platform) -> Set<AppProduct> {
+    public func individualProducts(on platform: IAPManager.Platform) -> Set<AppProduct> {
         if isEssential {
             var list: Set<AppProduct> = [.Essentials.iOS_macOS]
             switch platform {

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -27,15 +27,15 @@ import CommonIAP
 import Foundation
 
 extension AppFeature {
+
+    // some non-essential features can only be purchased individually
+    // here we suggest the products entitling for such features
     public var nonEssentialProducts: Set<AppProduct> {
-        guard !isEssential else {
-            return []
-        }
         switch self {
         case .appleTV:
             return [.Features.appleTV]
         default:
-            assertionFailure("Feature \(rawValue) is outdated or not purchasable individually")
+            assert(isEssential, "Non-essential feature \(rawValue) must be purchasable individually")
             return []
         }
     }

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -27,14 +27,14 @@ import CommonIAP
 import Foundation
 
 extension AppFeature {
-    public func individualProducts(for platform: IAPManager.Platform) -> [AppProduct] {
+    public func individualProducts(for platform: IAPManager.Platform) -> Set<AppProduct> {
         if isEssential {
-            var list = [AppProduct.Essentials.iOS_macOS]
+            var list: Set<AppProduct> = [.Essentials.iOS_macOS]
             switch platform {
             case .iOS:
-                list.append(AppProduct.Essentials.iOS)
+                list.insert(.Essentials.iOS)
             case .macOS:
-                list.append(AppProduct.Essentials.macOS)
+                list.insert(.Essentials.macOS)
             case .tvOS:
                 break
             }

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -35,6 +35,8 @@ extension AppFeature {
                 list.append(AppProduct.Essentials.iOS)
             case .macOS:
                 list.append(AppProduct.Essentials.macOS)
+            case .tvOS:
+                break
             }
             return list
         }

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -35,7 +35,7 @@ extension AppFeature {
         case .appleTV:
             return [.Features.appleTV]
         default:
-            assert(isEssential, "Non-essential feature \(rawValue) must be purchasable individually")
+            assert(isEssential, "Non-essential feature \(rawValue) must suggest a purchasable product")
             return []
         }
     }

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -1,8 +1,8 @@
 //
-//  AppFeature.swift
+//  AppFeature+Suggestions.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 9/10/24.
+//  Created by Davide De Rosa on 6/11/25.
 //  Copyright (c) 2025 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -23,50 +23,27 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import CommonIAP
 import Foundation
 
-public enum AppFeature: String, CaseIterable {
-    case appleTV
-
-    case dns
-
-    case httpProxy
-
-    case onDemand
-
-    case otp
-
-    case providers
-
-    case routing
-
-    case sharing
-}
-
 extension AppFeature {
-    public static let essentialFeatures: [AppFeature] = [
-        .dns,
-        .httpProxy,
-        .onDemand,
-        .otp,
-        .providers,
-        .routing,
-        .sharing
-    ]
-
-    public var isEssential: Bool {
-        Self.essentialFeatures.contains(self)
-    }
-}
-
-extension AppFeature: Identifiable {
-    public var id: String {
-        rawValue
-    }
-}
-
-extension AppFeature: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        rawValue
+    public func individualProducts(for platform: IAPManager.Platform) -> [AppProduct] {
+        if isEssential {
+            var list = [AppProduct.Essentials.iOS_macOS]
+            switch platform {
+            case .iOS:
+                list.append(AppProduct.Essentials.iOS)
+            case .macOS:
+                list.append(AppProduct.Essentials.macOS)
+            }
+            return list
+        }
+        switch self {
+        case .appleTV:
+            return [.Features.appleTV]
+        default:
+            assertionFailure("Feature \(rawValue) is outdated or not purchasable individually")
+            return []
+        }
     }
 }

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeature+Suggestions.swift
@@ -27,18 +27,9 @@ import CommonIAP
 import Foundation
 
 extension AppFeature {
-    public func individualProducts(on platform: IAPManager.Platform) -> Set<AppProduct> {
-        if isEssential {
-            var list: Set<AppProduct> = [.Essentials.iOS_macOS]
-            switch platform {
-            case .iOS:
-                list.insert(.Essentials.iOS)
-            case .macOS:
-                list.insert(.Essentials.macOS)
-            case .tvOS:
-                break
-            }
-            return list
+    public var nonEssentialProducts: Set<AppProduct> {
+        guard !isEssential else {
+            return []
         }
         switch self {
         case .appleTV:

--- a/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/AppFeatureProviding+Products.swift
@@ -32,7 +32,7 @@ extension AppProduct: AppFeatureProviding {
         // MARK: Current
 
         case .Essentials.iOS_macOS:
-            return AppFeature.essentialFeatures
+            return Array(AppFeature.essentialFeatures)
 
         case .Essentials.iOS:
 #if os(iOS) || os(tvOS)

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -111,18 +111,20 @@ extension IAPManager {
                 if !purchasedProducts.contains(.Essentials.macOS) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
-                if filters.contains(.singlePlatformEssentials) && !purchasedProducts.contains(.Essentials.iOS) {
+                let suggestsSinglePlatform = filters.contains(.singlePlatformEssentials) || purchasedProducts.contains(.Essentials.macOS)
+                if suggestsSinglePlatform && !purchasedProducts.contains(.Essentials.iOS) {
                     suggested.insert(.Essentials.iOS)
                 }
             case .macOS:
                 if !purchasedProducts.contains(.Essentials.iOS) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
-                if filters.contains(.singlePlatformEssentials) && !purchasedProducts.contains(.Essentials.macOS) {
+                let suggestsSinglePlatform = filters.contains(.singlePlatformEssentials) || purchasedProducts.contains(.Essentials.iOS)
+                if suggestsSinglePlatform && !purchasedProducts.contains(.Essentials.macOS) {
                     suggested.insert(.Essentials.macOS)
                 }
             case .tvOS:
-                if !purchasedProducts.contains(.Essentials.iOS_macOS) {
+                if !purchasedProducts.contains(where: \.isEssentials) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
             }

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -80,21 +80,15 @@ extension IAPManager {
         suggested.formUnion(nonEssentialProducts)
         let nonEssentialEligibleFeatures = nonEssentialProducts.flatMap(\.features)
 
-        // did purchase essentials for this platform?
-        let didPurchaseEssentials = {
-            switch platform {
-            case .iOS:
-                return purchasedProducts.contains(.Essentials.iOS) || purchasedProducts.contains(.Essentials.iOS_macOS)
-            case .macOS:
-                return purchasedProducts.contains(.Essentials.macOS) || purchasedProducts.contains(.Essentials.iOS_macOS)
-            case .tvOS:
-                return purchasedProducts.contains(where: \.isEssentials)
-            }
-        }()
-
-        // suggest essential packages if non-essential don't include required essential features
+        //
+        // suggest essential packages if:
+        //
+        // - never purchased any
+        // - non-essential eligible features don't include required essential features
+        //
         let essentialFeatures = features.filter(\.isEssential)
-        if !didPurchaseEssentials && !nonEssentialEligibleFeatures.contains(essentialFeatures) {
+        if !didPurchaseEssentials(on: platform) &&
+            !nonEssentialEligibleFeatures.contains(essentialFeatures) {
             switch platform {
             case .iOS:
                 // suggest both platforms if never purchased
@@ -151,6 +145,17 @@ extension IAPManager {
         suggested.subtract(purchasedProducts)
 
         return suggested
+    }
+
+    func didPurchaseEssentials(on platform: Platform) -> Bool {
+        switch platform {
+        case .iOS:
+            return purchasedProducts.contains(.Essentials.iOS) || purchasedProducts.contains(.Essentials.iOS_macOS)
+        case .macOS:
+            return purchasedProducts.contains(.Essentials.macOS) || purchasedProducts.contains(.Essentials.iOS_macOS)
+        case .tvOS:
+            return purchasedProducts.contains(where: \.isEssentials)
+        }
     }
 }
 

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -81,7 +81,7 @@ extension IAPManager {
 
         // prioritize non-essential products
         let nonEssentialProducts = nonEssential.reduce(into: Set<AppProduct>()) { group, element in
-            element.individualProducts(for: platform).forEach {
+            element.individualProducts(on: platform).forEach {
                 group.insert($0)
             }
         }

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -42,6 +42,7 @@ extension IAPManager {
 #elseif os(macOS)
         suggestedProducts(for: .macOS, filter: filter)
 #elseif os(tvOS)
+        // FIXME: ###, TV paywall
         fatalError("tvOS: Do not suggest products, paywall unsupported")
 #endif
     }

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -28,6 +28,12 @@ import CommonUtils
 import Foundation
 
 extension IAPManager {
+    public enum Platform {
+        case iOS
+
+        case macOS
+    }
+
     public enum SuggestionFilter {
         case complete
     }
@@ -46,12 +52,6 @@ extension IAPManager {
 
 // for testing
 extension IAPManager {
-    enum Platform {
-        case iOS
-
-        case macOS
-    }
-
     func suggestedProducts(
         for platform: Platform,
         filters: Set<SuggestionFilter>,

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -36,7 +36,7 @@ extension IAPManager {
         case tvOS
     }
 
-    public enum SuggestionFilter {
+    public enum SuggestionInclusion {
         case complete
 
         case singlePlatformEssentials
@@ -44,14 +44,14 @@ extension IAPManager {
 
     public func suggestedProducts(
         for features: Set<AppFeature>,
-        filters: Set<SuggestionFilter> = [.complete]
+        including: Set<SuggestionInclusion> = [.complete]
     ) -> Set<AppProduct> {
 #if os(iOS)
-        suggestedProducts(for: features, on: .iOS, filters: filters)
+        suggestedProducts(for: features, on: .iOS, including: including)
 #elseif os(macOS)
-        suggestedProducts(for: features, on: .macOS, filters: filters)
+        suggestedProducts(for: features, on: .macOS, including: including)
 #elseif os(tvOS)
-        suggestedProducts(for: features, on: .tvOS, filters: filters)
+        suggestedProducts(for: features, on: .tvOS, including: including)
 #endif
     }
 }
@@ -63,7 +63,7 @@ extension IAPManager {
     func suggestedProducts(
         for features: Set<AppFeature>,
         on platform: Platform,
-        filters: Set<SuggestionFilter>,
+        including: Set<SuggestionInclusion>,
         asserting: Bool = false
     ) -> Set<AppProduct> {
         guard !purchasedProducts.contains(where: \.isComplete) else {
@@ -111,7 +111,7 @@ extension IAPManager {
                 if !purchasedProducts.contains(.Essentials.macOS) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
-                let suggestsSinglePlatform = filters.contains(.singlePlatformEssentials) || purchasedProducts.contains(.Essentials.macOS)
+                let suggestsSinglePlatform = including.contains(.singlePlatformEssentials) || purchasedProducts.contains(.Essentials.macOS)
                 if suggestsSinglePlatform && !purchasedProducts.contains(.Essentials.iOS) {
                     suggested.insert(.Essentials.iOS)
                 }
@@ -119,7 +119,7 @@ extension IAPManager {
                 if !purchasedProducts.contains(.Essentials.iOS) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
-                let suggestsSinglePlatform = filters.contains(.singlePlatformEssentials) || purchasedProducts.contains(.Essentials.iOS)
+                let suggestsSinglePlatform = including.contains(.singlePlatformEssentials) || purchasedProducts.contains(.Essentials.iOS)
                 if suggestsSinglePlatform && !purchasedProducts.contains(.Essentials.macOS) {
                     suggested.insert(.Essentials.macOS)
                 }
@@ -146,7 +146,7 @@ extension IAPManager {
         }
 
         // suggest complete packages if eligible
-        if filters.contains(.complete) && suggestsComplete && purchasedProducts.isEligibleForComplete {
+        if including.contains(.complete) && suggestsComplete && purchasedProducts.isEligibleForComplete {
             suggested.insert(.Complete.Recurring.yearly)
             suggested.insert(.Complete.Recurring.monthly)
             suggested.insert(.Complete.OneTime.lifetime)

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -38,6 +38,8 @@ extension IAPManager {
 
     public enum SuggestionFilter {
         case complete
+
+        case singlePlatformEssentials
     }
 
     public func suggestedProducts(
@@ -109,14 +111,14 @@ extension IAPManager {
                 if !purchasedProducts.contains(.Essentials.macOS) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
-                if !purchasedProducts.contains(.Essentials.iOS) {
+                if filters.contains(.singlePlatformEssentials) && !purchasedProducts.contains(.Essentials.iOS) {
                     suggested.insert(.Essentials.iOS)
                 }
             case .macOS:
                 if !purchasedProducts.contains(.Essentials.iOS) {
                     suggested.insert(.Essentials.iOS_macOS)
                 }
-                if !purchasedProducts.contains(.Essentials.macOS) {
+                if filters.contains(.singlePlatformEssentials) && !purchasedProducts.contains(.Essentials.macOS) {
                     suggested.insert(.Essentials.macOS)
                 }
             case .tvOS:

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Suggestions.swift
@@ -130,8 +130,23 @@ extension IAPManager {
             }
         }
 
+        let suggestsComplete: Bool
+        switch platform {
+        case .tvOS:
+            //
+            // "essential" features are not accessible from the
+            // TV, therefore selling the "complete" packages is misleading
+            // for TV-only customers. only offer them if some "essential"
+            // feature is required, because it means that the iOS/macOS app
+            // is also installed
+            //
+            suggestsComplete = !essential.isEmpty
+        default:
+            suggestsComplete = true
+        }
+
         // suggest complete packages if eligible
-        if filters.contains(.complete) && purchasedProducts.isEligibleForComplete {
+        if filters.contains(.complete) && suggestsComplete && purchasedProducts.isEligibleForComplete {
             suggested.insert(.Complete.Recurring.yearly)
             suggested.insert(.Complete.Recurring.monthly)
             suggested.insert(.Complete.OneTime.lifetime)

--- a/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
+++ b/Packages/App/Sources/CommonLibrary/IAP/IAPManager+Verify.swift
@@ -37,7 +37,7 @@ extension IAPManager {
     public func verify(_ features: Set<AppFeature>) throws {
 #if os(tvOS)
         guard isEligible(for: .appleTV) else {
-            throw AppError.ineligibleProfile([.appleTV])
+            throw AppError.ineligibleProfile(features.union([.appleTV]))
         }
 #endif
         let requiredFeatures = features.filter {

--- a/Packages/App/Sources/CommonUtils/Views/View+Extensions.swift
+++ b/Packages/App/Sources/CommonUtils/Views/View+Extensions.swift
@@ -26,6 +26,10 @@
 import SwiftUI
 
 extension View {
+    public var isPreview: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
     public func debugChanges(condition: Bool = false) {
         if condition {
             Self._printChanges()

--- a/Packages/App/Sources/StringsLibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/de.lproj/Localizable.strings
@@ -275,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Diese Produkte enthalten aktuelle und zukünftige Funktionen.";
 "views.paywall.sections.full_products.header" = "Alle Funktionen";
 "views.paywall.sections.products.footer" = "Alle Käufe unterstützen die Familienfreigabe.";
-"views.paywall.sections.products.header" = "Empfohlene Produkte";
+"views.paywall.sections.products.header" = "Einzeln kaufen";
 "views.paywall.sections.required_features.header" = "Erforderliche Funktionen";
 "views.paywall.sections.restore.footer" = "Wenn Sie in der Vergangenheit Einkäufe getätigt haben, können Sie sie hier wiederherstellen.";
 "views.paywall.sections.restore.header" = "Wiederherstellen";

--- a/Packages/App/Sources/StringsLibrary/Resources/de.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/de.lproj/Localizable.strings
@@ -259,9 +259,8 @@
 "views.migration.no_profiles" = "Nichts zu migrieren";
 "views.migration.sections.main.header" = "Wähle unten die Profile aus alten Versionen von %@ aus, die du importieren möchtest. Wenn deine Profile in iCloud gespeichert sind, kann es eine Weile dauern, bis sie synchronisiert sind. Wenn du sie jetzt nicht siehst, komm später zurück.";
 "views.migration.title" = "Migrieren";
-"views.paywall.alerts.confirmation.edit_profile" = "Profil bearbeiten";
+"views.paywall.alerts.actions.save" = "Trotzdem speichern";
 "views.paywall.alerts.confirmation.message.connect" = "Sie können die Verbindung für %d Minuten testen.";
-"views.paywall.alerts.confirmation.message.save" = "Tippen Sie auf die Schlosssymbole, um die fehlenden Funktionen zu kaufen.";
 "views.paywall.alerts.confirmation.message" = "Dieses Profil erfordert kostenpflichtige Funktionen, um zu funktionieren.";
 "views.paywall.alerts.confirmation.title" = "Kauf erforderlich";
 "views.paywall.alerts.pending.message" = "Der Kauf wartet auf eine externe Bestätigung. Die Funktion wird nach Genehmigung gutgeschrieben.";
@@ -295,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Zeigt das aktive Profil auch oben für schnellen Zugriff an.";
 "views.preferences.pins_active_profile" = "Aktives Profil anheften";
 "views.preferences.system_appearance" = "Erscheinungsbild";
-"views.profile.alerts.purchase.buttons.ok" = "Trotzdem speichern";
 "views.profile.module_list.section.footer" = "Tippen Sie auf Module, um ihre Einstellungen zu bearbeiten. Module können gezogen werden, um die Priorität festzulegen.";
 "views.profile.rows.add_module" = "Modul hinzufügen";
 "views.profile.rows.delete_profile" = "Profil löschen";

--- a/Packages/App/Sources/StringsLibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/el.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Δεν υπάρχει τίποτα για μεταφορά";
 "views.migration.sections.main.header" = "Επιλέξτε παρακάτω τα προφίλ από τις παλιές εκδόσεις του %@ που θέλετε να εισάγετε. Εάν τα προφίλ σας είναι αποθηκευμένα στο iCloud, μπορεί να χρειαστεί λίγος χρόνος για να συγχρονιστούν. Εάν δεν τα βλέπετε τώρα, επιστρέψτε αργότερα.";
 "views.migration.title" = "Μεταφορά";
-"views.paywall.alerts.confirmation.edit_profile" = "Επεξεργασία προφίλ";
 "views.paywall.alerts.confirmation.message.connect" = "Μπορείτε να δοκιμάσετε τη σύνδεση για %d λεπτά.";
-"views.paywall.alerts.confirmation.message.save" = "Πατήστε στα εικονίδια κλειδώματος για να αγοράσετε τις ελλείπουσες λειτουργίες.";
 "views.paywall.alerts.confirmation.message" = "Αυτό το προφίλ απαιτεί επί πληρωμή λειτουργίες για να λειτουργήσει.";
 "views.paywall.alerts.confirmation.title" = "Απαιτείται αγορά";
 "views.paywall.alerts.pending.message" = "Η αγορά εκκρεμεί για εξωτερική επιβεβαίωση. Η λειτουργία θα πιστωθεί μετά την έγκριση.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Εμφανίζει επίσης το ενεργό προφίλ στην κορυφή για γρήγορη πρόσβαση.";
 "views.preferences.pins_active_profile" = "Καρφίτσωμα ενεργού προφίλ";
 "views.preferences.system_appearance" = "Εμφάνιση";
-"views.profile.alerts.purchase.buttons.ok" = "Αποθήκευση ούτως ή άλλως";
+"views.paywall.alerts.actions.save" = "Αποθήκευση ούτως ή άλλως";
 "views.profile.module_list.section.footer" = "Πατήστε σε ένα module για να επεξεργαστείτε τις ρυθμίσεις του. Τα modules μπορούν να μετακινηθούν για να καθορίσετε την προτεραιότητά τους.";
 "views.profile.rows.add_module" = "Προσθήκη μονάδας";
 "views.profile.rows.delete_profile" = "Διαγραφή προφίλ";

--- a/Packages/App/Sources/StringsLibrary/Resources/el.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/el.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Δεν υπάρχει τίποτα για μεταφορά";
 "views.migration.sections.main.header" = "Επιλέξτε παρακάτω τα προφίλ από τις παλιές εκδόσεις του %@ που θέλετε να εισάγετε. Εάν τα προφίλ σας είναι αποθηκευμένα στο iCloud, μπορεί να χρειαστεί λίγος χρόνος για να συγχρονιστούν. Εάν δεν τα βλέπετε τώρα, επιστρέψτε αργότερα.";
 "views.migration.title" = "Μεταφορά";
+"views.paywall.alerts.actions.save" = "Αποθήκευση ούτως ή άλλως";
 "views.paywall.alerts.confirmation.message.connect" = "Μπορείτε να δοκιμάσετε τη σύνδεση για %d λεπτά.";
 "views.paywall.alerts.confirmation.message" = "Αυτό το προφίλ απαιτεί επί πληρωμή λειτουργίες για να λειτουργήσει.";
 "views.paywall.alerts.confirmation.title" = "Απαιτείται αγορά";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Αυτά τα προϊόντα περιλαμβάνουν τρέχουσες και μελλοντικές δυνατότητες.";
 "views.paywall.sections.full_products.header" = "Όλες οι λειτουργίες";
 "views.paywall.sections.products.footer" = "Όλες οι αγορές υποστηρίζουν την Οικογενειακή Κοινή Χρήση.";
-"views.paywall.sections.products.header" = "Προτεινόμενα προϊόντα";
+"views.paywall.sections.products.header" = "Αγορά μεμονωμένα";
 "views.paywall.sections.required_features.header" = "Απαιτούμενες λειτουργίες";
 "views.paywall.sections.restore.footer" = "Αν έχετε πραγματοποιήσει αγορές στο παρελθόν, μπορείτε να τις επαναφέρετε εδώ.";
 "views.paywall.sections.restore.header" = "Επαναφορά";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Εμφανίζει επίσης το ενεργό προφίλ στην κορυφή για γρήγορη πρόσβαση.";
 "views.preferences.pins_active_profile" = "Καρφίτσωμα ενεργού προφίλ";
 "views.preferences.system_appearance" = "Εμφάνιση";
-"views.paywall.alerts.actions.save" = "Αποθήκευση ούτως ή άλλως";
 "views.profile.module_list.section.footer" = "Πατήστε σε ένα module για να επεξεργαστείτε τις ρυθμίσεις του. Τα modules μπορούν να μετακινηθούν για να καθορίσετε την προτεραιότητά τους.";
 "views.profile.rows.add_module" = "Προσθήκη μονάδας";
 "views.profile.rows.delete_profile" = "Διαγραφή προφίλ";

--- a/Packages/App/Sources/StringsLibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/en.lproj/Localizable.strings
@@ -93,8 +93,9 @@
 "views.paywall.alerts.confirmation.title" = "Purchase required";
 "views.paywall.alerts.confirmation.message" = "This profile requires paid features to work.";
 "views.paywall.alerts.confirmation.message.connect" = "You may test the connection for %d minutes.";
-"views.paywall.alerts.confirmation.message.save" = "Tap the lock icons to purchase the missing features.";
-"views.paywall.alerts.confirmation.edit_profile" = "Edit profile";
+//"views.paywall.alerts.actions.connect" = "Test connection";
+//"views.paywall.alerts.actions.purchase" = "Purchase";
+"views.paywall.alerts.actions.save" = "Save anyway";
 "views.paywall.alerts.verification.connect.1" = "Your purchases are being verified.";
 "views.paywall.alerts.verification.connect.2" = "If verification cannot be completed, the connection will end in %d minutes.";
 "views.paywall.alerts.verification.edit" = "Please wait while your purchases are being verified.";
@@ -127,7 +128,6 @@
 "views.profile.send_tv.form.message" = "Match the URL found in '%@ > %@' on your %@, making sure to be on the same network.";
 "views.profile.send_tv.qr.message" = "Scan the QR found in '%@ > %@' on your %@, making sure to be on the same network";
 "views.profile.send_tv.passcode.message" = "Enter the passcode";
-"views.profile.alerts.purchase.buttons.ok" = "Save anyway";
 
 "views.providers.module" = "Type";
 "views.providers.preset" = "Preset";

--- a/Packages/App/Sources/StringsLibrary/Resources/en.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/en.lproj/Localizable.strings
@@ -82,7 +82,7 @@
 "views.migration.alerts.delete.message" = "Do you want to discard these profiles? You will not be able to recover them later.\n\n%@";
 
 "views.paywall.sections.required_features.header" = "Required features";
-"views.paywall.sections.products.header" = "Suggested products";
+"views.paywall.sections.products.header" = "Purchase individually";
 "views.paywall.sections.products.footer" = "All purchases support Family Sharing.";
 "views.paywall.sections.full_products.header" = "All features";
 "views.paywall.sections.full_products.footer" = "These products include current and future features.";

--- a/Packages/App/Sources/StringsLibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/es.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Nada que migrar";
 "views.migration.sections.main.header" = "Selecciona a continuación los perfiles de versiones antiguas de %@ que deseas importar. Si tus perfiles están almacenados en iCloud, pueden tardar un poco en sincronizarse. Si no los ves ahora, por favor regresa más tarde.";
 "views.migration.title" = "Migrar";
-"views.paywall.alerts.confirmation.edit_profile" = "Editar perfil";
 "views.paywall.alerts.confirmation.message.connect" = "Puedes probar la conexión durante %d minutos.";
-"views.paywall.alerts.confirmation.message.save" = "Toca los iconos de candado para comprar las funciones faltantes.";
 "views.paywall.alerts.confirmation.message" = "Este perfil requiere características de pago para funcionar.";
 "views.paywall.alerts.confirmation.title" = "Compra requerida";
 "views.paywall.alerts.pending.message" = "La compra está pendiente de confirmación externa. La característica será acreditada tras la aprobación.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "También muestra el perfil activo en la parte superior para un acceso rápido.";
 "views.preferences.pins_active_profile" = "Fijar perfil activo";
 "views.preferences.system_appearance" = "Apariencia";
-"views.profile.alerts.purchase.buttons.ok" = "Guardar de todos modos";
+"views.paywall.alerts.actions.save" = "Guardar de todos modos";
 "views.profile.module_list.section.footer" = "Toca los módulos para editar su configuración. Se pueden arrastrar para establecer la prioridad.";
 "views.profile.rows.add_module" = "Añadir módulo";
 "views.profile.rows.delete_profile" = "Eliminar perfil";

--- a/Packages/App/Sources/StringsLibrary/Resources/es.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/es.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Nada que migrar";
 "views.migration.sections.main.header" = "Selecciona a continuación los perfiles de versiones antiguas de %@ que deseas importar. Si tus perfiles están almacenados en iCloud, pueden tardar un poco en sincronizarse. Si no los ves ahora, por favor regresa más tarde.";
 "views.migration.title" = "Migrar";
+"views.paywall.alerts.actions.save" = "Guardar de todos modos";
 "views.paywall.alerts.confirmation.message.connect" = "Puedes probar la conexión durante %d minutos.";
 "views.paywall.alerts.confirmation.message" = "Este perfil requiere características de pago para funcionar.";
 "views.paywall.alerts.confirmation.title" = "Compra requerida";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Estos productos incluyen características actuales y futuras.";
 "views.paywall.sections.full_products.header" = "Todas las funciones";
 "views.paywall.sections.products.footer" = "Todas las compras admiten En Familia.";
-"views.paywall.sections.products.header" = "Productos sugeridos";
+"views.paywall.sections.products.header" = "Comprar por separado";
 "views.paywall.sections.required_features.header" = "Características requeridas";
 "views.paywall.sections.restore.footer" = "Si has realizado compras en el pasado, puedes restaurarlas aquí.";
 "views.paywall.sections.restore.header" = "Restaurar";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "También muestra el perfil activo en la parte superior para un acceso rápido.";
 "views.preferences.pins_active_profile" = "Fijar perfil activo";
 "views.preferences.system_appearance" = "Apariencia";
-"views.paywall.alerts.actions.save" = "Guardar de todos modos";
 "views.profile.module_list.section.footer" = "Toca los módulos para editar su configuración. Se pueden arrastrar para establecer la prioridad.";
 "views.profile.rows.add_module" = "Añadir módulo";
 "views.profile.rows.delete_profile" = "Eliminar perfil";

--- a/Packages/App/Sources/StringsLibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/fr.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Rien à migrer";
 "views.migration.sections.main.header" = "Sélectionnez ci-dessous les profils des anciennes versions de %@ que vous souhaitez importer. Si vos profils sont stockés sur iCloud, ils peuvent mettre un certain temps à se synchroniser. Si vous ne les voyez pas maintenant, revenez plus tard.";
 "views.migration.title" = "Migrer";
+"views.paywall.alerts.actions.save" = "Enregistrer quand même";
 "views.paywall.alerts.confirmation.message.connect" = "Vous pouvez tester la connexion pendant %d minutes.";
 "views.paywall.alerts.confirmation.message" = "Ce profil nécessite des fonctionnalités payantes pour fonctionner.";
 "views.paywall.alerts.confirmation.title" = "Achat requis";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Ces produits incluent les fonctionnalités actuelles et futures.";
 "views.paywall.sections.full_products.header" = "Toutes les fonctionnalités";
 "views.paywall.sections.products.footer" = "Tous les achats prennent en charge le Partage familial.";
-"views.paywall.sections.products.header" = "Produits suggérés";
+"views.paywall.sections.products.header" = "Acheter individuellement";
 "views.paywall.sections.required_features.header" = "Fonctionnalités requises";
 "views.paywall.sections.restore.footer" = "Si vous avez effectué des achats par le passé, vous pouvez les restaurer ici.";
 "views.paywall.sections.restore.header" = "Restaurer";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Affiche également le profil actif en haut pour un accès rapide.";
 "views.preferences.pins_active_profile" = "Épingler le profil actif";
 "views.preferences.system_appearance" = "Apparence";
-"views.paywall.alerts.actions.save" = "Enregistrer quand même";
 "views.profile.module_list.section.footer" = "Touchez les modules pour modifier leurs paramètres. Ils peuvent être glissés pour définir leur priorité.";
 "views.profile.rows.add_module" = "Ajouter un module";
 "views.profile.rows.delete_profile" = "Supprimer le profil";

--- a/Packages/App/Sources/StringsLibrary/Resources/fr.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/fr.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Rien à migrer";
 "views.migration.sections.main.header" = "Sélectionnez ci-dessous les profils des anciennes versions de %@ que vous souhaitez importer. Si vos profils sont stockés sur iCloud, ils peuvent mettre un certain temps à se synchroniser. Si vous ne les voyez pas maintenant, revenez plus tard.";
 "views.migration.title" = "Migrer";
-"views.paywall.alerts.confirmation.edit_profile" = "Modifier le profil";
 "views.paywall.alerts.confirmation.message.connect" = "Vous pouvez tester la connexion pendant %d minutes.";
-"views.paywall.alerts.confirmation.message.save" = "Touchez les icônes de cadenas pour acheter les fonctionnalités manquantes.";
 "views.paywall.alerts.confirmation.message" = "Ce profil nécessite des fonctionnalités payantes pour fonctionner.";
 "views.paywall.alerts.confirmation.title" = "Achat requis";
 "views.paywall.alerts.pending.message" = "L'achat est en attente de confirmation externe. La fonctionnalité sera créditée une fois approuvée.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Affiche également le profil actif en haut pour un accès rapide.";
 "views.preferences.pins_active_profile" = "Épingler le profil actif";
 "views.preferences.system_appearance" = "Apparence";
-"views.profile.alerts.purchase.buttons.ok" = "Enregistrer quand même";
+"views.paywall.alerts.actions.save" = "Enregistrer quand même";
 "views.profile.module_list.section.footer" = "Touchez les modules pour modifier leurs paramètres. Ils peuvent être glissés pour définir leur priorité.";
 "views.profile.rows.add_module" = "Ajouter un module";
 "views.profile.rows.delete_profile" = "Supprimer le profil";

--- a/Packages/App/Sources/StringsLibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/it.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Niente da migrare";
 "views.migration.sections.main.header" = "Seleziona di seguito i profili dalle versioni precedenti di %@ che vuoi importare. Se i tuoi profili sono archiviati su iCloud, potrebbero impiegare un po' a sincronizzarsi. Se non li vedi ora, torna più tardi.";
 "views.migration.title" = "Migra";
-"views.paywall.alerts.confirmation.edit_profile" = "Modifica profilo";
 "views.paywall.alerts.confirmation.message.connect" = "Puoi provare la connessione per %d minuti.";
-"views.paywall.alerts.confirmation.message.save" = "Tocca le icone del lucchetto per acquistare le funzionalità mancanti.";
 "views.paywall.alerts.confirmation.message" = "Questo profilo richiede funzionalità a pagamento per funzionare.";
 "views.paywall.alerts.confirmation.title" = "Acquisto richiesto";
 "views.paywall.alerts.pending.message" = "L'acquisto è in attesa di conferma esterna. La funzionalità verrà accreditata dopo l'approvazione.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Mostra anche il profilo attivo in cima per un accesso rapido.";
 "views.preferences.pins_active_profile" = "Fissa profilo attivo";
 "views.preferences.system_appearance" = "Aspetto";
-"views.profile.alerts.purchase.buttons.ok" = "Salva comunque";
+"views.paywall.alerts.actions.save" = "Salva comunque";
 "views.profile.module_list.section.footer" = "Tocca i moduli per modificarne le impostazioni. Possono essere trascinati per determinare la priorità.";
 "views.profile.rows.add_module" = "Aggiungi modulo";
 "views.profile.rows.delete_profile" = "Elimina profilo";

--- a/Packages/App/Sources/StringsLibrary/Resources/it.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/it.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Niente da migrare";
 "views.migration.sections.main.header" = "Seleziona di seguito i profili dalle versioni precedenti di %@ che vuoi importare. Se i tuoi profili sono archiviati su iCloud, potrebbero impiegare un po' a sincronizzarsi. Se non li vedi ora, torna più tardi.";
 "views.migration.title" = "Migra";
+"views.paywall.alerts.actions.save" = "Salva comunque";
 "views.paywall.alerts.confirmation.message.connect" = "Puoi provare la connessione per %d minuti.";
 "views.paywall.alerts.confirmation.message" = "Questo profilo richiede funzionalità a pagamento per funzionare.";
 "views.paywall.alerts.confirmation.title" = "Acquisto richiesto";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Questi prodotti includono funzionalità attuali e future.";
 "views.paywall.sections.full_products.header" = "Tutte le funzionalità";
 "views.paywall.sections.products.footer" = "Tutti gli acquisti supportano “In famiglia”.";
-"views.paywall.sections.products.header" = "Prodotti suggeriti";
+"views.paywall.sections.products.header" = "Acquista singolarmente";
 "views.paywall.sections.required_features.header" = "Funzionalità richieste";
 "views.paywall.sections.restore.footer" = "Se hai effettuato acquisti in passato, puoi ripristinarli qui.";
 "views.paywall.sections.restore.header" = "Ripristina";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Mostra anche il profilo attivo in cima per un accesso rapido.";
 "views.preferences.pins_active_profile" = "Fissa profilo attivo";
 "views.preferences.system_appearance" = "Aspetto";
-"views.paywall.alerts.actions.save" = "Salva comunque";
 "views.profile.module_list.section.footer" = "Tocca i moduli per modificarne le impostazioni. Possono essere trascinati per determinare la priorità.";
 "views.profile.rows.add_module" = "Aggiungi modulo";
 "views.profile.rows.delete_profile" = "Elimina profilo";

--- a/Packages/App/Sources/StringsLibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/nl.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Niets om te migreren";
 "views.migration.sections.main.header" = "Selecteer hieronder de profielen van oudere versies van %@ die je wilt importeren. Als je profielen zijn opgeslagen in iCloud, kan het even duren voordat ze worden gesynchroniseerd. Als je ze nu niet ziet, kom dan later terug.";
 "views.migration.title" = "Migreren";
+"views.paywall.alerts.actions.save" = "Toch opslaan";
 "views.paywall.alerts.confirmation.message.connect" = "Je kunt de verbinding %d minuten testen.";
 "views.paywall.alerts.confirmation.message" = "Dit profiel vereist betaalde functies om te werken.";
 "views.paywall.alerts.confirmation.title" = "Aankoop vereist";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Deze producten bevatten huidige en toekomstige functies.";
 "views.paywall.sections.full_products.header" = "Alle functies";
 "views.paywall.sections.products.footer" = "Alle aankopen ondersteunen Delen met gezin.";
-"views.paywall.sections.products.header" = "Voorgestelde producten";
+"views.paywall.sections.products.header" = "Individueel kopen";
 "views.paywall.sections.required_features.header" = "Vereiste functies";
 "views.paywall.sections.restore.footer" = "Als je eerder aankopen hebt gedaan, kun je ze hier herstellen.";
 "views.paywall.sections.restore.header" = "Herstellen";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Toont ook het actieve profiel bovenaan voor snelle toegang.";
 "views.preferences.pins_active_profile" = "Actief profiel vastzetten";
 "views.preferences.system_appearance" = "Uiterlijk";
-"views.paywall.alerts.actions.save" = "Toch opslaan";
 "views.profile.module_list.section.footer" = "Tik op modules om hun instellingen te bewerken. Modules kunnen worden versleept om de prioriteit te bepalen.";
 "views.profile.rows.add_module" = "Module toevoegen";
 "views.profile.rows.delete_profile" = "Verwijder profiel";

--- a/Packages/App/Sources/StringsLibrary/Resources/nl.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/nl.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Niets om te migreren";
 "views.migration.sections.main.header" = "Selecteer hieronder de profielen van oudere versies van %@ die je wilt importeren. Als je profielen zijn opgeslagen in iCloud, kan het even duren voordat ze worden gesynchroniseerd. Als je ze nu niet ziet, kom dan later terug.";
 "views.migration.title" = "Migreren";
-"views.paywall.alerts.confirmation.edit_profile" = "Profiel bewerken";
 "views.paywall.alerts.confirmation.message.connect" = "Je kunt de verbinding %d minuten testen.";
-"views.paywall.alerts.confirmation.message.save" = "Tik op de slotpictogrammen om de ontbrekende functies te kopen.";
 "views.paywall.alerts.confirmation.message" = "Dit profiel vereist betaalde functies om te werken.";
 "views.paywall.alerts.confirmation.title" = "Aankoop vereist";
 "views.paywall.alerts.pending.message" = "De aankoop wacht op externe bevestiging. De functie wordt na goedkeuring gecrediteerd.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Toont ook het actieve profiel bovenaan voor snelle toegang.";
 "views.preferences.pins_active_profile" = "Actief profiel vastzetten";
 "views.preferences.system_appearance" = "Uiterlijk";
-"views.profile.alerts.purchase.buttons.ok" = "Toch opslaan";
+"views.paywall.alerts.actions.save" = "Toch opslaan";
 "views.profile.module_list.section.footer" = "Tik op modules om hun instellingen te bewerken. Modules kunnen worden versleept om de prioriteit te bepalen.";
 "views.profile.rows.add_module" = "Module toevoegen";
 "views.profile.rows.delete_profile" = "Verwijder profiel";

--- a/Packages/App/Sources/StringsLibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/pl.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Brak profili do migracji";
 "views.migration.sections.main.header" = "Wybierz poniżej profile ze starszych wersji %@, które chcesz zaimportować. Jeśli Twoje profile są przechowywane w iCloud, synchronizacja może zająć trochę czasu. Jeśli ich teraz nie widzisz, wróć później.";
 "views.migration.title" = "Migracja";
-"views.paywall.alerts.confirmation.edit_profile" = "Edytuj profil";
 "views.paywall.alerts.confirmation.message.connect" = "Możesz przetestować połączenie przez %d minut.";
-"views.paywall.alerts.confirmation.message.save" = "Stuknij ikony kłódki, aby kupić brakujące funkcje.";
 "views.paywall.alerts.confirmation.message" = "Ten profil wymaga płatnych funkcji do działania.";
 "views.paywall.alerts.confirmation.title" = "Wymagana zakup";
 "views.paywall.alerts.pending.message" = "Zakup oczekuje na zewnętrzne potwierdzenie. Funkcja zostanie przypisana po zatwierdzeniu.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Wyświetla także aktywny profil na górze dla szybkiego dostępu.";
 "views.preferences.pins_active_profile" = "Przypnij aktywny profil";
 "views.preferences.system_appearance" = "Wygląd";
-"views.profile.alerts.purchase.buttons.ok" = "Zapisz mimo to";
+"views.paywall.alerts.actions.save" = "Zapisz mimo to";
 "views.profile.module_list.section.footer" = "Stuknij moduły, aby edytować ich ustawienia. Można je przeciągnąć, aby ustalić priorytet.";
 "views.profile.rows.add_module" = "Dodaj moduł";
 "views.profile.rows.delete_profile" = "Usuń profil";

--- a/Packages/App/Sources/StringsLibrary/Resources/pl.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/pl.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Brak profili do migracji";
 "views.migration.sections.main.header" = "Wybierz poniżej profile ze starszych wersji %@, które chcesz zaimportować. Jeśli Twoje profile są przechowywane w iCloud, synchronizacja może zająć trochę czasu. Jeśli ich teraz nie widzisz, wróć później.";
 "views.migration.title" = "Migracja";
+"views.paywall.alerts.actions.save" = "Zapisz mimo to";
 "views.paywall.alerts.confirmation.message.connect" = "Możesz przetestować połączenie przez %d minut.";
 "views.paywall.alerts.confirmation.message" = "Ten profil wymaga płatnych funkcji do działania.";
 "views.paywall.alerts.confirmation.title" = "Wymagana zakup";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Te produkty zawierają obecne i przyszłe funkcje.";
 "views.paywall.sections.full_products.header" = "Wszystkie funkcje";
 "views.paywall.sections.products.footer" = "Wszystkie zakupy obsługują Chmurę rodzinną.";
-"views.paywall.sections.products.header" = "Sugerowane produkty";
+"views.paywall.sections.products.header" = "Kup osobno";
 "views.paywall.sections.required_features.header" = "Wymagane funkcje";
 "views.paywall.sections.restore.footer" = "Jeśli wcześniej dokonałeś zakupów, możesz je tutaj przywrócić.";
 "views.paywall.sections.restore.header" = "Przywróć";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Wyświetla także aktywny profil na górze dla szybkiego dostępu.";
 "views.preferences.pins_active_profile" = "Przypnij aktywny profil";
 "views.preferences.system_appearance" = "Wygląd";
-"views.paywall.alerts.actions.save" = "Zapisz mimo to";
 "views.profile.module_list.section.footer" = "Stuknij moduły, aby edytować ich ustawienia. Można je przeciągnąć, aby ustalić priorytet.";
 "views.profile.rows.add_module" = "Dodaj moduł";
 "views.profile.rows.delete_profile" = "Usuń profil";

--- a/Packages/App/Sources/StringsLibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/pt.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Nada para migrar";
 "views.migration.sections.main.header" = "Selecione abaixo os perfis de versões antigas de %@ que você deseja importar. Caso seus perfis estejam armazenados no iCloud, pode levar um tempo para sincronizá-los. Se não os vir agora, volte mais tarde.";
 "views.migration.title" = "Migrar";
-"views.paywall.alerts.confirmation.edit_profile" = "Editar perfil";
 "views.paywall.alerts.confirmation.message.connect" = "Você pode testar a conexão por %d minutos.";
-"views.paywall.alerts.confirmation.message.save" = "Toque nos ícones de cadeado para comprar os recursos ausentes.";
 "views.paywall.alerts.confirmation.message" = "Este perfil requer recursos pagos para funcionar.";
 "views.paywall.alerts.confirmation.title" = "Compra necessária";
 "views.paywall.alerts.pending.message" = "A compra está pendente de confirmação externa. O recurso será creditado após a aprovação.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Também exibe o perfil ativo no topo para acesso rápido.";
 "views.preferences.pins_active_profile" = "Fixar perfil ativo";
 "views.preferences.system_appearance" = "Aparência";
-"views.profile.alerts.purchase.buttons.ok" = "Salvar assim mesmo";
+"views.paywall.alerts.actions.save" = "Salvar assim mesmo";
 "views.profile.module_list.section.footer" = "Toque nos módulos para editar suas configurações. Eles podem ser arrastados para definir a prioridade.";
 "views.profile.rows.add_module" = "Adicionar módulo";
 "views.profile.rows.delete_profile" = "Excluir perfil";

--- a/Packages/App/Sources/StringsLibrary/Resources/pt.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/pt.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Nada para migrar";
 "views.migration.sections.main.header" = "Selecione abaixo os perfis de versões antigas de %@ que você deseja importar. Caso seus perfis estejam armazenados no iCloud, pode levar um tempo para sincronizá-los. Se não os vir agora, volte mais tarde.";
 "views.migration.title" = "Migrar";
+"views.paywall.alerts.actions.save" = "Salvar assim mesmo";
 "views.paywall.alerts.confirmation.message.connect" = "Você pode testar a conexão por %d minutos.";
 "views.paywall.alerts.confirmation.message" = "Este perfil requer recursos pagos para funcionar.";
 "views.paywall.alerts.confirmation.title" = "Compra necessária";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Estes produtos incluem recursos atuais e futuros.";
 "views.paywall.sections.full_products.header" = "Todos os recursos";
 "views.paywall.sections.products.footer" = "Todas as compras são compatíveis com Compartilhamento Familiar.";
-"views.paywall.sections.products.header" = "Produtos sugeridos";
+"views.paywall.sections.products.header" = "Comprar individualmente";
 "views.paywall.sections.required_features.header" = "Recursos necessários";
 "views.paywall.sections.restore.footer" = "Se você fez compras anteriormente, pode restaurá-las aqui.";
 "views.paywall.sections.restore.header" = "Restaurar";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Também exibe o perfil ativo no topo para acesso rápido.";
 "views.preferences.pins_active_profile" = "Fixar perfil ativo";
 "views.preferences.system_appearance" = "Aparência";
-"views.paywall.alerts.actions.save" = "Salvar assim mesmo";
 "views.profile.module_list.section.footer" = "Toque nos módulos para editar suas configurações. Eles podem ser arrastados para definir a prioridade.";
 "views.profile.rows.add_module" = "Adicionar módulo";
 "views.profile.rows.delete_profile" = "Excluir perfil";

--- a/Packages/App/Sources/StringsLibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/ru.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Нечего мигрировать";
 "views.migration.sections.main.header" = "Выберите ниже профили из старых версий %@, которые вы хотите импортировать. Если ваши профили хранятся в iCloud, синхронизация может занять некоторое время. Если вы их сейчас не видите, вернитесь позже.";
 "views.migration.title" = "Миграция";
-"views.paywall.alerts.confirmation.edit_profile" = "Редактировать профиль";
 "views.paywall.alerts.confirmation.message.connect" = "Вы можете протестировать подключение в течение %d минут.";
-"views.paywall.alerts.confirmation.message.save" = "Нажмите на значки замка, чтобы приобрести недостающие функции.";
 "views.paywall.alerts.confirmation.message" = "Этот профиль требует платных функций для работы.";
 "views.paywall.alerts.confirmation.title" = "Требуется покупка";
 "views.paywall.alerts.pending.message" = "Покупка ожидает внешнего подтверждения. Функция будет активирована после одобрения.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Также отображает активный профиль сверху для быстрого доступа.";
 "views.preferences.pins_active_profile" = "Закрепить активный профиль";
 "views.preferences.system_appearance" = "Внешний вид";
-"views.profile.alerts.purchase.buttons.ok" = "Сохранить в любом случае";
+"views.paywall.alerts.actions.save" = "Сохранить в любом случае";
 "views.profile.module_list.section.footer" = "Нажмите на модули, чтобы изменить их настройки. Их можно перетаскивать для установки приоритета.";
 "views.profile.rows.add_module" = "Добавить модуль";
 "views.profile.rows.delete_profile" = "Удалить профиль";

--- a/Packages/App/Sources/StringsLibrary/Resources/ru.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/ru.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Нечего мигрировать";
 "views.migration.sections.main.header" = "Выберите ниже профили из старых версий %@, которые вы хотите импортировать. Если ваши профили хранятся в iCloud, синхронизация может занять некоторое время. Если вы их сейчас не видите, вернитесь позже.";
 "views.migration.title" = "Миграция";
+"views.paywall.alerts.actions.save" = "Сохранить в любом случае";
 "views.paywall.alerts.confirmation.message.connect" = "Вы можете протестировать подключение в течение %d минут.";
 "views.paywall.alerts.confirmation.message" = "Этот профиль требует платных функций для работы.";
 "views.paywall.alerts.confirmation.title" = "Требуется покупка";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Эти продукты включают текущие и будущие функции.";
 "views.paywall.sections.full_products.header" = "Все функции";
 "views.paywall.sections.products.footer" = "Все покупки поддерживают Семейный доступ.";
-"views.paywall.sections.products.header" = "Рекомендуемые продукты";
+"views.paywall.sections.products.header" = "Купить отдельно";
 "views.paywall.sections.required_features.header" = "Необходимые функции";
 "views.paywall.sections.restore.footer" = "Если вы совершали покупки ранее, вы можете восстановить их здесь.";
 "views.paywall.sections.restore.header" = "Восстановить";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Также отображает активный профиль сверху для быстрого доступа.";
 "views.preferences.pins_active_profile" = "Закрепить активный профиль";
 "views.preferences.system_appearance" = "Внешний вид";
-"views.paywall.alerts.actions.save" = "Сохранить в любом случае";
 "views.profile.module_list.section.footer" = "Нажмите на модули, чтобы изменить их настройки. Их можно перетаскивать для установки приоритета.";
 "views.profile.rows.add_module" = "Добавить модуль";
 "views.profile.rows.delete_profile" = "Удалить профиль";

--- a/Packages/App/Sources/StringsLibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/sv.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Inget att migrera";
 "views.migration.sections.main.header" = "Välj nedan de profiler från äldre versioner av %@ som du vill importera. Om dina profiler är lagrade på iCloud kan det ta en stund att synkronisera. Om du inte ser dem nu, kom tillbaka senare.";
 "views.migration.title" = "Migrera";
-"views.paywall.alerts.confirmation.edit_profile" = "Redigera profil";
 "views.paywall.alerts.confirmation.message.connect" = "Du kan testa anslutningen i %d minuter.";
-"views.paywall.alerts.confirmation.message.save" = "Tryck på låsikonerna för att köpa de saknade funktionerna.";
 "views.paywall.alerts.confirmation.message" = "Den här profilen kräver betalda funktioner för att fungera.";
 "views.paywall.alerts.confirmation.title" = "Köp krävs";
 "views.paywall.alerts.pending.message" = "Köpet väntar på extern bekräftelse. Funktionen aktiveras efter godkännande.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Visar även den aktiva profilen överst för snabb åtkomst.";
 "views.preferences.pins_active_profile" = "Fäst aktiv profil";
 "views.preferences.system_appearance" = "Utseende";
-"views.profile.alerts.purchase.buttons.ok" = "Spara ändå";
+"views.paywall.alerts.actions.save" = "Spara ändå";
 "views.profile.module_list.section.footer" = "Tryck på moduler för att redigera inställningarna. Moduler kan dras för att bestämma prioritet.";
 "views.profile.rows.add_module" = "Lägg till modul";
 "views.profile.rows.delete_profile" = "Ta bort profil";

--- a/Packages/App/Sources/StringsLibrary/Resources/sv.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/sv.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Inget att migrera";
 "views.migration.sections.main.header" = "Välj nedan de profiler från äldre versioner av %@ som du vill importera. Om dina profiler är lagrade på iCloud kan det ta en stund att synkronisera. Om du inte ser dem nu, kom tillbaka senare.";
 "views.migration.title" = "Migrera";
+"views.paywall.alerts.actions.save" = "Spara ändå";
 "views.paywall.alerts.confirmation.message.connect" = "Du kan testa anslutningen i %d minuter.";
 "views.paywall.alerts.confirmation.message" = "Den här profilen kräver betalda funktioner för att fungera.";
 "views.paywall.alerts.confirmation.title" = "Köp krävs";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Dessa produkter inkluderar nuvarande och framtida funktioner.";
 "views.paywall.sections.full_products.header" = "Alla funktioner";
 "views.paywall.sections.products.footer" = "Alla köp stöder Familjedelning.";
-"views.paywall.sections.products.header" = "Föreslagna produkter";
+"views.paywall.sections.products.header" = "Köp individuellt";
 "views.paywall.sections.required_features.header" = "Krävda funktioner";
 "views.paywall.sections.restore.footer" = "Om du har gjort köp tidigare kan du återställa dem här.";
 "views.paywall.sections.restore.header" = "Återställ";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Visar även den aktiva profilen överst för snabb åtkomst.";
 "views.preferences.pins_active_profile" = "Fäst aktiv profil";
 "views.preferences.system_appearance" = "Utseende";
-"views.paywall.alerts.actions.save" = "Spara ändå";
 "views.profile.module_list.section.footer" = "Tryck på moduler för att redigera inställningarna. Moduler kan dras för att bestämma prioritet.";
 "views.profile.rows.add_module" = "Lägg till modul";
 "views.profile.rows.delete_profile" = "Ta bort profil";

--- a/Packages/App/Sources/StringsLibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/uk.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "Немає профілів для перенесення";
 "views.migration.sections.main.header" = "Виберіть нижче профілі зі старих версій %@, які ви хочете імпортувати. Якщо ваші профілі зберігаються в iCloud, може знадобитися час для їх синхронізації. Якщо ви не бачите їх зараз, поверніться пізніше.";
 "views.migration.title" = "Перенесення";
-"views.paywall.alerts.confirmation.edit_profile" = "Редагувати профіль";
 "views.paywall.alerts.confirmation.message.connect" = "Ви можете протестувати підключення протягом %d хвилин.";
-"views.paywall.alerts.confirmation.message.save" = "Торкніться значків замка, щоб придбати відсутні функції.";
 "views.paywall.alerts.confirmation.message" = "Цей профіль потребує платних функцій для роботи.";
 "views.paywall.alerts.confirmation.title" = "Потрібна покупка";
 "views.paywall.alerts.pending.message" = "Покупка очікує зовнішнього підтвердження. Функція буде увімкнена після схвалення.";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "Також показує активний профіль зверху для швидкого доступу.";
 "views.preferences.pins_active_profile" = "Закріпити активний профіль";
 "views.preferences.system_appearance" = "Зовнішній вигляд";
-"views.profile.alerts.purchase.buttons.ok" = "Зберегти все одно";
+"views.paywall.alerts.actions.save" = "Зберегти все одно";
 "views.profile.module_list.section.footer" = "Торкніться модулів, щоб змінити їхні налаштування. Їх можна перетягувати для визначення пріоритету.";
 "views.profile.rows.add_module" = "Додати модуль";
 "views.profile.rows.delete_profile" = "Видалити профіль";

--- a/Packages/App/Sources/StringsLibrary/Resources/uk.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/uk.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "Немає профілів для перенесення";
 "views.migration.sections.main.header" = "Виберіть нижче профілі зі старих версій %@, які ви хочете імпортувати. Якщо ваші профілі зберігаються в iCloud, може знадобитися час для їх синхронізації. Якщо ви не бачите їх зараз, поверніться пізніше.";
 "views.migration.title" = "Перенесення";
+"views.paywall.alerts.actions.save" = "Зберегти все одно";
 "views.paywall.alerts.confirmation.message.connect" = "Ви можете протестувати підключення протягом %d хвилин.";
 "views.paywall.alerts.confirmation.message" = "Цей профіль потребує платних функцій для роботи.";
 "views.paywall.alerts.confirmation.title" = "Потрібна покупка";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "Ці продукти містять поточні та майбутні функції.";
 "views.paywall.sections.full_products.header" = "Усі функції";
 "views.paywall.sections.products.footer" = "Усі покупки підтримують “Сімейний доступ”.";
-"views.paywall.sections.products.header" = "Рекомендовані продукти";
+"views.paywall.sections.products.header" = "Придбати окремо";
 "views.paywall.sections.required_features.header" = "Необхідні функції";
 "views.paywall.sections.restore.footer" = "Якщо ви раніше здійснювали покупки, ви можете відновити їх тут.";
 "views.paywall.sections.restore.header" = "Відновлення";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "Також показує активний профіль зверху для швидкого доступу.";
 "views.preferences.pins_active_profile" = "Закріпити активний профіль";
 "views.preferences.system_appearance" = "Зовнішній вигляд";
-"views.paywall.alerts.actions.save" = "Зберегти все одно";
 "views.profile.module_list.section.footer" = "Торкніться модулів, щоб змінити їхні налаштування. Їх можна перетягувати для визначення пріоритету.";
 "views.profile.rows.add_module" = "Додати модуль";
 "views.profile.rows.delete_profile" = "Видалити профіль";

--- a/Packages/App/Sources/StringsLibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -259,9 +259,7 @@
 "views.migration.no_profiles" = "没有可迁移的内容";
 "views.migration.sections.main.header" = "选择以下来自 %@ 的旧版本配置文件进行导入。如果您的配置文件存储在 iCloud 中，可能需要一些时间进行同步。如果现在没有看到，请稍后再试。";
 "views.migration.title" = "迁移";
-"views.paywall.alerts.confirmation.edit_profile" = "编辑配置文件";
 "views.paywall.alerts.confirmation.message.connect" = "您可以试用连接 %d 分钟。";
-"views.paywall.alerts.confirmation.message.save" = "点击锁定图标以购买缺失的功能。";
 "views.paywall.alerts.confirmation.message" = "此配置文件需要付费功能才能工作。";
 "views.paywall.alerts.confirmation.title" = "需要购买";
 "views.paywall.alerts.pending.message" = "购买正在等待外部确认。功能将在获得批准后被授予。";
@@ -295,7 +293,7 @@
 "views.preferences.pins_active_profile.footer" = "还会在顶部显示活动配置文件，以便快速访问。";
 "views.preferences.pins_active_profile" = "固定活动配置文件";
 "views.preferences.system_appearance" = "外观";
-"views.profile.alerts.purchase.buttons.ok" = "仍然保存";
+"views.paywall.alerts.actions.save" = "仍然保存";
 "views.profile.module_list.section.footer" = "点击模块以编辑其设置。可以拖动模块来确定优先级。";
 "views.profile.rows.add_module" = "添加模块";
 "views.profile.rows.delete_profile" = "删除配置文件";

--- a/Packages/App/Sources/StringsLibrary/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/App/Sources/StringsLibrary/Resources/zh-Hans.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "views.migration.no_profiles" = "没有可迁移的内容";
 "views.migration.sections.main.header" = "选择以下来自 %@ 的旧版本配置文件进行导入。如果您的配置文件存储在 iCloud 中，可能需要一些时间进行同步。如果现在没有看到，请稍后再试。";
 "views.migration.title" = "迁移";
+"views.paywall.alerts.actions.save" = "仍然保存";
 "views.paywall.alerts.confirmation.message.connect" = "您可以试用连接 %d 分钟。";
 "views.paywall.alerts.confirmation.message" = "此配置文件需要付费功能才能工作。";
 "views.paywall.alerts.confirmation.title" = "需要购买";
@@ -274,7 +275,7 @@
 "views.paywall.sections.full_products.footer" = "这些产品包含当前和未来的功能。";
 "views.paywall.sections.full_products.header" = "所有功能";
 "views.paywall.sections.products.footer" = "所有购买均支持“家人共享”。";
-"views.paywall.sections.products.header" = "推荐产品";
+"views.paywall.sections.products.header" = "单独购买";
 "views.paywall.sections.required_features.header" = "必需功能";
 "views.paywall.sections.restore.footer" = "如果您过去有购买记录，可以在此恢复。"
 "views.paywall.sections.restore.header" = "恢复";
@@ -293,7 +294,6 @@
 "views.preferences.pins_active_profile.footer" = "还会在顶部显示活动配置文件，以便快速访问。";
 "views.preferences.pins_active_profile" = "固定活动配置文件";
 "views.preferences.system_appearance" = "外观";
-"views.paywall.alerts.actions.save" = "仍然保存";
 "views.profile.module_list.section.footer" = "点击模块以编辑其设置。可以拖动模块来确定优先级。";
 "views.profile.rows.add_module" = "添加模块";
 "views.profile.rows.delete_profile" = "删除配置文件";

--- a/Packages/App/Sources/StringsLibrary/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/StringsLibrary/SwiftGen+Strings.swift
@@ -785,9 +785,11 @@ public enum Strings {
     }
     public enum Paywall {
       public enum Alerts {
+        public enum Actions {
+          /// Save anyway
+          public static let save = Strings.tr("Localizable", "views.paywall.alerts.actions.save", fallback: "Save anyway")
+        }
         public enum Confirmation {
-          /// Edit profile
-          public static let editProfile = Strings.tr("Localizable", "views.paywall.alerts.confirmation.edit_profile", fallback: "Edit profile")
           /// This profile requires paid features to work.
           public static let message = Strings.tr("Localizable", "views.paywall.alerts.confirmation.message", fallback: "This profile requires paid features to work.")
           /// Purchase required
@@ -797,8 +799,6 @@ public enum Strings {
             public static func connect(_ p1: Int) -> String {
               return Strings.tr("Localizable", "views.paywall.alerts.confirmation.message.connect", p1, fallback: "You may test the connection for %d minutes.")
             }
-            /// Tap the lock icons to purchase the missing features.
-            public static let save = Strings.tr("Localizable", "views.paywall.alerts.confirmation.message.save", fallback: "Tap the lock icons to purchase the missing features.")
           }
         }
         public enum Pending {
@@ -906,14 +906,6 @@ public enum Strings {
       }
     }
     public enum Profile {
-      public enum Alerts {
-        public enum Purchase {
-          public enum Buttons {
-            /// Save anyway
-            public static let ok = Strings.tr("Localizable", "views.profile.alerts.purchase.buttons.ok", fallback: "Save anyway")
-          }
-        }
-      }
       public enum ModuleList {
         public enum Section {
           /// Tap modules to edit their settings. Modules may be dragged to determine priority.

--- a/Packages/App/Sources/StringsLibrary/SwiftGen+Strings.swift
+++ b/Packages/App/Sources/StringsLibrary/SwiftGen+Strings.swift
@@ -844,8 +844,8 @@ public enum Strings {
         public enum Products {
           /// All purchases support Family Sharing.
           public static let footer = Strings.tr("Localizable", "views.paywall.sections.products.footer", fallback: "All purchases support Family Sharing.")
-          /// Suggested products
-          public static let header = Strings.tr("Localizable", "views.paywall.sections.products.header", fallback: "Suggested products")
+          /// Purchase individually
+          public static let header = Strings.tr("Localizable", "views.paywall.sections.products.header", fallback: "Purchase individually")
         }
         public enum RequiredFeatures {
           /// Required features

--- a/Packages/App/Sources/UILibrary/Strategy/AppCoordinatorConforming.swift
+++ b/Packages/App/Sources/UILibrary/Strategy/AppCoordinatorConforming.swift
@@ -36,7 +36,11 @@ public protocol AppCoordinatorConforming {
 
     func onProviderEntityRequired(_ profile: Profile, force: Bool)
 
-    func onPurchaseRequired(for profile: Profile, features: Set<AppFeature>, onCancel: (() -> Void)?)
+    func onPurchaseRequired(
+        for profile: Profile,
+        features: Set<AppFeature>,
+        continuation: (() -> Void)?
+    )
 
     func onError(_ error: Error, profile: Profile)
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator+Model.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator+Model.swift
@@ -1,0 +1,141 @@
+//
+//  PaywallCoordinator+Model.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 6/12/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonIAP
+import CommonLibrary
+import CommonUtils
+import Foundation
+
+extension PaywallCoordinator {
+
+    @MainActor
+    final class Model: ObservableObject {
+        var isFetchingProducts = true
+
+        private(set) var suggestedProducts: Set<AppProduct> = []
+
+        private(set) var completePurchasable: [InAppProduct] = []
+
+        private(set) var individualPurchasable: [InAppProduct] = []
+
+        var purchasingIdentifier: String?
+
+        var isPurchasePendingConfirmation = false
+    }
+}
+
+extension PaywallCoordinator.Model {
+    func fetchAvailableProducts(
+        for requiredFeatures: Set<AppFeature>,
+        with iapManager: IAPManager
+    ) async throws {
+        isFetchingProducts = true
+        defer {
+            isFetchingProducts = false
+        }
+        do {
+            let rawProducts = iapManager.suggestedProducts(for: requiredFeatures)
+            guard !rawProducts.isEmpty else {
+                throw AppError.emptyProducts
+            }
+            let rawSortedProducts = rawProducts.sorted {
+                $0.productRank < $1.productRank
+            }
+            let purchasable = try await iapManager.purchasableProducts(for: rawSortedProducts)
+            try setSuggestedProducts(rawProducts, purchasable: purchasable)
+        } catch {
+            pp_log_g(.App.iap, .error, "Unable to load purchasable products: \(error)")
+            throw error
+        }
+    }
+
+    func setSuggestedProducts(
+        _ suggestedProducts: Set<AppProduct>,
+        purchasable: [InAppProduct]
+    ) throws {
+        let completeProducts = suggestedProducts.filter(\.isComplete)
+
+        var completePurchasable: [InAppProduct] = []
+        var individualPurchasable: [InAppProduct] = []
+        purchasable.forEach {
+            guard let raw = AppProduct(rawValue: $0.productIdentifier) else {
+                return
+            }
+            if completeProducts.contains(raw) {
+                completePurchasable.append($0)
+            } else {
+                individualPurchasable.append($0)
+            }
+        }
+        pp_log_g(.App.iap, .info, "Individual products: \(individualPurchasable)")
+        guard !completePurchasable.isEmpty || !individualPurchasable.isEmpty else {
+            throw AppError.emptyProducts
+        }
+
+        self.suggestedProducts = suggestedProducts
+        self.completePurchasable = completePurchasable
+        self.individualPurchasable = individualPurchasable
+    }
+}
+
+private extension AppProduct {
+    var productRank: Int {
+        switch self {
+        case .Essentials.iOS_macOS:
+            return .min
+        case .Essentials.iOS:
+            return 1
+        case .Essentials.macOS:
+            return 2
+        case .Complete.Recurring.yearly:
+            return 3
+        case .Complete.Recurring.monthly:
+            return 4
+        default:
+            return .max
+        }
+    }
+}
+
+extension PaywallCoordinator.Model {
+
+    @MainActor
+    static func forPreviews(
+        _ features: Set<AppFeature>,
+        including: Set<IAPManager.SuggestionInclusion>
+    ) -> PaywallCoordinator.Model {
+        var state = PaywallCoordinator.Model()
+        state.isFetchingProducts = false
+        let suggested = IAPManager.forPreviews.suggestedProducts(
+            for: features,
+            including: including
+        )
+        try? state.setSuggestedProducts(
+            suggested,
+            purchasable: suggested.map(\.asFakeIAP)
+        )
+        return state
+    }
+}

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator+Model.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator+Model.swift
@@ -126,7 +126,7 @@ extension PaywallCoordinator.Model {
         _ features: Set<AppFeature>,
         including: Set<IAPManager.SuggestionInclusion>
     ) -> PaywallCoordinator.Model {
-        var state = PaywallCoordinator.Model()
+        let state = PaywallCoordinator.Model()
         state.isFetchingProducts = false
         let suggested = IAPManager.forPreviews.suggestedProducts(
             for: features,

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
@@ -159,14 +159,19 @@ private extension PaywallCoordinator {
         }
     }
 
+    var didPurchaseRequired: Bool {
+        iapManager.didPurchaseComplete || iapManager.didPurchase(state.individualPurchasable)
+    }
+
     func onComplete(_ productIdentifier: String, result: InAppPurchaseResult) {
         switch result {
         case .done:
             Task {
                 await iapManager.reloadReceipt()
+                if didPurchaseRequired {
+                    isPresented = false
+                }
             }
-            // FIXME: ###, dismiss if purchased complete or all individuals
-            isPresented = false
         case .pending:
             state.isPurchasePendingConfirmation = true
         case .cancelled:

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
@@ -24,30 +24,186 @@
 //
 
 import CommonIAP
+import CommonLibrary
+import CommonUtils
 import SwiftUI
 
+struct PaywallState {
+    var isFetchingProducts = true
+
+    var completeProducts: [InAppProduct] = []
+
+    var individualProducts: [InAppProduct] = []
+
+    var purchasingIdentifier: String?
+
+    var isPurchasePendingConfirmation = false
+}
+
 struct PaywallCoordinator: View {
+
+    @EnvironmentObject
+    private var iapManager: IAPManager
 
     @Binding
     var isPresented: Bool
 
     let requiredFeatures: Set<AppFeature>
 
+    @State
+    private var state = PaywallState()
+
+    @StateObject
+    private var errorHandler: ErrorHandler = .default()
+
     var body: some View {
+        contentView
+            .themeProgress(if: state.isFetchingProducts)
+            .disabled(state.purchasingIdentifier != nil)
+            .alert(
+                Strings.Global.Actions.purchase,
+                isPresented: $state.isPurchasePendingConfirmation,
+                actions: pendingActions,
+                message: pendingMessage
+            )
+            .task(id: requiredFeatures) {
+                await fetchAvailableProducts()
+            }
+            .withErrorHandler(errorHandler)
+    }
+}
+
+// MARK: -
+
+private extension PaywallCoordinator {
+    var contentView: some View {
 #if os(tvOS)
         PaywallView(
-            requiredFeatures: requiredFeatures
+            requiredFeatures: requiredFeatures,
+            state: state
         )
         .themeNavigationStack()
 #else
         PaywallView(
             isPresented: $isPresented,
-            requiredFeatures: requiredFeatures
+            iapManager: iapManager,
+            requiredFeatures: requiredFeatures,
+            state: $state,
+            errorHandler: errorHandler,
+            onComplete: onComplete,
+            onError: onError
         )
         .themeNavigationStack(closable: true)
 #endif
     }
+
+    func pendingActions() -> some View {
+        Button(Strings.Global.Nouns.ok) {
+            isPresented = false
+        }
+    }
+
+    func pendingMessage() -> some View {
+        Text(Strings.Views.Paywall.Alerts.Pending.message)
+    }
 }
+
+// MARK: -
+
+private extension PaywallCoordinator {
+    func fetchAvailableProducts() async {
+        state.isFetchingProducts = true
+        defer {
+            state.isFetchingProducts = false
+        }
+        do {
+            let rawProducts = iapManager.suggestedProducts(for: requiredFeatures)
+            guard !rawProducts.isEmpty else {
+                throw AppError.emptyProducts
+            }
+            let rawCompleteProducts = rawProducts.filter(\.isComplete)
+
+            let allProducts = try await iapManager.purchasableProducts(for: rawProducts
+                .sorted {
+                    $0.productRank < $1.productRank
+                }
+            )
+            var completeProducts: [InAppProduct] = []
+            var individualProducts: [InAppProduct] = []
+            allProducts.forEach {
+                guard let raw = AppProduct(rawValue: $0.productIdentifier) else {
+                    return
+                }
+                if rawCompleteProducts.contains(raw) {
+                    completeProducts.append($0)
+                } else {
+                    individualProducts.append($0)
+                }
+            }
+
+            pp_log_g(.App.iap, .info, "Individual products: \(individualProducts)")
+            guard !completeProducts.isEmpty || !individualProducts.isEmpty else {
+                throw AppError.emptyProducts
+            }
+
+            state.completeProducts = completeProducts
+            state.individualProducts = individualProducts
+        } catch {
+            pp_log_g(.App.iap, .error, "Unable to load purchasable products: \(error)")
+            onError(error, dismissing: true)
+        }
+    }
+
+    func onComplete(_ productIdentifier: String, result: InAppPurchaseResult) {
+        switch result {
+        case .done:
+            Task {
+                await iapManager.reloadReceipt()
+            }
+            // FIXME: ###, dismiss if purchased complete or all individuals
+            isPresented = false
+        case .pending:
+            state.isPurchasePendingConfirmation = true
+        case .cancelled:
+            break
+        case .notFound:
+            fatalError("Product not found: \(productIdentifier)")
+        }
+    }
+
+    func onError(_ error: Error) {
+        onError(error, dismissing: false)
+    }
+
+    func onError(_ error: Error, dismissing: Bool) {
+        errorHandler.handle(error, title: Strings.Global.Actions.purchase) {
+            if dismissing {
+                isPresented = false
+            }
+        }
+    }
+}
+
+private extension AppProduct {
+    var productRank: Int {
+        switch self {
+        case .Essentials.iOS_macOS:
+            return .min
+        case .Essentials.iOS:
+            return 1
+        case .Essentials.macOS:
+            return 2
+        case .Complete.Recurring.yearly:
+            return 3
+        case .Complete.Recurring.monthly:
+            return 4
+        default:
+            return .max
+        }
+    }
+}
+
+// MARK: - Previews
 
 #Preview {
     PaywallCoordinator(

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
@@ -1,0 +1,58 @@
+//
+//  PaywallCoordinator.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 9/10/24.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import CommonIAP
+import SwiftUI
+
+struct PaywallCoordinator: View {
+
+    @Binding
+    var isPresented: Bool
+
+    let requiredFeatures: Set<AppFeature>
+
+    var body: some View {
+#if os(tvOS)
+        PaywallView(
+            requiredFeatures: requiredFeatures
+        )
+        .themeNavigationStack()
+#else
+        PaywallView(
+            isPresented: $isPresented,
+            requiredFeatures: requiredFeatures
+        )
+        .themeNavigationStack(closable: true)
+#endif
+    }
+}
+
+#Preview {
+    PaywallCoordinator(
+        isPresented: .constant(true),
+        requiredFeatures: [.appleTV, .dns, .sharing]
+    )
+    .withMockEnvironment()
+}

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
@@ -215,13 +215,13 @@ extension PaywallState {
     @MainActor
     static func forPreviews(
         _ features: Set<AppFeature>,
-        filters: Set<IAPManager.SuggestionFilter>
+        including: Set<IAPManager.SuggestionInclusion>
     ) -> Self {
         var state = PaywallState()
         state.isFetchingProducts = false
         let suggested = IAPManager.forPreviews.suggestedProducts(
             for: features,
-            filters: filters
+            including: including
         )
         try? state.setSuggestedProducts(
             suggested,

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallCoordinator.swift
@@ -205,6 +205,18 @@ private extension AppProduct {
 
 // MARK: - Previews
 
+extension PaywallState {
+    static var forPreviews: Self {
+        var state = PaywallState()
+        state.isFetchingProducts = false
+        state.completeProducts = [AppProduct.Complete.OneTime.lifetime]
+            .map(\.asFakeIAP)
+        state.individualProducts = [AppProduct.Features.appleTV]
+            .map(\.asFakeIAP)
+        return state
+    }
+}
+
 #Preview {
     PaywallCoordinator(
         isPresented: .constant(true),

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier+Reason.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier+Reason.swift
@@ -43,19 +43,15 @@ extension PaywallModifier {
 
         public let requiredFeatures: Set<AppFeature>
 
-        public let suggestedProducts: Set<AppProduct>?
-
         public let action: Action
 
         public init(
             _ profile: Profile?,
             requiredFeatures: Set<AppFeature>,
-            suggestedProducts: Set<AppProduct>? = nil,
             action: Action
         ) {
             self.profile = profile
             self.requiredFeatures = requiredFeatures
-            self.suggestedProducts = suggestedProducts
             self.action = action
         }
 

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
@@ -192,15 +192,10 @@ private extension PaywallModifier {
 private extension PaywallModifier {
     func modalDestination() -> some View {
         reason.map {
-            PaywallView(
+            PaywallCoordinator(
                 isPresented: $isPurchasing,
                 requiredFeatures: iapManager.excludingEligible(from: $0.requiredFeatures)
             )
-#if os(tvOS)
-            .themeNavigationStack()
-#else
-            .themeNavigationStack(closable: true)
-#endif
         }
     }
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
@@ -196,7 +196,11 @@ private extension PaywallModifier {
                 isPresented: $isPurchasing,
                 requiredFeatures: iapManager.excludingEligible(from: $0.requiredFeatures)
             )
+#if os(tvOS)
             .themeNavigationStack()
+#else
+            .themeNavigationStack(closable: true)
+#endif
         }
     }
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
@@ -191,8 +191,7 @@ private extension PaywallModifier {
         reason.map {
             PaywallView(
                 isPresented: $isPurchasing,
-                requiredFeatures: iapManager.excludingEligible(from: $0.requiredFeatures),
-                suggestedProducts: $0.suggestedProducts
+                requiredFeatures: iapManager.excludingEligible(from: $0.requiredFeatures)
             )
             .themeNavigationStack()
         }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallModifier.swift
@@ -120,7 +120,6 @@ private extension PaywallModifier {
     }
 
     func confirmationActions() -> some View {
-#if !os(tvOS)
         reason.map { reason in
             Group {
                 if !iapManager.isBeta, let onAction {
@@ -133,9 +132,6 @@ private extension PaywallModifier {
                 }
             }
         }
-#else
-        EmptyView()
-#endif
     }
 
     var confirmationTitle: String {
@@ -195,7 +191,6 @@ private extension PaywallModifier {
 
 private extension PaywallModifier {
     func modalDestination() -> some View {
-#if !os(tvOS)
         reason.map {
             PaywallView(
                 isPresented: $isPurchasing,
@@ -203,10 +198,6 @@ private extension PaywallModifier {
             )
             .themeNavigationStack()
         }
-#else
-        // FIXME: ###
-        fatalError("tvOS: Paywall unsupported")
-#endif
     }
 }
 

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallProductView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallProductView.swift
@@ -91,7 +91,7 @@ private extension PaywallProductView {
 
     @ViewBuilder
     var productView: some View {
-        if #available(iOS 17, macOS 14, tvOS 17, *) {
+        if !isPreview, #available(iOS 17, macOS 14, tvOS 17, *) {
             StoreKitProductView(
                 style: style,
                 product: product,

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallProductView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallProductView.swift
@@ -54,7 +54,7 @@ public struct PaywallProductView: View {
         iapManager: IAPManager,
         style: PaywallProductViewStyle,
         product: InAppProduct,
-        withIncludedFeatures: Bool = true,
+        withIncludedFeatures: Bool,
         highlightedFeatures: Set<AppFeature> = [],
         purchasingIdentifier: Binding<String?>,
         onComplete: @escaping (String, InAppPurchaseResult) -> Void,
@@ -123,6 +123,7 @@ private extension PaywallProductView {
                 localizedPrice: "$10",
                 native: nil
             ),
+            withIncludedFeatures: true,
             highlightedFeatures: [.appleTV],
             purchasingIdentifier: .constant(nil),
             onComplete: { _, _ in },

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
@@ -53,9 +53,9 @@ struct PaywallView: View {
     var body: some View {
         Form {
             completeProductsView
-                .if(!state.completeProducts.isEmpty)
+                .if(!state.completePurchasable.isEmpty)
             individualProductsView
-                .if(!state.individualProducts.isEmpty)
+                .if(!state.individualPurchasable.isEmpty)
             restoreView
             linksView
         }
@@ -66,7 +66,7 @@ struct PaywallView: View {
 private extension PaywallView {
     var completeProductsView: some View {
         Group {
-            ForEach(state.completeProducts, id: \.productIdentifier) {
+            ForEach(state.completePurchasable, id: \.productIdentifier) {
                 PaywallProductView(
                     iapManager: iapManager,
                     style: .paywall,
@@ -99,7 +99,7 @@ private extension PaywallView {
     }
 
     var individualProductsView: some View {
-        ForEach(state.individualProducts, id: \.productIdentifier) {
+        ForEach(state.individualPurchasable, id: \.productIdentifier) {
             PaywallProductView(
                 iapManager: iapManager,
                 style: .paywall,
@@ -138,11 +138,12 @@ private extension PaywallView {
 // MARK: - Previews
 
 #Preview {
+    let features: Set<AppFeature> = [.appleTV, .dns, .sharing]
     PaywallView(
         isPresented: .constant(true),
         iapManager: .forPreviews,
-        requiredFeatures: [.appleTV, .dns, .sharing],
-        state: .constant(.forPreviews),
+        requiredFeatures: features,
+        state: .constant(.forPreviews(features, filters: [.complete])),
         errorHandler: .default(),
         onComplete: { _, _ in },
         onError: { _ in }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
@@ -53,7 +53,9 @@ struct PaywallView: View {
     var body: some View {
         Form {
             completeProductsView
+                .if(!state.completeProducts.isEmpty)
             individualProductsView
+                .if(!state.individualProducts.isEmpty)
             restoreView
             linksView
         }
@@ -63,65 +65,57 @@ struct PaywallView: View {
 
 private extension PaywallView {
     var completeProductsView: some View {
-        state.completeProducts
-            .nilIfEmpty
-            .map { products in
-                Group {
-                    ForEach(products, id: \.productIdentifier) {
-                        PaywallProductView(
-                            iapManager: iapManager,
-                            style: .paywall,
-                            product: $0,
-                            withIncludedFeatures: false,
-                            highlightedFeatures: requiredFeatures,
-                            purchasingIdentifier: $state.purchasingIdentifier,
-                            onComplete: onComplete,
-                            onError: onError
-                        )
-                    }
-                    VStack(alignment: .leading) {
-                        ForEach(AppFeature.allCases.sorted()) {
-                            IncludedFeatureRow(
-                                feature: $0,
-                                isHighlighted: requiredFeatures.contains($0)
-                            )
-                            .font(.subheadline)
-                        }
-                    }
-                }
-                .themeSection(
-                    header: Strings.Views.Paywall.Sections.FullProducts.header,
-                    footer: [
-                        Strings.Views.Paywall.Sections.FullProducts.footer,
-                        Strings.Views.Paywall.Sections.Products.footer
-                    ].joined(separator: " "),
-                    forcesFooter: true
+        Group {
+            ForEach(state.completeProducts, id: \.productIdentifier) {
+                PaywallProductView(
+                    iapManager: iapManager,
+                    style: .paywall,
+                    product: $0,
+                    withIncludedFeatures: false,
+                    highlightedFeatures: requiredFeatures,
+                    purchasingIdentifier: $state.purchasingIdentifier,
+                    onComplete: onComplete,
+                    onError: onError
                 )
             }
+            VStack(alignment: .leading) {
+                ForEach(AppFeature.allCases.sorted()) {
+                    IncludedFeatureRow(
+                        feature: $0,
+                        isHighlighted: requiredFeatures.contains($0)
+                    )
+                    .font(.subheadline)
+                }
+            }
+        }
+        .themeSection(
+            header: Strings.Views.Paywall.Sections.FullProducts.header,
+            footer: [
+                Strings.Views.Paywall.Sections.FullProducts.footer,
+                Strings.Views.Paywall.Sections.Products.footer
+            ].joined(separator: " "),
+            forcesFooter: true
+        )
     }
 
     var individualProductsView: some View {
-        state.individualProducts
-            .nilIfEmpty
-            .map { products in
-                ForEach(products, id: \.productIdentifier) {
-                    PaywallProductView(
-                        iapManager: iapManager,
-                        style: .paywall,
-                        product: $0,
-                        withIncludedFeatures: true,
-                        highlightedFeatures: requiredFeatures,
-                        purchasingIdentifier: $state.purchasingIdentifier,
-                        onComplete: onComplete,
-                        onError: onError
-                    )
-                }
-                .themeSection(
-                    header: Strings.Views.Paywall.Sections.Products.header,
-                    footer: Strings.Views.Paywall.Sections.Products.footer,
-                    forcesFooter: true
-                )
-            }
+        ForEach(state.individualProducts, id: \.productIdentifier) {
+            PaywallProductView(
+                iapManager: iapManager,
+                style: .paywall,
+                product: $0,
+                withIncludedFeatures: true,
+                highlightedFeatures: requiredFeatures,
+                purchasingIdentifier: $state.purchasingIdentifier,
+                onComplete: onComplete,
+                onError: onError
+            )
+        }
+        .themeSection(
+            header: Strings.Views.Paywall.Sections.Products.header,
+            footer: Strings.Views.Paywall.Sections.Products.footer,
+            forcesFooter: true
+        )
     }
 
     var linksView: some View {

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
@@ -148,7 +148,7 @@ private extension PaywallView {
         isPresented: .constant(true),
         iapManager: .forPreviews,
         requiredFeatures: [.appleTV, .dns, .sharing],
-        state: .constant(PaywallState()),
+        state: .constant(.forPreviews),
         errorHandler: .default(),
         onComplete: { _, _ in },
         onError: { _ in }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
@@ -1,5 +1,5 @@
 //
-//  PaywallView.swift
+//  PaywallView+Main.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 9/10/24.
@@ -23,12 +23,13 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#if !os(tvOS)
+
 import CommonLibrary
 import CommonUtils
 import StoreKit
 import SwiftUI
 
-// FIXME: ###, purchase multiple products in sequence
 struct PaywallView: View {
 
     @EnvironmentObject
@@ -289,3 +290,5 @@ private extension AppProduct {
     )
     .withMockEnvironment()
 }
+
+#endif

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
@@ -143,7 +143,7 @@ private extension PaywallView {
         isPresented: .constant(true),
         iapManager: .forPreviews,
         requiredFeatures: features,
-        state: .constant(.forPreviews(features, filters: [.complete])),
+        state: .constant(.forPreviews(features, including: [.complete])),
         errorHandler: .default(),
         onComplete: { _, _ in },
         onError: { _ in }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+Main.swift
@@ -41,7 +41,7 @@ struct PaywallView: View {
     let requiredFeatures: Set<AppFeature>
 
     @Binding
-    var state: PaywallState
+    var model: PaywallCoordinator.Model
 
     @ObservedObject
     var errorHandler: ErrorHandler
@@ -53,9 +53,9 @@ struct PaywallView: View {
     var body: some View {
         Form {
             completeProductsView
-                .if(!state.completePurchasable.isEmpty)
+                .if(!model.completePurchasable.isEmpty)
             individualProductsView
-                .if(!state.individualPurchasable.isEmpty)
+                .if(!model.individualPurchasable.isEmpty)
             restoreView
             linksView
         }
@@ -66,14 +66,14 @@ struct PaywallView: View {
 private extension PaywallView {
     var completeProductsView: some View {
         Group {
-            ForEach(state.completePurchasable, id: \.productIdentifier) {
+            ForEach(model.completePurchasable, id: \.productIdentifier) {
                 PaywallProductView(
                     iapManager: iapManager,
                     style: .paywall,
                     product: $0,
                     withIncludedFeatures: false,
                     highlightedFeatures: requiredFeatures,
-                    purchasingIdentifier: $state.purchasingIdentifier,
+                    purchasingIdentifier: $model.purchasingIdentifier,
                     onComplete: onComplete,
                     onError: onError
                 )
@@ -99,14 +99,14 @@ private extension PaywallView {
     }
 
     var individualProductsView: some View {
-        ForEach(state.individualPurchasable, id: \.productIdentifier) {
+        ForEach(model.individualPurchasable, id: \.productIdentifier) {
             PaywallProductView(
                 iapManager: iapManager,
                 style: .paywall,
                 product: $0,
                 withIncludedFeatures: true,
                 highlightedFeatures: requiredFeatures,
-                purchasingIdentifier: $state.purchasingIdentifier,
+                purchasingIdentifier: $model.purchasingIdentifier,
                 onComplete: onComplete,
                 onError: onError
             )
@@ -143,7 +143,7 @@ private extension PaywallView {
         isPresented: .constant(true),
         iapManager: .forPreviews,
         requiredFeatures: features,
-        state: .constant(.forPreviews(features, including: [.complete])),
+        model: .constant(.forPreviews(features, including: [.complete])),
         errorHandler: .default(),
         onComplete: { _, _ in },
         onError: { _ in }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
@@ -32,6 +32,8 @@ import SwiftUI
 struct PaywallView: View {
     let requiredFeatures: Set<AppFeature>
 
+    let state: PaywallState
+
     var body: some View {
         EmptyView()
             .themeNavigationStack()
@@ -42,7 +44,8 @@ struct PaywallView: View {
 
 #Preview {
     PaywallView(
-        requiredFeatures: [.appleTV, .dns, .sharing]
+        requiredFeatures: [.appleTV, .dns, .sharing],
+        state: PaywallState()
     )
     .withMockEnvironment()
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
@@ -1,0 +1,50 @@
+//
+//  PaywallView+TV.swift
+//  Passepartout
+//
+//  Created by Davide De Rosa on 9/10/24.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Passepartout.
+//
+//  Passepartout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Passepartout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#if os(tvOS)
+
+import CommonIAP
+import SwiftUI
+
+// FIXME: ###, TV paywall
+struct PaywallView: View {
+    let requiredFeatures: Set<AppFeature>
+
+    var body: some View {
+        EmptyView()
+            .themeNavigationStack()
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    PaywallView(
+        requiredFeatures: [.appleTV, .dns, .sharing]
+    )
+    .withMockEnvironment()
+}
+
+#endif

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
@@ -28,15 +28,15 @@
 import CommonIAP
 import SwiftUI
 
-// FIXME: ###, TV paywall
 struct PaywallView: View {
     let requiredFeatures: Set<AppFeature>
 
     let state: PaywallState
 
     var body: some View {
-        EmptyView()
-            .themeNavigationStack()
+        fatalError("FIXME: ###, TV paywall")
+//        EmptyView()
+//            .themeNavigationStack()
     }
 }
 

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView+TV.swift
@@ -31,7 +31,7 @@ import SwiftUI
 struct PaywallView: View {
     let requiredFeatures: Set<AppFeature>
 
-    let state: PaywallState
+    let model: PaywallCoordinator.Model
 
     var body: some View {
         fatalError("FIXME: ###, TV paywall")
@@ -43,9 +43,10 @@ struct PaywallView: View {
 // MARK: - Previews
 
 #Preview {
+    let features: Set<AppFeature> = [.appleTV, .dns, .sharing]
     PaywallView(
-        requiredFeatures: [.appleTV, .dns, .sharing],
-        state: PaywallState()
+        requiredFeatures: features,
+        model: .forPreviews(features, including: [])
     )
     .withMockEnvironment()
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -87,7 +87,9 @@ private extension PaywallView {
             productsView
             completeProductsView
             restoreView
+#if !os(tvOS)
             linksView
+#endif
         }
         .themeForm()
         .disabled(purchasingIdentifier != nil)

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -43,9 +43,6 @@ struct PaywallView: View {
 
     let requiredFeatures: Set<AppFeature>
 
-    // nil = essentials
-    let suggestedProducts: Set<AppProduct>?
-
     @State
     private var isFetchingProducts = true
 
@@ -74,7 +71,7 @@ struct PaywallView: View {
                 actions: pendingActions,
                 message: pendingMessage
             )
-            .task(id: suggestedProducts) {
+            .task(id: requiredFeatures) {
                 await fetchAvailableProducts()
             }
             .withErrorHandler(errorHandler)
@@ -230,7 +227,7 @@ private extension PaywallView {
             isFetchingProducts = false
         }
         do {
-            let rawProducts = suggestedProducts ?? iapManager.suggestedProducts()
+            let rawProducts = iapManager.suggestedProducts()
             guard !rawProducts.isEmpty else {
                 throw AppError.emptyProducts
             }
@@ -323,8 +320,7 @@ private extension AppProduct {
 #Preview {
     PaywallView(
         isPresented: .constant(true),
-        requiredFeatures: [.appleTV],
-        suggestedProducts: [.Features.appleTV, .Complete.OneTime.lifetime]
+        requiredFeatures: [.appleTV]
     )
     .withMockEnvironment()
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -298,7 +298,7 @@ private extension AppProduct {
 #Preview {
     PaywallView(
         isPresented: .constant(true),
-        requiredFeatures: [.appleTV]
+        requiredFeatures: [.appleTV, .dns, .sharing]
     )
     .withMockEnvironment()
 }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -28,8 +28,7 @@ import CommonUtils
 import StoreKit
 import SwiftUI
 
-#if !os(tvOS)
-
+// FIXME: ###, purchase multiple products in sequence
 struct PaywallView: View {
 
     @EnvironmentObject
@@ -324,5 +323,3 @@ private extension AppProduct {
     )
     .withMockEnvironment()
 }
-
-#endif

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -190,7 +190,7 @@ private extension PaywallView {
             isFetchingProducts = false
         }
         do {
-            let rawProducts = iapManager.suggestedProducts()
+            let rawProducts = iapManager.suggestedProducts(for: requiredFeatures)
             guard !rawProducts.isEmpty else {
                 throw AppError.emptyProducts
             }

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -141,6 +141,7 @@ private extension PaywallView {
                         iapManager: iapManager,
                         style: .paywall,
                         product: $0,
+                        withIncludedFeatures: true,
                         highlightedFeatures: requiredFeatures,
                         purchasingIdentifier: $purchasingIdentifier,
                         onComplete: onComplete,

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -84,7 +84,6 @@ private extension PaywallView {
 
     var contentView: some View {
         Form {
-            requiredFeaturesView
             productsView
             completeProductsView
             restoreView
@@ -92,22 +91,6 @@ private extension PaywallView {
         }
         .themeForm()
         .disabled(purchasingIdentifier != nil)
-    }
-
-    var requiredFeaturesView: some View {
-        requiredFeatures
-            .nilIfEmpty
-            .map { features in
-                FeatureListView(
-                    style: .list,
-                    header: Strings.Views.Paywall.Sections.RequiredFeatures.header,
-                    features: features.sorted(),
-                    content: {
-                        featureView(for: $0)
-                            .fontWeight(theme.relevantWeight)
-                    }
-                )
-            }
     }
 
     var productsView: some View {
@@ -176,11 +159,6 @@ private extension PaywallView {
             Link(Strings.Unlocalized.eula, destination: Constants.shared.websites.eula)
             Link(Strings.Views.Settings.Links.Rows.privacyPolicy, destination: Constants.shared.websites.privacyPolicy)
         }
-    }
-
-    func featureView(for feature: AppFeature) -> some View {
-        Text(feature.localizedDescription)
-            .scrollableOnTV()
     }
 
     var restoreView: some View {

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -84,8 +84,8 @@ private extension PaywallView {
 
     var contentView: some View {
         Form {
-            productsView
             completeProductsView
+            productsView
             restoreView
 #if !os(tvOS)
             linksView
@@ -146,7 +146,6 @@ private extension PaywallView {
                     }
                 }
                 .themeSection(
-                    header: Strings.Views.Paywall.Sections.FullProducts.header,
                     footer: [
                         Strings.Views.Paywall.Sections.FullProducts.footer,
                         Strings.Views.Paywall.Sections.Products.footer

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -145,6 +145,7 @@ private extension PaywallView {
                     }
                 }
                 .themeSection(
+                    header: Strings.Views.Paywall.Sections.FullProducts.header,
                     footer: [
                         Strings.Views.Paywall.Sections.FullProducts.footer,
                         Strings.Views.Paywall.Sections.Products.footer

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -63,7 +63,6 @@ struct PaywallView: View {
     var body: some View {
         contentView
             .themeProgress(if: isFetchingProducts)
-            .toolbar(content: toolbarContent)
             .alert(
                 Strings.Global.Actions.purchase,
                 isPresented: $isPurchasePendingConfirmation,
@@ -169,16 +168,6 @@ private extension PaywallView {
                 footer: Strings.Views.Paywall.Sections.Restore.footer,
                 above: true
             )
-    }
-
-    func toolbarContent() -> some ToolbarContent {
-        ToolbarItem(placement: .cancellationAction) {
-            Button {
-                isPresented = false
-            } label: {
-                ThemeCloseLabel()
-            }
-        }
     }
 
     func pendingActions() -> some View {

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PaywallView.swift
@@ -184,10 +184,6 @@ private extension PaywallView {
 // MARK: -
 
 private extension PaywallView {
-    var essentialFeatures: [AppFeature] {
-        AppProduct.Essentials.iOS_macOS.features
-    }
-
     func fetchAvailableProducts() async {
         isFetchingProducts = true
         defer {

--- a/Packages/App/Sources/UILibrary/Views/Paywall/PurchaseRequiredView.swift
+++ b/Packages/App/Sources/UILibrary/Views/Paywall/PurchaseRequiredView.swift
@@ -64,13 +64,12 @@ extension PurchaseRequiredView where Content == PurchaseRequiredButton {
         reason: Binding<PaywallReason?>,
         suggesting products: Set<AppProduct>? = nil
     ) {
-        self.init(requiring: requiring?.features, reason: reason, suggesting: products)
+        self.init(requiring: requiring?.features, reason: reason)
     }
 
     public init(
         requiring features: Set<AppFeature>?,
-        reason: Binding<PaywallReason?>,
-        suggesting products: Set<AppProduct>? = nil
+        reason: Binding<PaywallReason?>
     ) {
         self.features = features
         content = {
@@ -78,7 +77,6 @@ extension PurchaseRequiredView where Content == PurchaseRequiredButton {
                 reason.wrappedValue = .init(
                     nil,
                     requiredFeatures: features ?? [],
-                    suggestedProducts: products,
                     action: .purchase
                 )
             }
@@ -101,7 +99,6 @@ extension PurchaseRequiredView where Content == Button<Text> {
                 reason.wrappedValue = .init(
                     nil,
                     requiredFeatures: features,
-                    suggestedProducts: products,
                     action: .purchase
                 )
             }

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -377,14 +377,14 @@ extension IAPManagerTests {
 
     func test_givenFree_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filter: .includingComplete), [
+        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.Recurring.yearly,
             .Complete.Recurring.monthly,
             .Complete.OneTime.lifetime
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filter: .includingComplete), [
+        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.Recurring.yearly,
@@ -395,14 +395,14 @@ extension IAPManagerTests {
 
     func test_givenOldProducts_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [.Features.trustedNetworks])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filter: .includingComplete), [
+        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.OneTime.lifetime,
             .Complete.Recurring.monthly,
             .Complete.Recurring.yearly
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filter: .includingComplete), [
+        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.OneTime.lifetime,
@@ -413,11 +413,11 @@ extension IAPManagerTests {
 
     func test_givenNewProducts_whenWithComplete_thenSuggestsEssentials() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filter: .includingComplete), [
+        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filter: .includingComplete), [
+        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])
@@ -616,7 +616,8 @@ private extension IAPManager {
         await reloadReceipt()
     }
 
+    // BEWARE: default value filters in suggestedProducts() is [.complete]
     func suggestedProducts(for platform: Platform) -> Set<AppProduct> {
-        suggestedProducts(for: platform, filter: .excludingComplete)
+        suggestedProducts(for: platform, filters: [])
     }
 }

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -377,14 +377,20 @@ extension IAPManagerTests {
 
     func test_givenFree_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete, .singlePlatformEssentials]), [
+        XCTAssertEqual(sut.essentialProducts(
+            on: .iOS,
+            including: [.complete, .singlePlatformEssentials]
+        ), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.Recurring.yearly,
             .Complete.Recurring.monthly,
             .Complete.OneTime.lifetime
         ])
-        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete, .singlePlatformEssentials]), [
+        XCTAssertEqual(sut.essentialProducts(
+            on: .macOS,
+            including: [.complete, .singlePlatformEssentials]
+        ), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.Recurring.yearly,
@@ -395,14 +401,20 @@ extension IAPManagerTests {
 
     func test_givenOldProducts_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [.Features.trustedNetworks])
-        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete, .singlePlatformEssentials]), [
+        XCTAssertEqual(sut.essentialProducts(
+            on: .iOS,
+            including: [.complete, .singlePlatformEssentials]
+        ), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.OneTime.lifetime,
             .Complete.Recurring.monthly,
             .Complete.Recurring.yearly
         ])
-        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete, .singlePlatformEssentials]), [
+        XCTAssertEqual(sut.essentialProducts(
+            on: .macOS,
+            including: [.complete, .singlePlatformEssentials]
+        ), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.OneTime.lifetime,
@@ -413,11 +425,17 @@ extension IAPManagerTests {
 
     func test_givenNewProducts_whenWithComplete_thenSuggestsEssentials() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete, .singlePlatformEssentials]), [
+        XCTAssertEqual(sut.essentialProducts(
+            on: .iOS,
+            including: [.complete, .singlePlatformEssentials]
+        ), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete, .singlePlatformEssentials]), [
+        XCTAssertEqual(sut.essentialProducts(
+            on: .macOS,
+            including: [.complete, .singlePlatformEssentials]
+        ), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])
@@ -659,16 +677,16 @@ private extension IAPManager {
 
     func essentialProducts(
         on platform: Platform,
-        filters: Set<SuggestionFilter> = [.singlePlatformEssentials]
+        including: Set<SuggestionInclusion> = [.singlePlatformEssentials]
     ) -> Set<AppProduct> {
-        suggestedProducts(for: AppFeature.essentialFeatures, on: platform, filters: filters)
+        suggestedProducts(for: AppFeature.essentialFeatures, on: platform, including: including)
     }
 
     func mixedProducts(
         for features: Set<AppFeature>,
         on platform: Platform,
-        filters: Set<SuggestionFilter> = [.singlePlatformEssentials]
+        including: Set<SuggestionInclusion> = [.singlePlatformEssentials]
     ) -> Set<AppProduct> {
-        suggestedProducts(for: features, on: platform, filters: filters)
+        suggestedProducts(for: features, on: platform, including: including)
     }
 }

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -377,14 +377,14 @@ extension IAPManagerTests {
 
     func test_givenFree_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete, .singlePlatformEssentials]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.Recurring.yearly,
             .Complete.Recurring.monthly,
             .Complete.OneTime.lifetime
         ])
-        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete, .singlePlatformEssentials]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.Recurring.yearly,
@@ -395,14 +395,14 @@ extension IAPManagerTests {
 
     func test_givenOldProducts_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [.Features.trustedNetworks])
-        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete, .singlePlatformEssentials]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.OneTime.lifetime,
             .Complete.Recurring.monthly,
             .Complete.Recurring.yearly
         ])
-        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete, .singlePlatformEssentials]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.OneTime.lifetime,
@@ -413,11 +413,11 @@ extension IAPManagerTests {
 
     func test_givenNewProducts_whenWithComplete_thenSuggestsEssentials() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete, .singlePlatformEssentials]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete, .singlePlatformEssentials]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])
@@ -659,7 +659,7 @@ private extension IAPManager {
 
     func essentialProducts(
         on platform: Platform,
-        filters: Set<SuggestionFilter> = []
+        filters: Set<SuggestionFilter> = [.singlePlatformEssentials]
     ) -> Set<AppProduct> {
         suggestedProducts(for: AppFeature.essentialFeatures, on: platform, filters: filters)
     }
@@ -667,7 +667,7 @@ private extension IAPManager {
     func individualProducts(
         for features: Set<AppFeature>,
         on platform: Platform,
-        filters: Set<SuggestionFilter> = []
+        filters: Set<SuggestionFilter> = [.singlePlatformEssentials]
     ) -> Set<AppProduct> {
         suggestedProducts(for: features, on: platform, filters: filters)
     }

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -424,18 +424,18 @@ extension IAPManagerTests {
     }
 }
 
-// MARK: - Suggestions (Individual)
+// MARK: - Suggestions (Non-essential)
 
 extension IAPManagerTests {
     func test_givenFree_whenSuggestMixedFeatures_thenSuggestsEssentials() async {
         let sut = await IAPManager(products: [])
         let features: Set<AppFeature> = [.appleTV, .dns]
-        XCTAssertEqual(sut.individualProducts(for: features, on: .iOS), [
+        XCTAssertEqual(sut.mixedProducts(for: features, on: .iOS), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Features.appleTV
         ])
-        XCTAssertEqual(sut.individualProducts(for: features, on: .macOS), [
+        XCTAssertEqual(sut.mixedProducts(for: features, on: .macOS), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Features.appleTV
@@ -445,10 +445,10 @@ extension IAPManagerTests {
     func test_givenFree_whenSuggestNonEssentialFeature_thenDoesNotSuggestEssentials() async {
         let sut = await IAPManager(products: [])
         let features: Set<AppFeature> = [.appleTV]
-        XCTAssertEqual(sut.individualProducts(for: features, on: .iOS), [
+        XCTAssertEqual(sut.mixedProducts(for: features, on: .iOS), [
             .Features.appleTV
         ])
-        XCTAssertEqual(sut.individualProducts(for: features, on: .macOS), [
+        XCTAssertEqual(sut.mixedProducts(for: features, on: .macOS), [
             .Features.appleTV
         ])
     }
@@ -456,10 +456,10 @@ extension IAPManagerTests {
     func test_givenFree_whenSuggestNonEssentialImplyingEssentialFeature_thenDoesNotSuggestEssentials() async {
         let sut = await IAPManager(products: [])
         let features: Set<AppFeature> = [.appleTV, .sharing]
-        XCTAssertEqual(sut.individualProducts(for: features, on: .iOS), [
+        XCTAssertEqual(sut.mixedProducts(for: features, on: .iOS), [
             .Features.appleTV
         ])
-        XCTAssertEqual(sut.individualProducts(for: features, on: .macOS), [
+        XCTAssertEqual(sut.mixedProducts(for: features, on: .macOS), [
             .Features.appleTV
         ])
     }
@@ -664,7 +664,7 @@ private extension IAPManager {
         suggestedProducts(for: AppFeature.essentialFeatures, on: platform, filters: filters)
     }
 
-    func individualProducts(
+    func mixedProducts(
         for features: Set<AppFeature>,
         on platform: Platform,
         filters: Set<SuggestionFilter> = [.singlePlatformEssentials]

--- a/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
+++ b/Packages/App/Tests/CommonLibraryTests/Business/IAPManagerTests.swift
@@ -290,16 +290,16 @@ extension IAPManagerTests {
     }
 }
 
-// MARK: - Suggestions
+// MARK: - Suggestions (Essentials)
 
 extension IAPManagerTests {
     func test_givenFree_thenSuggestsEssentialsAllAndPlatform() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])
@@ -307,39 +307,39 @@ extension IAPManagerTests {
 
     func test_givenEssentialsiOS_thenSuggestsEssentialsmacOS() async {
         let sut = await IAPManager(products: [.Essentials.iOS])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [
             .Essentials.macOS
         ])
     }
 
     func test_givenEssentialsmacOS_thenSuggestsEssentialsiOS() async {
         let sut = await IAPManager(products: [.Essentials.macOS])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [])
     }
 
     func test_givenEssentialsiOSmacOS_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Essentials.iOS, .Essentials.macOS])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [])
     }
 
     func test_givenEssentialsAll_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Essentials.iOS_macOS])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [])
     }
 
     func test_givenAppleTV_thenSuggestsEssentialsAllAndPlatform() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])
@@ -347,11 +347,11 @@ extension IAPManagerTests {
 
     func test_givenFeature_thenSuggestsEssentialsAllAndPlatform() async {
         let sut = await IAPManager(products: [.Features.trustedNetworks])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
         ])
@@ -359,32 +359,32 @@ extension IAPManagerTests {
 
     func test_givenLifetime_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Complete.OneTime.lifetime])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [])
     }
 
     func test_givenRecurringMonthly_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Complete.Recurring.monthly])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [])
     }
 
     func test_givenRecurringYearly_thenSuggestsNothing() async {
         let sut = await IAPManager(products: [.Complete.Recurring.yearly])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS), [])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .iOS), [])
+        XCTAssertEqual(sut.essentialProducts(on: .macOS), [])
     }
 
     func test_givenFree_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.Recurring.yearly,
             .Complete.Recurring.monthly,
             .Complete.OneTime.lifetime
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.Recurring.yearly,
@@ -395,14 +395,14 @@ extension IAPManagerTests {
 
     func test_givenOldProducts_whenWithComplete_thenSuggestsEssentialsAndComplete() async {
         let sut = await IAPManager(products: [.Features.trustedNetworks])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS,
             .Complete.OneTime.lifetime,
             .Complete.Recurring.monthly,
             .Complete.Recurring.yearly
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS,
             .Complete.OneTime.lifetime,
@@ -413,13 +413,54 @@ extension IAPManagerTests {
 
     func test_givenNewProducts_whenWithComplete_thenSuggestsEssentials() async {
         let sut = await IAPManager(products: [.Features.appleTV])
-        XCTAssertEqual(sut.suggestedProducts(for: .iOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .iOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.iOS
         ])
-        XCTAssertEqual(sut.suggestedProducts(for: .macOS, filters: [.complete]), [
+        XCTAssertEqual(sut.essentialProducts(on: .macOS, filters: [.complete]), [
             .Essentials.iOS_macOS,
             .Essentials.macOS
+        ])
+    }
+}
+
+// MARK: - Suggestions (Individual)
+
+extension IAPManagerTests {
+    func test_givenFree_whenSuggestMixedFeatures_thenSuggestsEssentials() async {
+        let sut = await IAPManager(products: [])
+        let features: Set<AppFeature> = [.appleTV, .dns]
+        XCTAssertEqual(sut.individualProducts(for: features, on: .iOS), [
+            .Essentials.iOS_macOS,
+            .Essentials.iOS,
+            .Features.appleTV
+        ])
+        XCTAssertEqual(sut.individualProducts(for: features, on: .macOS), [
+            .Essentials.iOS_macOS,
+            .Essentials.macOS,
+            .Features.appleTV
+        ])
+    }
+
+    func test_givenFree_whenSuggestNonEssentialFeature_thenDoesNotSuggestEssentials() async {
+        let sut = await IAPManager(products: [])
+        let features: Set<AppFeature> = [.appleTV]
+        XCTAssertEqual(sut.individualProducts(for: features, on: .iOS), [
+            .Features.appleTV
+        ])
+        XCTAssertEqual(sut.individualProducts(for: features, on: .macOS), [
+            .Features.appleTV
+        ])
+    }
+
+    func test_givenFree_whenSuggestNonEssentialImplyingEssentialFeature_thenDoesNotSuggestEssentials() async {
+        let sut = await IAPManager(products: [])
+        let features: Set<AppFeature> = [.appleTV, .sharing]
+        XCTAssertEqual(sut.individualProducts(for: features, on: .iOS), [
+            .Features.appleTV
+        ])
+        XCTAssertEqual(sut.individualProducts(for: features, on: .macOS), [
+            .Features.appleTV
         ])
     }
 }
@@ -616,8 +657,18 @@ private extension IAPManager {
         await reloadReceipt()
     }
 
-    // BEWARE: default value filters in suggestedProducts() is [.complete]
-    func suggestedProducts(for platform: Platform) -> Set<AppProduct> {
-        suggestedProducts(for: platform, filters: [])
+    func essentialProducts(
+        on platform: Platform,
+        filters: Set<SuggestionFilter> = []
+    ) -> Set<AppProduct> {
+        suggestedProducts(for: AppFeature.essentialFeatures, on: platform, filters: filters)
+    }
+
+    func individualProducts(
+        for features: Set<AppFeature>,
+        on platform: Platform,
+        filters: Set<SuggestionFilter> = []
+    ) -> Set<AppProduct> {
+        suggestedProducts(for: features, on: platform, filters: filters)
     }
 }


### PR DESCRIPTION
We want to offer a "Purchase" button in the purchase confirmation alert, in addition to the "Connect" and "Save anyway" fallback actions. This is problematic in case the profile requires the purchase of more than 1 product, because StoreKit only allows 1 purchase at a time.

Therefore, split the paywall into two sections:

- Complete packages (if eligible)
- Individual purchases

In the case of individual purchases, let the user purchase them one at a time. Gray out the purchased ones, and dismiss the paywall after purchasing all of them.

The PR prepares for the reintroduction of the paywall on tvOS, but this will be done later (it crashes now). For now, share the paywall view logic in PaywallCoordinator and split the iOS/macOS (+Main) and tvOS (+TV) layouts.