### PR TITLE
API: Remove ProtonVPN for discontinuing support of public API

### DIFF
--- a/fastlane/metadata/iOS/de-DE/description.txt
+++ b/fastlane/metadata/iOS/de-DE/description.txt
@@ -11,7 +11,6 @@ Passepartout unterstützt Voreinstellungen für beliebte VPN-Anbieter, sodass Si
 - NordVPN
 - Oeck
 - PIA
-- ProtonVPN
 - Surfshark
 - TorGuard
 - TunnelBear

--- a/fastlane/metadata/iOS/el/description.txt
+++ b/fastlane/metadata/iOS/el/description.txt
@@ -11,7 +11,6 @@
 - NordVPN
 - Oeck
 - PIA
-- ProtonVPN
 - Surfshark
 - TorGuard
 - TunnelBear

--- a/fastlane/metadata/iOS/en-US/description.txt
+++ b/fastlane/metadata/iOS/en-US/description.txt
@@ -11,7 +11,6 @@ Passepartout supports presets for popular VPN providers, making it easy to conne
 - NordVPN
 - Oeck
 - PIA
-- ProtonVPN
 - Surfshark
 - TorGuard
 - TunnelBear

--- a/fastlane/metadata/iOS/es-MX/description.txt
+++ b/fastlane/metadata/iOS/es-MX/description.txt
@@ -11,7 +11,6 @@ Passepartout admite configuraciones para los proveedores de VPN más populares, 
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/fr-FR/description.txt
+++ b/fastlane/metadata/iOS/fr-FR/description.txt
@@ -11,7 +11,6 @@ Passepartout prend en charge les préréglages pour les fournisseurs VPN les plu
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/it/description.txt
+++ b/fastlane/metadata/iOS/it/description.txt
@@ -11,7 +11,6 @@ Passepartout supporta preset per i principali fornitori di VPN, rendendo facile 
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/nl-NL/description.txt
+++ b/fastlane/metadata/iOS/nl-NL/description.txt
@@ -11,7 +11,6 @@ Passepartout ondersteunt presets voor populaire VPN-providers, zodat je eenvoudi
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/pl/description.txt
+++ b/fastlane/metadata/iOS/pl/description.txt
@@ -11,7 +11,6 @@ Passepartout obsługuje konfiguracje dla popularnych dostawców VPN, co ułatwia
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/pt-BR/description.txt
+++ b/fastlane/metadata/iOS/pt-BR/description.txt
@@ -11,7 +11,6 @@ Passepartout oferece suporte a configurações para os provedores de VPN mais po
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/ru/description.txt
+++ b/fastlane/metadata/iOS/ru/description.txt
@@ -11,7 +11,6 @@ Passepartout поддерживает предустановки для попу
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  

--- a/fastlane/metadata/iOS/sv/description.txt
+++ b/fastlane/metadata/iOS/sv/description.txt
@@ -11,7 +11,6 @@ Passepartout stöder förinställningar för populära VPN-leverantörer, vilket
 - NordVPN  
 - Oeck  
 - PIA  
-- ProtonVPN  
 - Surfshark  
 - TorGuard  
 - TunnelBear  


### PR DESCRIPTION
Until there's an official way to authenticate HTTP calls.