### PR TITLE
Prevent coalescing foreground tasks

### DIFF
--- a/Packages/App/Sources/CommonLibrary/Business/ConfigManager.swift
+++ b/Packages/App/Sources/CommonLibrary/Business/ConfigManager.swift
@@ -37,6 +37,8 @@ public final class ConfigManager: ObservableObject {
     @Published
     private var bundle: ConfigBundle?
 
+    private var isPending = false
+
     public init() {
         strategy = nil
     }
@@ -49,6 +51,13 @@ public final class ConfigManager: ObservableObject {
     public func refreshBundle() async {
         guard let strategy else {
             return
+        }
+        guard !isPending else {
+            return
+        }
+        isPending = true
+        defer {
+            isPending = false
         }
         do {
             pp_log_g(.app, .debug, "Config: refreshing bundle...")

--- a/Packages/App/Sources/CommonLibrary/Strategy/GitHubConfigStrategy.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/GitHubConfigStrategy.swift
@@ -1,5 +1,5 @@
 //
-//  WebConfigStrategy.swift
+//  GitHubConfigStrategy.swift
 //  Passepartout
 //
 //  Created by Davide De Rosa on 7/8/25.
@@ -27,7 +27,7 @@ import Foundation
 import GenericJSON
 
 @MainActor
-public final class WebConfigStrategy: ConfigManagerStrategy {
+public final class GitHubConfigStrategy: ConfigManagerStrategy {
     private let url: URL
 
     private let ttl: TimeInterval
@@ -44,11 +44,11 @@ public final class WebConfigStrategy: ConfigManagerStrategy {
         if lastUpdated > .distantPast {
             let elapsed = -lastUpdated.timeIntervalSinceNow
             guard elapsed >= ttl else {
-                pp_log_g(.app, .debug, "Config: elapsed \(elapsed) < \(ttl)")
+                pp_log_g(.app, .debug, "Config (GitHub): elapsed \(elapsed) < \(ttl)")
                 throw AppError.rateLimit
             }
         }
-        pp_log_g(.app, .debug, "Config: fetching bundle from \(url)")
+        pp_log_g(.app, .debug, "Config (GitHub): fetching bundle from \(url)")
         var request = URLRequest(url: url)
         request.cachePolicy = .reloadIgnoringCacheData
         let result = try await URLSession.shared.data(for: request)

--- a/Packages/App/Sources/CommonLibrary/Strategy/GitHubReleaseStrategy.swift
+++ b/Packages/App/Sources/CommonLibrary/Strategy/GitHubReleaseStrategy.swift
@@ -40,7 +40,7 @@ public final class GitHubReleaseStrategy: VersionCheckerStrategy {
         if since > .distantPast {
             let elapsed = -since.timeIntervalSinceNow
             guard elapsed >= rateLimit else {
-                pp_log_g(.app, .debug, "GitHub: elapsed \(elapsed) < \(rateLimit)")
+                pp_log_g(.app, .debug, "Version (GitHub): elapsed \(elapsed) < \(rateLimit)")
                 throw AppError.rateLimit
             }
         }
@@ -52,7 +52,7 @@ public final class GitHubReleaseStrategy: VersionCheckerStrategy {
         let json = try JSONDecoder().decode(VersionJSON.self, from: result.0)
         let newVersion = json.name
         guard let semNew = SemanticVersion(newVersion) else {
-            pp_log_g(.app, .error, "GitHub: unparsable release name '\(newVersion)'")
+            pp_log_g(.app, .error, "Version (GitHub): unparsable release name '\(newVersion)'")
             throw AppError.unexpectedResponse
         }
         return semNew

--- a/Passepartout/App/Context/AppContext+Production.swift
+++ b/Passepartout/App/Context/AppContext+Production.swift
@@ -269,7 +269,7 @@ extension AppContext {
         let configURL = Constants.shared.websites.config
 #endif
         let configManager = ConfigManager(
-            strategy: WebConfigStrategy(
+            strategy: GitHubConfigStrategy(
                 url: configURL,
                 ttl: Constants.shared.websites.configTTL
             )


### PR DESCRIPTION
Avoid duplicated tasks to:

- Check for updates
- Fetch config bundle

with a simple isPending flag.