### PR TITLE
Consider ProviderModule a potential connection builder

### DIFF
--- a/app-apple/Sources/AppLibrary/Domain/EditableProfile.swift
+++ b/app-apple/Sources/AppLibrary/Domain/EditableProfile.swift
@@ -56,12 +56,22 @@ public struct EditableProfile: MutableProfileType {
 
         // some modules may require an active connection module (VPN)
         // for example, IP and HTTP Proxy modules require a VPN in NE
-        if builder.activeConnectionModule == nil,
+        if !builder.hasConnection,
            let requiringConnection = builder.activeModules.first(where: \.requiresConnection) {
             throw ABI.AppError.moduleRequiresConnection(requiringConnection)
         }
 
         return builder
+    }
+}
+
+private extension Profile.Builder {
+    var hasConnection: Bool {
+        if activeConnectionModule != nil { return true }
+        if let providerModule = firstModule(ofType: ProviderModule.self, ifActive: true) {
+            return providerModule.buildsConnection
+        }
+        return false
     }
 }
 

--- a/app-apple/Sources/AppLibrary/L10n/AppError+L10n.swift
+++ b/app-apple/Sources/AppLibrary/L10n/AppError+L10n.swift
@@ -22,10 +22,9 @@ extension ABI.AppError: @retroactive LocalizedError {
         case .malformedModule(let module, let error):
             return V.malformedModule(module.moduleType.localizedDescription, error.localizedDescription)
         case .moduleRequiresConnection(let module):
-            let connectionTypes = ModuleType.allCases.filter(\.isConnection)
             return V.moduleRequiresConnection(
                 module.moduleType.localizedDescription,
-                connectionTypes
+                ModuleType.connectionTypes
                     .map(\.localizedDescription)
                     .joined(separator: ", ")
             )

--- a/app-cross/Sources/CommonLibraryCore/Extensions/ModuleType+Known.swift
+++ b/app-cross/Sources/CommonLibraryCore/Extensions/ModuleType+Known.swift
@@ -17,6 +17,10 @@ extension ModuleType: @retroactive CaseIterable {
         list.append(.Provider)
         return list
     }()
+
+    public static var connectionTypes: [ModuleType] {
+        ModuleType.allCases.filter(\.isConnection)
+    }
 }
 
 extension ModuleType {
@@ -27,5 +31,11 @@ extension ModuleType {
         default:
             return false
         }
+    }
+}
+
+extension ProviderModule {
+    public var buildsConnection: Bool {
+        ModuleType.connectionTypes.contains(providerModuleType)
     }
 }


### PR DESCRIPTION
HTTP and IP modules require an active ConnectionModule in the profile, and ProviderModule was not being considered as such.