### PR TITLE
Split TV-related feature flags

### DIFF
--- a/Packages/App/Sources/AppLibraryTV/Views/Profiles/ProfilesView.swift
+++ b/Packages/App/Sources/AppLibraryTV/Views/Profiles/ProfilesView.swift
@@ -38,7 +38,7 @@ struct ProfilesView: View {
 private extension ProfilesView {
     var masterView: some View {
         List {
-            if configManager.canSendToTV {
+            if configManager.canImportToTV {
                 importSection
             }
             if profileManager.hasProfiles {
@@ -48,7 +48,7 @@ private extension ProfilesView {
         .themeList()
         .frame(maxWidth: .infinity)
         .themeEmpty(
-            if: !configManager.canSendToTV && !profileManager.hasProfiles,
+            if: !configManager.canImportToTV && !profileManager.hasProfiles,
             message: Strings.Views.App.Folders.noProfiles
         )
     }

--- a/Packages/App/Sources/CommonLibrary/Domain/ConfigFlag.swift
+++ b/Packages/App/Sources/CommonLibrary/Domain/ConfigFlag.swift
@@ -5,7 +5,8 @@
 public enum ConfigFlag: String, RawRepresentable, Codable, Sendable {
     case appNotWorking
     case newPaywall
-    case sendToTV
+    case tvSendTo
+    case tvWebImport
 }
 
 extension ConfigFlag: CustomStringConvertible {

--- a/Packages/App/Sources/CommonLibrary/Extensions/ConfigManager+Extensions.swift
+++ b/Packages/App/Sources/CommonLibrary/Extensions/ConfigManager+Extensions.swift
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0
 
 extension ConfigManager {
+    public var canImportToTV: Bool {
+        isActive(.newPaywall) && isActive(.tvWebImport)
+    }
+
     public var canSendToTV: Bool {
-        isActive(.newPaywall) && isActive(.sendToTV)
+        isActive(.newPaywall) && isActive(.tvSendTo)
     }
 }

--- a/Passepartout/App/Context/test-bundle.json
+++ b/Passepartout/App/Context/test-bundle.json
@@ -2,7 +2,10 @@
     "newPaywall": {
         "rate": 100
     },
-    "sendToTV": {
+    "tvSendTo": {
+        "rate": 100
+    },
+    "tvWebImport": {
         "rate": 100
     },
     "appNotWorking": {


### PR DESCRIPTION
- .tvWebImport, for the tvOS web import interface
- .tvSendTo, for the iOS/macOS "Send to TV" button