### PR TITLE
Send profile to TV without saving it

### DIFF
--- a/Packages/App/Sources/AppLibrary/Extensions/ProfileEditor+Save.swift
+++ b/Packages/App/Sources/AppLibrary/Extensions/ProfileEditor+Save.swift
@@ -13,7 +13,7 @@ extension ProfileEditor {
     }
 
     public func save(
-        to profileManager: ProfileManager,
+        to profileManager: ProfileManager?,
         buildingWith registry: Registry,
         verifyingWith iapManager: IAPManager?,
         preferencesManager: PreferencesManager
@@ -38,8 +38,8 @@ extension ProfileEditor {
             }
         }
 
-        // persist
-        try await profileManager.save(profileToSave, isLocal: true, remotelyShared: isShared)
+        // persist (optional)
+        try await profileManager?.save(profileToSave, isLocal: true, remotelyShared: isShared)
 
         // clean up module preferences
         removedModules.keys.forEach {

--- a/Packages/App/Sources/AppLibraryMain/Views/Profile/ProfileCoordinator.swift
+++ b/Packages/App/Sources/AppLibraryMain/Views/Profile/ProfileCoordinator.swift
@@ -210,12 +210,12 @@ private extension ProfileCoordinator {
     func sendProfileToTV() {
         Task {
             do {
-                guard let profile = try await commitEditing(
-                    action: nil, // skip profile verification and thus paywall
-                    dismissing: false
-                ) else {
-                    return
-                }
+                let profile = try await profileEditor.save(
+                    to: nil,
+                    buildingWith: registry,
+                    verifyingWith: nil,
+                    preferencesManager: preferencesManager
+                )
                 modalRoute = .sendToTV(profile)
             } catch {
                 errorHandler.handle(error, title: Strings.Global.Actions.save)


### PR DESCRIPTION
Avoids a reconnection on send due to the AppContext.onSaveProfile() observer of the ProfileManager.didChange events.

Simplify saveProfile() and commitEditing() with non-optional action. Committing always requires verification now that sendProfileToTV() no longer uses commitEditing(), but profileEditor.save() directly.

Fixes #1435