### PR TITLE
Constrain configurations to minimum build number

### DIFF
--- a/app-apple/Package/Sources/CommonLibrary/Business/ConfigManager.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Business/ConfigManager.swift
@@ -45,7 +45,8 @@ public final class ConfigManager: ObservableObject {
             pp_log_g(.app, .debug, "Config: refreshing bundle...")
             let newBundle = try await strategy.bundle()
             bundle = newBundle
-            pp_log_g(.app, .info, "Config: active flags = \(newBundle.activeFlags)")
+            let activeFlags = newBundle.activeFlags(withBuild: buildNumber)
+            pp_log_g(.app, .info, "Config: active flags = \(activeFlags)")
             pp_log_g(.app, .debug, "Config: \(newBundle)")
         } catch AppError.rateLimit {
             pp_log_g(.app, .debug, "Config: TTL")
@@ -68,10 +69,8 @@ private extension ConfigManager {
         guard let map = bundle?.map[flag] else {
             return nil
         }
-        if let minBuild = map.minBuild {
-            guard buildNumber >= minBuild else {
-                return nil
-            }
+        guard map.isActive(withBuild: buildNumber) else {
+            return nil
         }
         return map
     }

--- a/app-apple/Package/Sources/CommonLibrary/Business/ConfigManager.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Business/ConfigManager.swift
@@ -21,7 +21,7 @@ public final class ConfigManager: ObservableObject {
 
     public init() {
         strategy = nil
-        buildNumber = .max
+        buildNumber = .max // activate flags regardless of .minBuild
     }
 
     public init(strategy: ConfigManagerStrategy, buildNumber: Int) {

--- a/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
@@ -10,6 +10,12 @@ public struct ConfigBundle: Decodable {
 
         public let data: JSON?
 
+        init(rate: Int, minBuild: Int?, data: JSON?) {
+            self.rate = rate
+            self.minBuild = minBuild
+            self.data = data
+        }
+
         public func isActive(withBuild buildNumber: Int) -> Bool {
             if let minBuild, buildNumber < minBuild {
                 return false
@@ -20,6 +26,10 @@ public struct ConfigBundle: Decodable {
 
     // flag -> deployment (0-100)
     public let map: [ConfigFlag: Config]
+
+    init(map: [ConfigFlag : Config]) {
+        self.map = map
+    }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
@@ -11,10 +11,8 @@ public struct ConfigBundle: Decodable {
         public let data: JSON?
 
         public func isActive(withBuild buildNumber: Int) -> Bool {
-            if let minBuild {
-                guard buildNumber >= minBuild else {
-                    return false
-                }
+            if let minBuild, buildNumber < minBuild {
+                return false
             }
             return rate == 100
         }

--- a/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
@@ -9,6 +9,15 @@ public struct ConfigBundle: Decodable {
         public let minBuild: Int?
 
         public let data: JSON?
+
+        public func isActive(withBuild buildNumber: Int) -> Bool {
+            if let minBuild {
+                guard buildNumber >= minBuild else {
+                    return false
+                }
+            }
+            return rate == 100
+        }
     }
 
     // flag -> deployment (0-100)
@@ -26,7 +35,10 @@ public struct ConfigBundle: Decodable {
             }
     }
 
-    public var activeFlags: Set<ConfigFlag> {
-        Set(map.filter { $0.value.rate == 100 }.keys)
+    public func activeFlags(withBuild buildNumber: Int) -> Set<ConfigFlag> {
+        let flags = map.filter {
+            $0.value.isActive(withBuild: buildNumber)
+        }
+        return Set(flags.keys)
     }
 }

--- a/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Domain/ConfigBundle.swift
@@ -6,6 +6,8 @@ public struct ConfigBundle: Decodable {
     public struct Config: Codable {
         public let rate: Int
 
+        public let minBuild: Int?
+
         public let data: JSON?
     }
 

--- a/app-apple/Package/Tests/CommonLibraryTests/Domain/ConfigBundleTests.swift
+++ b/app-apple/Package/Tests/CommonLibraryTests/Domain/ConfigBundleTests.swift
@@ -16,4 +16,15 @@ struct ConfigBundleTests {
         let activeFlags: Set<ConfigFlag> = isActive ? [.newPaywall] : []
         #expect(sut.activeFlags(withBuild: 1) == activeFlags)
     }
+
+    @Test(arguments: [
+        ([ConfigFlag.newPaywall: ConfigBundle.Config(rate: 100, minBuild: nil, data: nil)], true),
+        ([ConfigFlag.newPaywall: ConfigBundle.Config(rate: 100, minBuild: 500, data: nil)], true),
+        ([ConfigFlag.newPaywall: ConfigBundle.Config(rate: 100, minBuild: 1000, data: nil)], false)
+    ])
+    func givenBundle_whenMinBuild_thenIsActive(map: [ConfigFlag: ConfigBundle.Config], isActive: Bool) {
+        let sut = ConfigBundle(map: map)
+        let activeFlags: Set<ConfigFlag> = isActive ? [.newPaywall] : []
+        #expect(sut.activeFlags(withBuild: 750) == activeFlags)
+    }
 }

--- a/app-apple/Package/Tests/CommonLibraryTests/Domain/ConfigBundleTests.swift
+++ b/app-apple/Package/Tests/CommonLibraryTests/Domain/ConfigBundleTests.swift
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+@testable import CommonLibrary
+import Testing
+
+struct ConfigBundleTests {
+    @Test(arguments: [
+        ([ConfigFlag.newPaywall: ConfigBundle.Config(rate: 10, minBuild: nil, data: nil)], false),
+        ([ConfigFlag.newPaywall: ConfigBundle.Config(rate: 100, minBuild: nil, data: nil)], true),
+        ([ConfigFlag.newPaywall: ConfigBundle.Config(rate: 200, minBuild: nil, data: nil)], false)
+    ])
+    func givenBundle_whenRate100_thenIsActive(map: [ConfigFlag: ConfigBundle.Config], isActive: Bool) {
+        let sut = ConfigBundle(map: map)
+        let activeFlags: Set<ConfigFlag> = isActive ? [.newPaywall] : []
+        #expect(sut.activeFlags(withBuild: 1) == activeFlags)
+    }
+}

--- a/app-apple/Passepartout/App/Context/AppContext+Production.swift
+++ b/app-apple/Passepartout/App/Context/AppContext+Production.swift
@@ -278,7 +278,8 @@ extension AppContext {
                 isBeta: { [weak iapManager] in
                     iapManager?.isBeta == true
                 }
-            )
+            ),
+            buildNumber: BundleConfiguration.mainBuildNumber
         )
 
         // MARK: Version

--- a/app-apple/Passepartout/Passepartout.xctestplan
+++ b/app-apple/Passepartout/Passepartout.xctestplan
@@ -14,14 +14,21 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:Packages\/App",
-        "identifier" : "CommonUtilsTests",
-        "name" : "CommonUtilsTests"
+        "containerPath" : "container:Package",
+        "identifier" : "AppLibraryTests",
+        "name" : "AppLibraryTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:Packages\/App",
+        "containerPath" : "container:Package",
+        "identifier" : "CommonLibraryTests",
+        "name" : "CommonLibraryTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Package",
         "identifier" : "AppLibraryMainTests",
         "name" : "AppLibraryMainTests"
       }
@@ -35,30 +42,22 @@
       }
     },
     {
-      "parallelizable" : true,
       "target" : {
-        "containerPath" : "container:Packages\/App",
-        "identifier" : "CommonLibraryTests",
-        "name" : "CommonLibraryTests"
+        "containerPath" : "container:Package",
+        "identifier" : "CommonUtilsTests",
+        "name" : "CommonUtilsTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:Packages\/App",
-        "identifier" : "AppLibraryTests",
-        "name" : "AppLibraryTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:Packages\/App",
+        "containerPath" : "container:Package",
         "identifier" : "CommonWebTests",
         "name" : "CommonWebTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:Packages\/App",
+        "containerPath" : "container:Package",
         "identifier" : "CommonLegacyV2Tests",
         "name" : "CommonLegacyV2Tests"
       }


### PR DESCRIPTION
Add an optional `minBuild` field to activate configurations only past a given build number.