### PR TITLE
Fix wrong initial UI state

### DIFF
--- a/app-apple/Sources/AppLibrary/Observables/ProfileObservable.swift
+++ b/app-apple/Sources/AppLibrary/Observables/ProfileObservable.swift
@@ -27,7 +27,7 @@ public final class ProfileObservable {
         allHeaders = [:]
         filteredHeaders = []
         isReady = false
-        isRemoteImportingEnabled = abi.isRemoteImportingEnabled
+        isRemoteImportingEnabled = false
         searchSubject = CurrentValueSubject("")
 
         observeEvents(searchDebounce: searchDebounce)

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
@@ -112,6 +112,11 @@ extension AppABI {
         let tunnelEvents = tunnelManager.observeObjects()
         let versionEvents = versionChecker.didChange.subscribe()
         let webReceiverEvents = webReceiverManager.didChange.subscribe()
+
+        // Post initial state AFTER events registration (in case it was missed)
+        iapManager.postInitialState()
+        profileManager.postInitialState()
+
         subscriptions.append(Task {
             for await event in configEvents {
                 dispatch(.config(event), handler)

--- a/app-cross/Sources/CommonLibrary/ABI/AppABIProtocol.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABIProtocol.swift
@@ -22,6 +22,7 @@ public protocol AppABIIAPProtocol: Sendable {
     func restorePurchases() async throws
     func suggestedProducts(for features: Set<ABI.AppFeature>, hints: Set<ABI.StoreProductHint>?) -> Set<ABI.AppProduct>
     func purchasableProducts(for products: [ABI.AppProduct]) async throws -> [ABI.StoreProduct]
+    // Non-observable
     var verificationDelayMinutes: Int { get }
 }
 
@@ -36,7 +37,6 @@ public protocol AppABIProfileProtocol: Sendable {
     func remove(_ ids: [Profile.ID]) async
     func removeAllRemote() async throws
     // Non-observable
-    var isRemoteImportingEnabled: Bool { get }
     func profile(withId id: Profile.ID) -> Profile?
 }
 

--- a/app-cross/Sources/CommonLibraryCore/Business/IAPManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/IAPManager.swift
@@ -110,6 +110,10 @@ public final class IAPManager {
 // MARK: - Actions
 
 extension IAPManager {
+    public func postInitialState() {
+        didChange.send(.status(.init(isEnabled: isEnabled)))
+    }
+
     public func fetchPurchasableProducts(for products: [ABI.AppProduct]) async throws -> [ABI.StoreProduct] {
         guard isEnabled else { return [] }
         do {

--- a/app-cross/Sources/CommonLibraryCore/Business/ProfileManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/ProfileManager.swift
@@ -94,6 +94,10 @@ public final class ProfileManager {
 // MARK: - Actions
 
 extension ProfileManager {
+    public func postInitialState() {
+        didChange.send(.changeRemoteImporting(.init(isImporting: isRemoteImportingEnabled)))
+    }
+
     public func enableRemoteImporting(_ isRemoteImportingEnabled: Bool) {
         self.isRemoteImportingEnabled = isRemoteImportingEnabled
     }


### PR DESCRIPTION
Some state is set too early in AppABI.init(), before observables in AppContext have a chance to register for events. Repost the initial state on registration to keep the observables in sync via onUpdate().

- IAPManager.isEnabled (the "In-app purchases" preference appeared ON despite being OFF)
- ProfileManager.isRemoteImportingEnabled (#1738)