### PR TITLE
Side-align text fields

### DIFF
--- a/app-apple/Sources/AppLibrary/Theme/Views/ThemeTextField.swift
+++ b/app-apple/Sources/AppLibrary/Theme/Views/ThemeTextField.swift
@@ -5,35 +5,42 @@
 import SwiftUI
 
 public struct ThemeTextField: View {
-    let title: String?
+    private let title: String?
 
     @Binding
-    var text: String
+    private var text: String
 
-    let placeholder: String
+    private let placeholder: String
 
-    let inputType: ThemeInputType
+    private let inputType: ThemeInputType
+
+    private let sideAligned: Bool
 
     public init(
         _ title: String?,
         text: Binding<String>,
         placeholder: String,
-        inputType: ThemeInputType = .text
+        inputType: ThemeInputType = .text,
+        sideAligned: Bool = false
     ) {
         self.title = title
         _text = text
         self.placeholder = placeholder
         self.inputType = inputType
+        self.sideAligned = sideAligned
     }
 }
 
 extension ThemeTextField {
-
     @ViewBuilder
     var labeledView: some View {
         if let title {
             LabeledContent {
                 fieldView
+#if os(iOS)
+                    .multilineTextAlignment(sideAligned ? .trailing : .leading)
+                    .frame(maxWidth: .infinity, alignment: sideAligned ? .trailing : .leading)
+#endif
             } label: {
                 Text(title)
             }

--- a/app-apple/Sources/AppLibraryMain/Views/Modules/IPView+Route.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Modules/IPView+Route.swift
@@ -35,13 +35,15 @@ extension IPView {
                             Strings.Global.Nouns.destination,
                             text: $destinationString,
                             placeholder: Strings.Unlocalized.Placeholders.ipDestination(forFamily: family),
-                            inputType: .ipAddress
+                            inputType: .ipAddress,
+                            sideAligned: true
                         )
                         ThemeTextField(
                             Strings.Global.Nouns.gateway,
                             text: $gatewayString,
                             placeholder: Strings.Unlocalized.Placeholders.ipAddress(forFamily: family),
-                            inputType: .ipAddress
+                            inputType: .ipAddress,
+                            sideAligned: true
                         )
                     }
                 }

--- a/app-apple/Sources/AppLibraryMain/Views/Modules/IPView.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Modules/IPView.swift
@@ -6,7 +6,6 @@ import CommonLibrary
 import SwiftUI
 
 struct IPView: View, ModuleDraftEditing {
-
     @ObservedObject
     var draft: ModuleDraft<IPModule.Builder>
 
@@ -76,13 +75,13 @@ private extension IPView {
             Strings.Global.Nouns.address,
             text: $subnets[family] ?? "",
             placeholder: Strings.Unlocalized.Placeholders.ipDestination(forFamily: family),
-            inputType: .ipAddress
+            inputType: .ipAddress,
+            sideAligned: true
         )
         .themeContainerWithSingleEntry(
             header: family.localizedDescription,
             footer: Strings.Modules.Ip.Address.footer
         )
-
         Group {
             ForEach(Array(ip.wrappedValue.includedRoutes.enumerated()), id: \.offset) { item in
                 row(forRoute: item.element) {
@@ -138,7 +137,8 @@ private extension IPView {
                     draft.module.mtu = Int($0)
                 },
                 placeholder: Strings.Unlocalized.Placeholders.mtu,
-                inputType: .number
+                inputType: .number,
+                sideAligned: true
             )
         }
         .themeSection(header: Strings.Global.Nouns.interface)

--- a/app-apple/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
@@ -83,7 +83,8 @@ private extension WireGuardView.ConfigurationView {
                 Strings.Unlocalized.mtu,
                 text: $viewModel.mtu,
                 placeholder: Strings.Unlocalized.Placeholders.mtu,
-                inputType: .number
+                inputType: .number,
+                sideAligned: true
             )
         }
     }


### PR DESCRIPTION
Enforce trailing alignment on some labeled text fields. macOS does it by default. On iOS we do it manually.

Fields:

- IP/Routing: Addresses, Routes, MTU
- WireGuard: MTU