### PR TITLE
Fix missed early logs by tunnel logger

### DIFF
--- a/app-apple/Package/Sources/CommonLibrary/Domain/ConfigFlag.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Domain/ConfigFlag.swift
@@ -14,9 +14,20 @@ public enum ConfigFlag: String, CaseIterable, RawRepresentable, Codable, Sendabl
     case neSocketUDP
     case neSocketTCP
     case tvWebImport            // 08/09
+    case unknown
 }
 
 extension ConfigFlag: CustomStringConvertible {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let known = ConfigFlag(rawValue: rawValue) else {
+            self = .unknown
+            return
+        }
+        self = known
+    }
+
     public var description: String {
         rawValue
     }

--- a/app-apple/Package/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
+++ b/app-apple/Package/Sources/CommonLibrary/Extensions/PartoutLogger+Extensions.swift
@@ -7,8 +7,8 @@ import Foundation
 extension PartoutLogger {
     public enum Target {
         case app
-
-        case tunnel(Profile.ID, DistributionTarget)
+        case tunnelGlobal(DistributionTarget)
+        case tunnelProfile(Profile.ID, DistributionTarget)
     }
 
     private static var isDefaultLoggerRegistered = false
@@ -27,7 +27,12 @@ extension PartoutLogger {
                 logger.logPreamble(parameters: Constants.shared.log)
             }
             return .global
-        case .tunnel(let profileId, let target):
+        case .tunnelGlobal(let target):
+            let logger = tunnelLogger(preferences: preferences, target: target)
+            PartoutLogger.register(logger)
+            logger.logPreamble(parameters: Constants.shared.log)
+            return .global
+        case .tunnelProfile(let profileId, let target):
             if !isDefaultLoggerRegistered {
                 isDefaultLoggerRegistered = true
                 let logger = tunnelLogger(preferences: preferences, target: target)

--- a/app-apple/Passepartout/App/Context/AppContext+Production.swift
+++ b/app-apple/Passepartout/App/Context/AppContext+Production.swift
@@ -22,9 +22,9 @@ extension AppContext {
 
         // MARK: Declare globals
 
-        let dependencies: Dependencies = .shared
         let distributionTarget = Dependencies.distributionTarget
         let constants: Constants = .shared
+        let dependencies: Dependencies = .shared
         let kvManager = dependencies.kvManager
 
         let ctx = PartoutLogger.register(for: .app, with: kvManager.preferences)

--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -32,19 +32,18 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         // MARK: Declare globals
 
-        let dependencies: Dependencies = await .shared
         let distributionTarget = Dependencies.distributionTarget
         let constants: Constants = .shared
 
-        // MARK: Update or fetch existing preferences
-
-        let (kvManager, preferences) = await MainActor.run {
+        // Update or fetch existing preferences
+        let (dependencies, kvManager, preferences) = await MainActor.run {
+            let dependencies: Dependencies = .shared
             let kvManager = dependencies.kvManager
             if let startPreferences {
                 kvManager.preferences = startPreferences
-                return (kvManager, startPreferences)
+                return (dependencies, kvManager, startPreferences)
             } else {
-                return (kvManager, kvManager.preferences)
+                return (dependencies, kvManager, kvManager.preferences)
             }
         }
 


### PR DESCRIPTION
Also, tolerate unknown ConfigFlag values, as observed after deleting a serialized value in #1551.

Fixes #1508 