### PR TITLE
Use whole ProviderModule to fetch an infrastructure

### DIFF
--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -264,7 +264,6 @@ private struct ProviderServerCoordinatorIfSupported: View {
         if let supporting = module as? ProviderModule {
             ProviderServerCoordinator(
                 module: supporting,
-                selectedEntity: supporting.entity,
                 selectTitle: selectTitle,
                 onSelect: {
                     var newBuilder = supporting.builder()

--- a/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/App/AppCoordinator.swift
@@ -263,8 +263,7 @@ private struct ProviderServerCoordinatorIfSupported: View {
     var body: some View {
         if let supporting = module as? ProviderModule {
             ProviderServerCoordinator(
-                providerId: supporting.providerId,
-                moduleType: supporting.providerModuleType,
+                module: supporting,
                 selectedEntity: supporting.entity,
                 selectTitle: selectTitle,
                 onSelect: {

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderModule+UI.swift
@@ -78,7 +78,6 @@ private struct DestinationView: View {
                 module.map {
                     ProviderServerView(
                         module: $0,
-                        selectedEntity: draft.module.entity,
                         onSelect: {
                             draft.module.entity = $0
                             path.removeLast()

--- a/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderModule+UI.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Modules/Provider/ProviderModule+UI.swift
@@ -75,11 +75,9 @@ private struct DestinationView: View {
         Group {
             switch route {
             case .server:
-                if let providerId = draft.module.providerId,
-                   let providerModuleType = draft.module.providerModuleType {
+                module.map {
                     ProviderServerView(
-                        providerId: providerId,
-                        moduleType: providerModuleType,
+                        module: $0,
                         selectedEntity: draft.module.entity,
                         onSelect: {
                             draft.module.entity = $0
@@ -92,6 +90,11 @@ private struct DestinationView: View {
                 ProviderView.OpenVPNCredentialsView(draft: draft)
             }
         }
+    }
+
+    // FIXME: #1470, heavy data copy in SwiftUI
+    private var module: ProviderModule? {
+        try? draft.module.tryBuild()
     }
 }
 

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderFiltersView.swift
@@ -28,7 +28,9 @@ import CommonLibrary
 import SwiftUI
 
 struct ProviderFiltersView: View {
-    let providerId: ProviderID
+
+    // FIXME: #1470, heavy data copy in SwiftUI
+    let module: ProviderModule
 
     @ObservedObject
     var model: Model
@@ -50,7 +52,7 @@ struct ProviderFiltersView: View {
                 HStack {
                     favoritesToggle
                     Spacer()
-                    RefreshInfrastructureButton(providerId: providerId)
+                    RefreshInfrastructureButton(module: module)
                     clearFiltersButton
                 }
 #endif
@@ -113,10 +115,12 @@ private extension ProviderFiltersView {
     }
 }
 
+// MARK: - Preview
+
 #Preview {
     NavigationStack {
         ProviderFiltersView(
-            providerId: .mullvad,
+            module: ProviderID.mullvad.asPreviewModule,
             model: .init(kvManager: KeyValueManager()),
             heuristic: .constant(nil)
         )

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerCoordinator.swift
@@ -35,9 +35,6 @@ struct ProviderServerCoordinator: View {
     // FIXME: #1470, heavy data copy in SwiftUI
     let module: ProviderModule
 
-    // FIXME: #1470, heavy data copy in SwiftUI
-    let selectedEntity: ProviderEntity?
-
     let selectTitle: String
 
     let onSelect: (ProviderEntity) async throws -> Void
@@ -48,7 +45,6 @@ struct ProviderServerCoordinator: View {
     var body: some View {
         ProviderServerView(
             module: module,
-            selectedEntity: selectedEntity,
             selectTitle: selectTitle,
             onSelect: onSelect
         )

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerCoordinator.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerCoordinator.swift
@@ -32,10 +32,10 @@ struct ProviderServerCoordinator: View {
     @Environment(\.dismiss)
     private var dismiss
 
-    let providerId: ProviderID
+    // FIXME: #1470, heavy data copy in SwiftUI
+    let module: ProviderModule
 
-    let moduleType: ModuleType
-
+    // FIXME: #1470, heavy data copy in SwiftUI
     let selectedEntity: ProviderEntity?
 
     let selectTitle: String
@@ -47,8 +47,7 @@ struct ProviderServerCoordinator: View {
 
     var body: some View {
         ProviderServerView(
-            providerId: providerId,
-            moduleType: moduleType,
+            module: module,
             selectedEntity: selectedEntity,
             selectTitle: selectTitle,
             onSelect: onSelect

--- a/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/ProviderServerView.swift
@@ -38,9 +38,6 @@ struct ProviderServerView: View {
     // FIXME: #1470, heavy data copy in SwiftUI
     let module: ProviderModule
 
-    // FIXME: #1470, heavy data copy in SwiftUI
-    let selectedEntity: ProviderEntity?
-
     var selectTitle = Strings.Views.Providers.selectEntity
 
     let onSelect: (ProviderEntity) -> Void
@@ -94,7 +91,6 @@ extension ProviderServerView {
         ContentView(
             module: module,
             servers: filteredServers,
-            selectedServer: selectedEntity?.server,
             heuristic: $heuristic,
             isFiltering: isFiltering,
             filtersViewModel: filtersViewModel,
@@ -103,7 +99,7 @@ extension ProviderServerView {
             onSelect: onSelectServer
         )
         .onLoad {
-            heuristic = selectedEntity?.heuristic
+            heuristic = module.entity?.heuristic
         }
         .task {
             await loadInitialServers()
@@ -145,7 +141,7 @@ private extension ProviderServerView {
     }
 
     var initialFilters: ProviderFilters? {
-        guard let selectedEntity else {
+        guard let selectedEntity = module.entity else {
             return nil
         }
         var filters = ProviderFilters()
@@ -247,7 +243,6 @@ extension ProviderID {
     NavigationStack {
         ProviderServerView(
             module: ProviderID.hideme.asPreviewModule,
-            selectedEntity: nil as ProviderEntity?,
             selectTitle: "Select",
             onSelect: { _ in }
         )

--- a/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
@@ -37,8 +37,6 @@ extension ProviderServerView {
 
         let servers: [ProviderServer]
 
-        let selectedServer: ProviderServer?
-
         @Binding
         var heuristic: ProviderHeuristic?
 
@@ -92,7 +90,7 @@ private extension ProviderServerView.ContentView {
                 header: filtersViewModel.filters.categoryName ?? Strings.Views.Vpn.Category.any
             )
             .onLoad {
-                if let selectedServer {
+                if let selectedServer = module.entity?.server {
                     expandedCodes.insert(selectedServer.metadata.countryCode)
                 }
             }

--- a/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/iOS/ProviderServer+Content+iOS.swift
@@ -31,7 +31,9 @@ import UIAccessibility
 
 extension ProviderServerView {
     struct ContentView: View {
-        let providerId: ProviderID
+
+        // FIXME: #1470, heavy data copy in SwiftUI
+        let module: ProviderModule
 
         let servers: [ProviderServer]
 
@@ -72,7 +74,7 @@ private extension ProviderServerView.ContentView {
         List {
             Section {
                 Toggle(Strings.Views.Providers.onlyFavorites, isOn: $filtersViewModel.onlyShowsFavorites)
-                RefreshInfrastructureButton(providerId: providerId)
+                RefreshInfrastructureButton(module: module)
             }
             Group {
                 if isFiltering || !servers.isEmpty {

--- a/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
@@ -39,8 +39,6 @@ extension ProviderServerView {
 
         let servers: [ProviderServer]
 
-        let selectedServer: ProviderServer?
-
         @Binding
         var heuristic: ProviderHeuristic?
 

--- a/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
+++ b/Packages/App/Sources/AppUIMain/Views/Providers/macOS/ProviderServer+Content+macOS.swift
@@ -34,7 +34,8 @@ extension ProviderServerView {
         @EnvironmentObject
         private var theme: Theme
 
-        let providerId: ProviderID
+        // FIXME: #1470, heavy data copy in SwiftUI
+        let module: ProviderModule
 
         let servers: [ProviderServer]
 

--- a/Passepartout/App/Context/DefaultAppProcessor.swift
+++ b/Passepartout/App/Context/DefaultAppProcessor.swift
@@ -139,7 +139,8 @@ private extension ProviderModule.Builder {
         guard let providerId, let providerModuleType, let entity else {
             return
         }
-        let repo = try await apiManager.providerRepository(for: providerId)
+        let module = try ProviderModule.Builder(providerId: providerId, providerModuleType: providerModuleType).tryBuild()
+        let repo = try await apiManager.providerRepository(for: module)
         let providerManager = ProviderManager()
         try await providerManager.setRepository(repo, for: providerModuleType)
 


### PR DESCRIPTION
Prepare for more complex API calls with provider auth/metadata.

Add FIXMEs for heavy copies in SwiftUI (#1470), given that the provider views suck in general.