### PR TITLE
Subscribe to tunnel events atomically on observation

### DIFF
--- a/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
@@ -109,7 +109,7 @@ extension AppABI {
         let configEvents = configManager.didChange.subscribe()
         let iapEvents = iapManager.didChange.subscribe()
         let profileEvents = profileManager.didChange.subscribe()
-        let tunnelEvents = tunnelManager.didChange.subscribe()
+        let tunnelEvents = tunnelManager.observeObjects()
         let versionEvents = versionChecker.didChange.subscribe()
         let webReceiverEvents = webReceiverManager.didChange.subscribe()
         subscriptions.append(Task {

--- a/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
@@ -20,7 +20,7 @@ public final class TunnelManager {
 
     private let interval: TimeInterval
 
-    public nonisolated let didChange: PassthroughStream<ABI.TunnelEvent>
+    private nonisolated let didChange: PassthroughStream<ABI.TunnelEvent>
 
     private var latestActiveProfiles: [Profile.ID: TunnelActiveProfile]
 
@@ -29,7 +29,7 @@ public final class TunnelManager {
     private var subscriptions: [Task<Void, Never>]
 
     // TODO: #218, keep "last used profile" until .multiple
-    public init(
+    public nonisolated init(
         tunnel: Tunnel,
         extensionInstaller: ExtensionInstaller? = nil,
         kvStore: KeyValueStore? = nil,
@@ -45,8 +45,6 @@ public final class TunnelManager {
         latestActiveProfiles = [:]
         latestEnvironments = [:]
         subscriptions = []
-
-        observeObjects()
     }
 }
 
@@ -157,8 +155,8 @@ extension TunnelManager {
 
 // MARK: - Observation
 
-private extension TunnelManager {
-    func observeObjects() {
+extension TunnelManager {
+    public func observeObjects() -> AsyncStream<ABI.TunnelEvent> {
         let tunnelEvents = tunnel.activeProfilesStream.removeDuplicates()
         let tunnelSubscription = Task { [weak self] in
             guard let self else { return }
@@ -169,6 +167,7 @@ private extension TunnelManager {
                 }
                 // Copy locally for sync access
                 latestActiveProfiles = newActiveProfiles
+                latestEnvironments = await tunnel.allEnvironments()
                 // TODO: #218, keep "last used profile" until .multiple
                 if let first = newActiveProfiles.first {
                     kvStore?.set(first.key.uuidString, forAppPreference: .lastUsedProfileId)
@@ -195,6 +194,7 @@ private extension TunnelManager {
         }
 
         subscriptions = [tunnelSubscription, timerSubscription]
+        return didChange.subscribe()
     }
 }
 

--- a/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
@@ -30,10 +30,10 @@ extension TunnelManagerTests {
         env.setEnvironmentValue(.crypto, forKey: TunnelEnvironmentKeys.lastErrorCode)
 
         let exp = Expectation()
-        let tunnelEvents = sut.didChange.subscribe()
+        let stream = sut.observeObjects()
         var didCall = false
         Task {
-            for await _ in tunnelEvents {
+            for await _ in stream {
                 if !didCall, sut.lastError(ofProfileId: profile.id) != nil {
                     didCall = true
                     await exp.fulfill()
@@ -59,16 +59,16 @@ extension TunnelManagerTests {
             env
         }
         let sut = TunnelManager(tunnel: tunnel, interval: 0.1)
-        let stream = sut.didChange.subscribe()
-        let expectedXfer = ABI.ProfileTransfer(received: 500, sent: 700)
+        let stream = sut.observeObjects()
+        #expect(await stream.nextActiveProfiles() == [:])
 
         let module = try DNSModule.Builder().build()
         let profile = try Profile.Builder(modules: [module]).build()
 
-        try await sut.install(profile)
-        #expect(await stream.nextActiveProfiles() == [:])
+        try await sut.connect(with: profile)
         let active = await stream.nextActiveProfiles()
 
+        let expectedXfer = ABI.ProfileTransfer(received: 500, sent: 700)
         #expect(active.first?.key == profile.id)
         let dataCount = DataCount(UInt(expectedXfer.received), UInt(expectedXfer.sent))
         env.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
@@ -85,13 +85,13 @@ extension TunnelManagerTests {
         }
         let processor = MockTunnelProcessor()
         let sut = TunnelManager(tunnel: tunnel, processor: processor, interval: 0.1)
-        let stream = sut.didChange.subscribe()
+        let stream = sut.observeObjects()
+        #expect(await stream.nextActiveProfiles() == [:])
 
         let module = try DNSModule.Builder().build()
         let profile = try Profile.Builder(modules: [module]).build()
 
         try await sut.install(profile)
-        #expect(await stream.nextActiveProfiles() == [:])
         let active = await stream.nextActiveProfiles()
 
         #expect(active.first?.key == profile.id)
@@ -107,13 +107,13 @@ extension TunnelManagerTests {
         }
         let processor = MockTunnelProcessor()
         let sut = TunnelManager(tunnel: tunnel, processor: processor, interval: 0.1)
-        let stream = sut.didChange.subscribe()
+        let stream = sut.observeObjects()
+        #expect(await stream.nextActiveProfiles() == [:])
 
         let module = try DNSModule.Builder().build()
         let profile = try Profile.Builder(modules: [module]).build()
 
         try await sut.install(profile)
-        #expect(await stream.nextActiveProfiles() == [:])
         let pulled = await stream.nextActiveProfiles()
 
         #expect(pulled.first?.key == profile.id)


### PR DESCRIPTION
Fix a few things by doing observeObjects() and didChange.subscribe() at once:

- Subscribe to tunnel events exactly once
- Be compatible with Swift 6 nonisolated init
- Update environments also on changes to active profiles
- Regression in tests after #1716 