### PR TITLE
Fix assertion failure on nil .deviceId in tunnel start

### DIFF
--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -55,6 +55,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             let kvStore = appConfiguration.newKeyValueStore()
             if let startPreferences {
                 kvStore.preferences = startPreferences
+                pspLog(.core, .debug, "PTP: kvStore.preferences: \(kvStore.preferences)")
+                pspLog(.core, .debug, "PTP: startPreferences: \(startPreferences)")
+                assert(kvStore.preferences == startPreferences)
+                return startPreferences
             }
             return kvStore.preferences
         }()

--- a/app-shared/Sources/CommonLibraryCore/Domain/AppPreference.swift
+++ b/app-shared/Sources/CommonLibraryCore/Domain/AppPreference.swift
@@ -124,7 +124,7 @@ extension KeyValueStore {
             return values
         }
         set {
-            set(newValue.deviceId, forAppPreference: .dnsFallsBack)
+            set(newValue.deviceId, forAppPreference: .deviceId)
             set(newValue.dnsFallsBack, forAppPreference: .dnsFallsBack)
             set(newValue.lastCheckedVersionDate, forAppPreference: .lastCheckedVersionDate)
             set(newValue.lastCheckedVersion, forAppPreference: .lastCheckedVersion)


### PR DESCRIPTION
The tunnel was literally unable to start while debugging because of an early assertion failure about the missing `deviceId` preference.

The regression comes from #1682 where PacketTunnelProvider was refactored to return `kvStore.preferences` even when `startPreferences` was set.

This code:

```swift
kvStore.preferences = startPreferences
return startPreferences
```

Was rewritten to:

```swift
kvStore.preferences = startPreferences
return kvStore.preferences
```

But this was not equivalent because the `.deviceId` field was not copied due to a typo in AppPreferenceValues mapping. This PR adds a convenient assertion to guarantee the equivalence:

```swift
kvStore.preferences = startPreferences
assert(kvStore.preferences == startPreferences)
```