### PR TITLE
Fix potential crash on tunnel start

### DIFF
--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -233,7 +233,6 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         fwd = nil
         flushLogs()
         await untrackContext()
-        ctx = nil
     }
 
     override func cancelTunnelWithError(_ error: (any Error)?) {


### PR DESCRIPTION
If stopTunnel() is invoked during startTunnel(), which is possible due to the await suspension points in startTunnel(), ctx could be nil-ed out and walk into the fatalError at L148. Do not nil out ctx, it's harmless.