### PR TITLE
Update Partout with new Core deployment

### DIFF
--- a/ci/use-partout-core-source.sh
+++ b/ci/use-partout-core-source.sh
@@ -1,22 +1,36 @@
 #!/bin/bash
-manifest="submodules/partout/Package.swift"
-core_status=`git submodule status submodules/partout-core`
-sha1=${core_status:1:40}
+partout="submodules/partout"
+partout_core="vendors/core"
 
+# Local Core submodule
+local_core="submodules/partout-core"
+local_core_status=`git submodule status $local_core`
+local_core_sha1=${local_core_status:1:40}
+
+# Ensure that the Partout submodule is on the same Core version
+partout_core_status=`cd $partout && git submodule status $partout_core`
+partout_core_sha1=${partout_core_status:1:40}
+
+set -e
+
+echo "Core SHA-1 locally:      $local_core_sha1"
+echo "Core SHA-1 in submodule: $partout_core_sha1"
+if [ "${local_core_sha1}" != "${partout_core_sha1}" ]; then
+    echo "Core SHA-1 in submodule doesn't match local"
+    exit 1
+fi
+
+# Perform these inside Partout submodule
+pushd $partout
 env_line_old='let coreDeployment = envCoreDeployment \?\? \.remoteBinary'
-env_line_new='let coreDeployment = envCoreDeployment \?\? .remoteSource'
-sed -E -i '' "s/^${env_line_old}$/${env_line_new}/" "$manifest"
-if ! grep -E -q "^${env_line_new}$" "$manifest"; then
+env_line_new='let coreDeployment = envCoreDeployment \?\? .localSource'
+sed -E -i '' "s/^${env_line_old}$/${env_line_new}/" Package.swift
+if ! grep -E -q "^${env_line_new}$" Package.swift; then
     echo "Unable to set Core deployment"
     exit 1
 fi
+git submodule init $partout_core
+git submodule update --depth 1 $partout_core
+popd
 
-sha1_line_pattern="let coreSourceSHA1 = .*"
-sha1_line_new="let coreSourceSHA1 = \"${sha1}\""
-sed -E -i '' "s/^${sha1_line_pattern}$/${sha1_line_new}/" "$manifest"
-if ! grep -E -q "^${sha1_line_new}$" "$manifest"; then
-    echo "Unable to set SHA-1"
-    exit 1
-fi
-
-echo "Updated partout manifest, partout-core -> $sha1"
+echo "Updated partout manifest, partout-core -> $local_core_sha1"


### PR DESCRIPTION
Partout now relies on submodules for versioning, rather than a fragile SHA-1 in Package.swift. Therefore, ensure that the local Core submodule and the one in Partout are on the same page, because this will affect the build outcome in CI.

This must pass the "Full Tests" workflow.