### PR TITLE
Update Partout with OpenVPN TCP and WireGuard for Windows

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,1 +1,1 @@
-* Update Partout with cross-platform WireGuard connection implementation (#1543)
+* OpenVPN: Fix TCP breaking on fast uploads

--- a/app-android/app/src/main/cpp/CMakeLists.txt
+++ b/app-android/app/src/main/cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 # Library versions
-set(PARTOUT_SHA1 999e72d4)
+set(PARTOUT_SHA1 e4254355)
 set(SWIFT_VERSION 6.1)
 set(JNI_DIR ${CMAKE_SOURCE_DIR}/libs)
 

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -10,13 +10,13 @@
 #include "vpn.h"
 
 JNIEXPORT jstring JNICALL
-Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
+Java_com_algoritmico_partout_NativeLibraryWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
     jstring jmsg = (*env)->NewStringUTF(env, PARTOUT_VERSION);
     return jmsg;
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutInitialize(JNIEnv *env, jobject thiz, jstring cacheDir) {
+Java_com_algoritmico_partout_NativeLibraryWrapper_partoutInitialize(JNIEnv *env, jobject thiz, jstring cacheDir) {
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     partout_init_args args = { 0 };
@@ -29,12 +29,12 @@ Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutInitialize(JNIEnv 
 }
 
 JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutDeinitialize(JNIEnv *env, jobject thiz, jlong ctx) {
+Java_com_algoritmico_partout_NativeLibraryWrapper_partoutDeinitialize(JNIEnv *env, jobject thiz, jlong ctx) {
     partout_deinit((void *)ctx);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutDaemonStart(JNIEnv *env, jobject thiz, jlong ctx, jstring profile, jobject vpnWrapper) {
+Java_com_algoritmico_partout_NativeLibraryWrapper_partoutDaemonStart(JNIEnv *env, jobject thiz, jlong ctx, jstring profile, jobject vpnWrapper) {
     const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
 
     partout_daemon_start_args args = { 0 };
@@ -61,6 +61,6 @@ Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutDaemonStart(JNIEnv
 }
 
 JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_NativeLibraryWrapper_partoutDaemonStop(JNIEnv *env, jobject thiz, jlong ctx) {
+Java_com_algoritmico_partout_NativeLibraryWrapper_partoutDaemonStop(JNIEnv *env, jobject thiz, jlong ctx) {
     partout_daemon_stop((void *)ctx);
 }

--- a/app-android/app/src/main/java/com/algoritmico/partout/NativeLibraryWrapper.kt
+++ b/app-android/app/src/main/java/com/algoritmico/partout/NativeLibraryWrapper.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-package com.algoritmico.passepartout
+package com.algoritmico.partout
 import android.util.Log
 
 class NativeLibraryWrapper {

--- a/app-android/app/src/main/java/com/algoritmico/partout/VpnWrapper.kt
+++ b/app-android/app/src/main/java/com/algoritmico/partout/VpnWrapper.kt
@@ -1,4 +1,4 @@
-package com.algoritmico.passepartout
+package com.algoritmico.partout
 
 import android.net.VpnService
 import android.os.ParcelFileDescriptor

--- a/app-android/app/src/main/java/com/algoritmico/passepartout/DummyVPNService.kt
+++ b/app-android/app/src/main/java/com/algoritmico/passepartout/DummyVPNService.kt
@@ -7,6 +7,8 @@ import android.util.Log
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import com.algoritmico.partout.NativeLibraryWrapper
+import com.algoritmico.partout.VpnWrapper
 
 class DummyVPNService: VpnService() {
     private val library = NativeLibraryWrapper()

--- a/app-android/app/src/main/java/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/java/com/algoritmico/passepartout/MainActivity.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContextCompat
+import com.algoritmico.passepartout.DummyVPNService
+import com.algoritmico.partout.NativeLibraryWrapper
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activityVersion = "1.10.1"
-agp = "8.12.2"
+agp = "8.12.3"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"

--- a/app-apple/Package/Package.resolved
+++ b/app-apple/Package/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/passepartoutvpn/wg-go-apple",
       "state" : {
-        "revision" : "1fbdb00e6617864f950685168f3e3f7ca76b2ab4",
-        "version" : "0.0.20250630"
+        "revision" : "89b513dfaf8b3d76e89fc2b5fe14060dfba4e7e0",
+        "version" : "0.0.2025063102"
       }
     }
   ],

--- a/app-apple/Package/Package.swift
+++ b/app-apple/Package/Package.swift
@@ -174,7 +174,7 @@ let package = Package(
             dependencies: [
                 "CommonIAP",
                 "CommonUtils",
-                .product(name: "PartoutInterfaces", package: "partout")
+                .product(name: "Partout", package: "partout")
             ],
             resources: [
                 .process("Resources")

--- a/app-apple/Package/Sources/AppLibrary/L10n/WireGuard+L10n.swift
+++ b/app-apple/Package/Sources/AppLibrary/L10n/WireGuard+L10n.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import Foundation
-import PartoutInterfaces
+import Partout
 
 extension WireGuardParseError: @retroactive LocalizedError {
     public var errorDescription: String? {

--- a/app-apple/Package/Sources/AppLibraryMain/Views/Modules/OpenVPN/OpenVPNView+Import.swift
+++ b/app-apple/Package/Sources/AppLibraryMain/Views/Modules/OpenVPN/OpenVPNView+Import.swift
@@ -77,7 +77,7 @@ private extension OpenVPNView.ImportModifier {
             }
             let parsed: Module
             do {
-                parsed = try impl.importer.module(fromURL: url, object: importPassphrase)
+                parsed = try impl.importerBlock().module(fromURL: url, object: importPassphrase)
             } catch let error as PartoutError {
                 pp_log_g(.app, .error, "Unable to parse URL: \(error)")
 

--- a/app-apple/Package/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Import.swift
+++ b/app-apple/Package/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Import.swift
@@ -53,7 +53,7 @@ private extension WireGuardView.ImportModifier {
             }
             let parsed: Module
             do {
-                parsed = try impl.importer.module(fromURL: url, object: nil)
+                parsed = try impl.importerBlock().module(fromURL: url, object: nil)
             } catch let error as PartoutError {
                 pp_log_g(.app, .error, "Unable to parse URL: \(error)")
 

--- a/app-apple/Package/Sources/CommonLegacyV2/Domain/Profile+WireGuardSettings.swift
+++ b/app-apple/Package/Sources/CommonLegacyV2/Domain/Profile+WireGuardSettings.swift
@@ -5,8 +5,6 @@
 import CommonLibrary
 import Foundation
 import Partout
-// FIXME: #93/partout, only import interfaces after moving WireGuard parser to Core
-//import PartoutInterfaces
 
 extension ProfileV2 {
     struct WireGuardSettings: Codable, Equatable, VPNProtocolProviding {
@@ -20,11 +18,11 @@ extension ProfileV2 {
             public init(from decoder: Decoder) throws {
                 let container = try decoder.singleValueContainer()
                 let wg = try container.decode(String.self)
-                configuration = try StandardWireGuardParser().configuration(from: wg)
+                configuration = try LegacyWireGuardParser().configuration(from: wg)
             }
 
             public func encode(to encoder: Encoder) throws {
-                let wg = try StandardWireGuardParser().string(from: configuration)
+                let wg = try LegacyWireGuardParser().string(from: configuration)
                 var container = encoder.singleValueContainer()
                 try container.encode(wg)
             }

--- a/app-apple/Package/Sources/CommonLibrary/CommonLibrary.swift
+++ b/app-apple/Package/Sources/CommonLibrary/CommonLibrary.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 @_exported import CommonIAP
-@_exported import PartoutInterfaces
+@_exported import Partout
 
 public enum CommonLibrary {
     public static func assertMissingImplementations(with registry: Registry) {

--- a/app-apple/Package/Sources/CommonLibrary/Domain/AppPreference.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Domain/AppPreference.swift
@@ -37,6 +37,9 @@ public struct AppPreferenceValues: Hashable, Codable, Sendable {
     }
 
     public var deviceId: String?
+    // XXX: These are copied from ConfigManager.activeFlags for use
+    // in the PacketTunnelProvider (see AppContext.onApplicationActive).
+    // In the app, use ConfigManager.activeFlags directly.
     public var configFlagsData: Data? = nil
 
     public var dnsFallsBack = true
@@ -96,5 +99,9 @@ extension AppPreferenceValues {
 
     public func isFlagEnabled(_ flag: ConfigFlag) -> Bool {
         configFlags.contains(flag) && !experimental.ignoredConfigFlags.contains(flag)
+    }
+
+    public func enabledFlags(of flags: Set<ConfigFlag>) -> Set<ConfigFlag> {
+        flags.subtracting(experimental.ignoredConfigFlags)
     }
 }

--- a/app-apple/Package/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
@@ -100,7 +100,7 @@ private extension PartoutLogger.Builder {
             .api,
             .app,
             .core,
-            .ne,
+            .os,
             .openvpn,
             .providers,
             .wireguard,

--- a/app-apple/Package/Sources/CommonLibrary/Shared+API.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Shared+API.swift
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import PartoutInterfaces
+import Partout
 
 extension API {
     public static var shared: [APIMapper] {

--- a/app-apple/Package/Sources/CommonLibrary/Shared.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Shared.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 import Foundation
-import PartoutInterfaces
+import Partout
 
 extension LoggerCategory {
     public static let app = LoggerCategory(rawValue: "app")

--- a/app-apple/Package/Sources/CommonUtils/Extensions/MainActor+Sync.swift
+++ b/app-apple/Package/Sources/CommonUtils/Extensions/MainActor+Sync.swift
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import Foundation
+
+// XXX: Trick to call MainActor code synchronously
+extension MainActor {
+    public static func sync<T>(_ block: @escaping @Sendable @MainActor () -> T) -> T where T: Sendable {
+        guard Thread.isMainThread else {
+            var result: T!
+            let semaphore = DispatchSemaphore(value: 0)
+            Task { @MainActor in
+                result = block()
+                semaphore.signal()
+            }
+            semaphore.wait()
+            return result
+        }
+        return MainActor.assumeIsolated(block)
+    }
+}

--- a/app-apple/Passepartout/App/Context/AppContext+Testing.swift
+++ b/app-apple/Passepartout/App/Context/AppContext+Testing.swift
@@ -34,7 +34,8 @@ extension AppContext {
         )
         let registry = dependencies.newRegistry(
             distributionTarget: .appStore,
-            deviceId: "TestDeviceID"
+            deviceId: "TestDeviceID",
+            configBlock: { [] }
         )
         let processor = dependencies.appProcessor(
             apiManager: apiManager,

--- a/app-apple/Passepartout/App/Context/test-bundle.json
+++ b/app-apple/Passepartout/App/Context/test-bundle.json
@@ -1,4 +1,10 @@
 {
+    "neSocketUDP": {
+        "rate": 100
+    },
+    "neSocketTCP": {
+        "rate": 100
+    },
     "ovpnCrossConnection": {
         "rate": 100
     },
@@ -9,12 +15,6 @@
         "rate": 100
     },
     "tvSendTo": {
-        "rate": 100
-    },
-    "neSocketUDP": {
-        "rate": 100
-    },
-    "neSocketTCP": {
         "rate": 100
     },
     "tvWebImport": {

--- a/app-apple/Passepartout/App/Context/test-bundle.json
+++ b/app-apple/Passepartout/App/Context/test-bundle.json
@@ -2,6 +2,9 @@
     "ovpnCrossConnection": {
         "rate": 100
     },
+    "wgCrossParser": {
+        "rate": 100
+    },
     "wgCrossConnection": {
         "rate": 100
     },

--- a/app-apple/Passepartout/Config.xcconfig
+++ b/app-apple/Passepartout/Config.xcconfig
@@ -1,5 +1,5 @@
-MARKETING_VERSION = 3.5.11
-CURRENT_PROJECT_VERSION = 3919
+MARKETING_VERSION = 3.5.12
+CURRENT_PROJECT_VERSION = 3922
 
 // tweak these based on app and team
 CFG_APP_ID = com.algoritmico.ios.Passepartout

--- a/app-apple/Passepartout/Shared/Dependencies+Partout.swift
+++ b/app-apple/Passepartout/Shared/Dependencies+Partout.swift
@@ -18,7 +18,8 @@ extension Dependencies {
 
     nonisolated func newRegistry(
         distributionTarget: DistributionTarget,
-        deviceId: String
+        deviceId: String,
+        configBlock: @escaping @Sendable () -> Set<ConfigFlag>
     ) -> Registry {
         Registry(
             withKnown: true,
@@ -29,8 +30,13 @@ extension Dependencies {
                 return resolvers
             }(),
             allImplementations: [
-                OpenVPNImplementationBuilder(distributionTarget: distributionTarget).build(),
-                WireGuardImplementationBuilder().build()
+                OpenVPNImplementationBuilder(
+                    distributionTarget: distributionTarget,
+                    configBlock: configBlock
+                ).build(),
+                WireGuardImplementationBuilder(
+                    configBlock: configBlock
+                ).build()
             ]
         )
     }

--- a/app-apple/Passepartout/Tests/LocalizationTests.swift
+++ b/app-apple/Passepartout/Tests/LocalizationTests.swift
@@ -4,17 +4,19 @@
 
 import AppLibrary
 import Foundation
-import PartoutInterfaces
-import XCTest
+import Partout
+import Testing
 
-final class LocalizationTests: XCTestCase {
-    func test_givenModules_whenTranslateApp_thenWorks() {
-        XCTAssertEqual(Strings.Global.Actions.connect, "Connect")
-        XCTAssertEqual(Strings.Global.Nouns.address, "Address")
+final class LocalizationTests {
+    @Test
+    func givenModules_whenTranslateApp_thenWorks() {
+        #expect(Strings.Global.Actions.connect == "Connect")
+        #expect(Strings.Global.Nouns.address == "Address")
     }
 
-    func test_givenModules_whenTranslateWireGuard_thenWorks() {
+    @Test
+    func givenModules_whenTranslateWireGuard_thenWorks() {
         let sut = WireGuardParseError.noInterface
-        XCTAssertEqual(sut.localizedDescription, "Configuration must have an ‘Interface’ section.")
+        #expect(sut.localizedDescription == "Configuration must have an ‘Interface’ section.")
     }
 }

--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -53,7 +53,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         assert(preferences.deviceId != nil, "No Device ID found in preferences")
         let registry = dependencies.newRegistry(
             distributionTarget: distributionTarget,
-            deviceId: preferences.deviceId ?? "MissingDeviceID"
+            deviceId: preferences.deviceId ?? "MissingDeviceID",
+            configBlock: { preferences.configFlags }
         )
         pp_log_g(.app, .info, "Device ID: \(preferences.deviceId ?? "not set")")
         CommonLibrary.assertMissingImplementations(with: registry)

--- a/fastlane/metadata/iOS/default/release_notes.txt
+++ b/fastlane/metadata/iOS/default/release_notes.txt
@@ -1,1 +1,1 @@
-* Update Partout with cross-platform WireGuard connection implementation (#1543)
+* OpenVPN: Fix TCP breaking on fast uploads

--- a/fastlane/metadata/macOS/default/release_notes.txt
+++ b/fastlane/metadata/macOS/default/release_notes.txt
@@ -1,1 +1,1 @@
-* Update Partout with cross-platform WireGuard connection implementation (#1543)
+* OpenVPN: Fix TCP breaking on fast uploads

--- a/fastlane/metadata/tvOS/default/release_notes.txt
+++ b/fastlane/metadata/tvOS/default/release_notes.txt
@@ -1,1 +1,1 @@
-* Update Partout with cross-platform WireGuard connection implementation (#1543)
+* OpenVPN: Fix TCP breaking on fast uploads


### PR DESCRIPTION
Updates:

- WireGuard now works on Windows!
- Fix OpenVPN over TCP (though still slow)
- Flattened targets, no more "PartoutInterfaces"
- Pick VPN implementations through config flags. Requires reordering of AppContext initializations, build ConfigManager on top.
- Log OpenVPN/WireGuard cross/legacy connection init in the library

Beware of potential deadlocks in MainActor.sync() extension. Update Android app by regrouping app/library files.