### PR TITLE
Fix regression in required bundle keys

### DIFF
--- a/app-shared/Sources/CommonLibrary/Domain/AppConfiguration.swift
+++ b/app-shared/Sources/CommonLibrary/Domain/AppConfiguration.swift
@@ -84,8 +84,9 @@ extension ABI {
             }
 
             // Fetch user level manually
-            let rawUserLevel = bundle.integerIfPresent(for: .userLevel)
-            customUserLevel = rawUserLevel.map(AppUserLevel.init(rawValue:)) ?? nil
+            customUserLevel = bundle.integerIfPresent(for: .userLevel).map {
+                AppUserLevel(rawValue: $0)
+            } ?? nil
 
             let appGroupURL = {
                 let groupId = bundle.string(for: .groupId)


### PR DESCRIPTION
Evident because the tunnel crashes on start, all known bundle keys were being looked for. Do the same for the .appStoreId key, which was fetched regardless of the requirements due to `urlForReview`.

Regression in #1604 