### PR TITLE
Update Partout with better tunnel/profile arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tmp/
 *.so
 *.lib
 *.dll
+*.dmg

--- a/app-apple/Package/Tests/CommonLibraryTests/Mock/MockTunnelProcessor.swift
+++ b/app-apple/Package/Tests/CommonLibraryTests/Mock/MockTunnelProcessor.swift
@@ -5,7 +5,7 @@
 import CommonLibrary
 import Foundation
 
-final class MockTunnelProcessor: AppTunnelProcessor {
+final class MockTunnelProcessor: AppTunnelProcessor, @unchecked Sendable {
     var titleCount = 0
 
     var willInstallCount = 0

--- a/app-apple/Passepartout/Shared/Dependencies+Partout.swift
+++ b/app-apple/Passepartout/Shared/Dependencies+Partout.swift
@@ -35,7 +35,7 @@ extension Dependencies {
         )
     }
 
-    func neProtocolCoder(_ ctx: PartoutLoggerContext, registry: Registry) -> NEProtocolCoder {
+    nonisolated func neProtocolCoder(_ ctx: PartoutLoggerContext, registry: Registry) -> NEProtocolCoder {
         if Self.distributionTarget.supportsAppGroups {
             return KeychainNEProtocolCoder(
                 ctx,

--- a/app-apple/Passepartout/Shared/OpenVPNImplementationBuilder.swift
+++ b/app-apple/Passepartout/Shared/OpenVPNImplementationBuilder.swift
@@ -41,7 +41,7 @@ private extension OpenVPNImplementationBuilder {
         with parameters: ConnectionParameters,
         module: OpenVPNModule
     ) throws -> Connection {
-        let ctx = PartoutLoggerContext(parameters.controller.profile.id)
+        let ctx = PartoutLoggerContext(parameters.profile.id)
         var options = OpenVPN.ConnectionOptions()
         options.writeTimeout = TimeInterval(parameters.options.linkWriteTimeout) / 1000.0
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
@@ -66,7 +66,7 @@ private extension OpenVPNImplementationBuilder {
         with parameters: ConnectionParameters,
         module: OpenVPNModule
     ) throws -> Connection {
-        let ctx = PartoutLoggerContext(parameters.controller.profile.id)
+        let ctx = PartoutLoggerContext(parameters.profile.id)
         var options = OpenVPN.ConnectionOptions()
         options.writeTimeout = TimeInterval(parameters.options.linkWriteTimeout) / 1000.0
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0

--- a/app-apple/Passepartout/Shared/WireGuardImplementationBuilder.swift
+++ b/app-apple/Passepartout/Shared/WireGuardImplementationBuilder.swift
@@ -12,7 +12,7 @@ struct WireGuardImplementationBuilder: Sendable {
             importer: StandardWireGuardParser(),
             validator: StandardWireGuardParser(),
             connectionBlock: {
-                let ctx = PartoutLoggerContext($0.controller.profile.id)
+                let ctx = PartoutLoggerContext($0.profile.id)
                 return try WireGuardConnection(
                     ctx,
                     parameters: $0,

--- a/app-apple/Passepartout/Tunnel/DefaultTunnelProcessor.swift
+++ b/app-apple/Passepartout/Tunnel/DefaultTunnelProcessor.swift
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import CommonLibrary
-import Foundation
 
 final class DefaultTunnelProcessor: Sendable {
     init() {

--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -174,7 +174,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             await iapManager.fetchLevelIfNeeded()
             let isBeta = await iapManager.isBeta
             let params = constants.tunnel.verificationParameters(isBeta: isBeta)
-            pp_log(ctx, .app, .info, "Will start profile verification in \(params.delay) seconds")
+            pp_log(ctx, .App.iap, .info, "Will start profile verification in \(params.delay) seconds")
 
             // Start the tunnel (ignore all start options)
             try await fwd.startTunnel(options: [:])
@@ -302,7 +302,7 @@ private extension PacketTunnelProvider {
                 return
             }
             do {
-                pp_log(ctx, .app, .info, "Verify profile, requires: \(profile.features)")
+                pp_log(ctx, .App.iap, .info, "Verify profile, requires: \(profile.features)")
                 await iapManager.reloadReceipt()
                 try iapManager.verify(profile)
             } catch {
@@ -312,7 +312,7 @@ private extension PacketTunnelProvider {
                     // cases, retry a few times before failing
                     if attempts > 0 {
                         attempts -= 1
-                        pp_log(ctx, .app, .error, "Verification failed for profile \(profile.id), next attempt in \(params.retryInterval) seconds... (remaining: \(attempts), products: \(iapManager.purchasedProducts))")
+                        pp_log(ctx, .App.iap, .error, "Verification failed for profile \(profile.id), next attempt in \(params.retryInterval) seconds... (remaining: \(attempts), products: \(iapManager.purchasedProducts))")
                         try? await Task.sleep(interval: params.retryInterval)
                         continue
                     }
@@ -320,7 +320,7 @@ private extension PacketTunnelProvider {
 
                 let error = PartoutError(.App.ineligibleProfile)
                 environment.setEnvironmentValue(error.code, forKey: TunnelEnvironmentKeys.lastErrorCode)
-                pp_log(ctx, .app, .fault, "Verification failed for profile \(profile.id), shutting down: \(error)")
+                pp_log(ctx, .App.iap, .fault, "Verification failed for profile \(profile.id), shutting down: \(error)")
 
                 // Hold on failure to prevent on-demand reconnection
                 environment.setEnvironmentValue(true, forKey: TunnelEnvironmentKeys.holdFlag)
@@ -328,7 +328,7 @@ private extension PacketTunnelProvider {
                 return
             }
 
-            pp_log(ctx, .app, .info, "Will verify profile again in \(params.interval) seconds...")
+            pp_log(ctx, .App.iap, .info, "Will verify profile again in \(params.interval) seconds...")
             try? await Task.sleep(interval: params.interval)
 
             // On successful verification, reset attempts for the next verification

--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -74,12 +74,13 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         // Post-process profile (e.g. resolve and apply local preferences)
         let resolvedProfile = try registry.resolvedProfile(originalProfile)
         let processor = DefaultTunnelProcessor()
-        let profile = try processor.willProcess(resolvedProfile)
-        let environment = dependencies.tunnelEnvironment(profileId: originalProfile.id)
+        let processedProfile = try processor.willProcess(resolvedProfile)
+        assert(processedProfile.id == originalProfile.id)
+        let environment = dependencies.tunnelEnvironment(profileId: processedProfile.id)
 
         let neTunnelController = try await NETunnelController(
             provider: self,
-            profile: profile,
+            profile: processedProfile,
             options: {
                 var options = NETunnelController.Options()
                 if preferences.dnsFallsBack {
@@ -132,7 +133,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
             fwd = try NEPTPForwarder(
                 ctx,
-                profile: profile,
+                profile: processedProfile,
                 registry: registry,
                 controller: neTunnelController,
                 environment: environment,

--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -14,6 +14,9 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     private var verifierSubscription: Task<Void, Error>?
 
     override func startTunnel(options: [String: NSObject]? = nil) async throws {
+
+        // FIXME: #1508, register global logger ASAP (logs before registration are lost)
+
         let startPreferences: AppPreferenceValues?
         if let encodedPreferences = options?[ExtendedTunnel.appPreferences] as? NSData {
             do {
@@ -32,8 +35,6 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         let dependencies: Dependencies = await .shared
         let distributionTarget = Dependencies.distributionTarget
         let constants: Constants = .shared
-
-        // FIXME: #1508, register global logger here
 
         // MARK: Update or fetch existing preferences
 
@@ -66,6 +67,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             originalProfile = try Profile(withNEProvider: self, decoder: decoder)
         } catch {
             pp_log_g(.App.profiles, .fault, "Unable to decode profile: \(error)")
+            flushLogs()
             throw error
         }
 
@@ -87,6 +89,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             assert(processedProfile.id == originalProfile.id)
         } catch {
             pp_log(ctx, .App.profiles, .fault, "Unable to process profile: \(error)")
+            flushLogs()
             throw error
         }
 
@@ -107,6 +110,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             )
         } catch {
             pp_log(ctx, .app, .fault, "Unable to create NETunnelController: \(error)")
+            flushLogs()
             throw error
         }
 


### PR DESCRIPTION
Perform profile resolution and processing transparently, rather than inside NETunnelController. Same with environment, create it beforehand, rather than with a block argument. Much better for reuse and debugging.

See https://github.com/passepartoutvpn/partout/pull/191