### PR TITLE
OpenVPN: Update connection to v2 with config flag

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/ConfigFlag.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/ConfigFlag.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
 /**
  * 
  *
- * Values: allowsRelaxedVerification,appNotWorking,forcesRelaxedVerification,neSocketUDP,neSocketTCP,newProfileEncoding,wgCrossV2,unknown
+ * Values: allowsRelaxedVerification,appNotWorking,forcesRelaxedVerification,neSocketUDP,neSocketTCP,newProfileEncoding,ovpnCrossV2,wgCrossV2,unknown
  */
 @Serializable
 enum class ConfigFlag(val value: kotlin.String) {
@@ -45,6 +45,9 @@ enum class ConfigFlag(val value: kotlin.String) {
 
     @SerialName(value = "newProfileEncoding")
     newProfileEncoding("newProfileEncoding"),
+
+    @SerialName(value = "ovpnCrossV2")
+    ovpnCrossV2("ovpnCrossV2"),
 
     @SerialName(value = "wgCrossV2")
     wgCrossV2("wgCrossV2"),

--- a/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
@@ -40,12 +40,33 @@ private extension OpenVPNImplementationBuilder {
         var options = OpenVPNConnection.Options()
         options.writeTimeout = TimeInterval(parameters.options.linkWriteTimeout) / 1000.0
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
-        return try OpenVPNConnection(
+#if !PSP_CROSS
+        let flags = configBlock()
+        if flags.contains(.ovpnCrossV2) {
+            return try OpenVPNConnectionV2(
+                ctx,
+                parameters: parameters,
+                module: module,
+                cachesURL: cachesURL,
+                options: options
+            )
+        } else {
+            return try OpenVPNConnection(
+                ctx,
+                parameters: parameters,
+                module: module,
+                cachesURL: cachesURL,
+                options: options
+            )
+        }
+#else
+        return try OpenVPNConnectionV2(
             ctx,
             parameters: parameters,
             module: module,
             cachesURL: cachesURL,
             options: options
         )
+#endif
     }
 }

--- a/app-cross/Sources/CommonLibrary/Dependencies/WireGuardImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/WireGuardImplementationBuilder.swift
@@ -17,9 +17,9 @@ struct WireGuardImplementationBuilder: Sendable {
             importerBlock: { newParser() },
             validatorBlock: { newParser() },
             connectionBlock: {
-                let flags = configBlock()
                 let ctx = PartoutLoggerContext($0.profile.id)
 #if !PSP_CROSS
+                let flags = configBlock()
                 if flags.contains(.wgCrossV2) {
                     return try WireGuardConnection(
                         ctx,

--- a/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIConfigFlag.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIConfigFlag.swift
@@ -14,6 +14,7 @@ public enum OpenAPIConfigFlag: String, Sendable, Codable, CaseIterable {
     case neSocketUDP = "neSocketUDP"
     case neSocketTCP = "neSocketTCP"
     case newProfileEncoding = "newProfileEncoding"
+    case ovpnCrossV2 = "ovpnCrossV2"
     case wgCrossV2 = "wgCrossV2"
     case unknown = "unknown"
 }

--- a/app-cross/abi.yaml
+++ b/app-cross/abi.yaml
@@ -406,6 +406,7 @@ components:
       - neSocketUDP
       - neSocketTCP
       - newProfileEncoding
+      - ovpnCrossV2
       - wgCrossV2
       - unknown
       enum:
@@ -415,6 +416,7 @@ components:
       - neSocketUDP
       - neSocketTCP
       - newProfileEncoding
+      - ovpnCrossV2
       - wgCrossV2
       - unknown
     ConnectionStatus:


### PR DESCRIPTION
Enable refactored OpenVPNConnectionV2 behind .ovpnCrossV2 config flag. Also fixes a few leaks in the tunnel daemon.