### PR TITLE
OpenVPN: Use modern cipher negotiation

### DIFF
--- a/app-apple/Sources/AppLibrary/L10n/Modules/OpenVPNModule+L10n.swift
+++ b/app-apple/Sources/AppLibrary/L10n/Modules/OpenVPNModule+L10n.swift
@@ -26,6 +26,19 @@ extension OpenVPN.Cipher: LocalizableEntity {
     }
 }
 
+extension Array: StyledLocalizableEntity where Element == OpenVPN.Cipher {
+    public enum Style {
+        case dataCiphers
+    }
+
+    public func localizedDescription(style: Style) -> String {
+        switch style {
+        case .dataCiphers:
+            map(\.rawValue).joined(separator: ":")
+        }
+    }
+}
+
 extension OpenVPN.Digest: LocalizableEntity {
     public var localizedDescription: String {
         description

--- a/app-apple/Sources/AppLibraryMain/Views/Modules/OpenVPN/OpenVPNView+Configuration.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Modules/OpenVPN/OpenVPNView+Configuration.swift
@@ -213,6 +213,13 @@ private extension OpenVPNView.ConfigurationView {
 
     var communicationSection: some View {
         themeModuleSection(if: communicationRows, header: Strings.Modules.Openvpn.communication) {
+            configuration.dataCiphers
+                .map {
+                    ThemeLongContentLink(
+                        Strings.Modules.Openvpn.dataCiphers,
+                        text: .constant($0.localizedDescription(style: .dataCiphers))
+                    )
+                }
             configuration.cipher
                 .map {
                     ThemeRow(Strings.Modules.Openvpn.cipher, value: $0.localizedDescription)
@@ -387,6 +394,7 @@ private extension OpenVPNView.ConfigurationView {
 
     var communicationRows: [Any?] {
         [
+            configuration.dataCiphers,
             configuration.cipher,
             configuration.digest,
             configuration.xorMethod

--- a/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Aktiviere den VPN %@.";
 "modules.on_demand.policy" = "Richtlinie";
 "modules.on_demand.ssid.add" = "SSID hinzufügen";
+"modules.openvpn.data_ciphers" = "Datenverschlüsselung";
 "modules.openvpn.cipher" = "Verschlüsselung";
 "modules.openvpn.communication" = "Kommunikation";
 "modules.openvpn.compression_algorithm" = "Algorithmus";

--- a/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Ενεργοποιήστε το VPN %@.";
 "modules.on_demand.policy" = "Πολιτική";
 "modules.on_demand.ssid.add" = "Προσθήκη SSID";
+"modules.openvpn.data_ciphers" = "Κρυπτογράφηση δεδομένων";
 "modules.openvpn.cipher" = "Κρυπτογράφηση";
 "modules.openvpn.communication" = "Επικοινωνία";
 "modules.openvpn.compression_algorithm" = "Αλγόριθμος";

--- a/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
@@ -224,6 +224,7 @@
 "modules.openvpn.credentials.guidance.link" = "See your OpenVPN credentials";
 "modules.openvpn.remotes" = "Remote endpoints";
 "modules.openvpn.communication" = "Communication";
+"modules.openvpn.data_ciphers" = "Data ciphers";
 "modules.openvpn.cipher" = "Cipher";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.compression" = "Compression";

--- a/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Activa la VPN %@.";
 "modules.on_demand.policy" = "Política";
 "modules.on_demand.ssid.add" = "Añadir SSID";
+"modules.openvpn.data_ciphers" = "Cifrados de datos";
 "modules.openvpn.cipher" = "Cifrado";
 "modules.openvpn.communication" = "Comunicación";
 "modules.openvpn.compression_algorithm" = "Algoritmo";

--- a/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Activez le VPN %@.";
 "modules.on_demand.policy" = "Politique";
 "modules.on_demand.ssid.add" = "Ajouter un SSID";
+"modules.openvpn.data_ciphers" = "Chiffrement des données";
 "modules.openvpn.cipher" = "Chiffrement";
 "modules.openvpn.communication" = "Communication";
 "modules.openvpn.compression_algorithm" = "Algorithme";

--- a/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Attiva la VPN %@.";
 "modules.on_demand.policy" = "Politica";
 "modules.on_demand.ssid.add" = "Aggiungi SSID";
+"modules.openvpn.data_ciphers" = "Cifratura dati";
 "modules.openvpn.cipher" = "Cifratura";
 "modules.openvpn.communication" = "Comunicazione";
 "modules.openvpn.compression_algorithm" = "Algoritmo";

--- a/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Activeer de VPN %@.";
 "modules.on_demand.policy" = "Beleid";
 "modules.on_demand.ssid.add" = "SSID toevoegen";
+"modules.openvpn.data_ciphers" = "Data ciphers";
 "modules.openvpn.cipher" = "Cipher";
 "modules.openvpn.communication" = "Communicatie";
 "modules.openvpn.compression_algorithm" = "Algoritme";

--- a/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Aktywuj VPN %@.";
 "modules.on_demand.policy" = "Polityka";
 "modules.on_demand.ssid.add" = "Dodaj SSID";
+"modules.openvpn.data_ciphers" = "Szyfry danych";
 "modules.openvpn.cipher" = "Szyfr";
 "modules.openvpn.communication" = "Komunikacja";
 "modules.openvpn.compression_algorithm" = "Algorytm";

--- a/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Ative o VPN %@.";
 "modules.on_demand.policy" = "Política";
 "modules.on_demand.ssid.add" = "Adicionar SSID";
+"modules.openvpn.data_ciphers" = "Cifras de dados";
 "modules.openvpn.cipher" = "Cifra";
 "modules.openvpn.communication" = "Comunicação";
 "modules.openvpn.compression_algorithm" = "Algoritmo";

--- a/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Активировать VPN %@.";
 "modules.on_demand.policy" = "Политика";
 "modules.on_demand.ssid.add" = "Добавить SSID";
+"modules.openvpn.data_ciphers" = "Шифры данных";
 "modules.openvpn.cipher" = "Шифр";
 "modules.openvpn.communication" = "Коммуникация";
 "modules.openvpn.compression_algorithm" = "Алгоритм";

--- a/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Aktivera VPN %@.";
 "modules.on_demand.policy" = "Policy";
 "modules.on_demand.ssid.add" = "Lägg till SSID";
+"modules.openvpn.data_ciphers" = "Datachiffer";
 "modules.openvpn.cipher" = "Chiffer";
 "modules.openvpn.communication" = "Kommunikation";
 "modules.openvpn.compression_algorithm" = "Algoritm";

--- a/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "Активуйте VPN %@.";
 "modules.on_demand.policy" = "Політика";
 "modules.on_demand.ssid.add" = "Додати SSID";
+"modules.openvpn.data_ciphers" = "Шифри даних";
 "modules.openvpn.cipher" = "Шифр";
 "modules.openvpn.communication" = "Зв'язок";
 "modules.openvpn.compression_algorithm" = "Алгоритм";

--- a/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
@@ -257,6 +257,7 @@
 "modules.on_demand.policy.footer" = "激活 VPN %@。";
 "modules.on_demand.policy" = "策略";
 "modules.on_demand.ssid.add" = "添加 SSID";
+"modules.openvpn.data_ciphers" = "数据加密算法";
 "modules.openvpn.cipher" = "加密算法";
 "modules.openvpn.communication" = "通信";
 "modules.openvpn.compression_algorithm" = "算法";

--- a/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
+++ b/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
@@ -732,6 +732,8 @@ public enum Strings {
       public static let compressionFraming = Strings.tr("Localizable", "modules.openvpn.compression_framing", fallback: "Framing")
       /// Credentials
       public static let credentials = Strings.tr("Localizable", "modules.openvpn.credentials", fallback: "Credentials")
+      /// Data ciphers
+      public static let dataCiphers = Strings.tr("Localizable", "modules.openvpn.data_ciphers", fallback: "Data ciphers")
       /// Digest
       public static let digest = Strings.tr("Localizable", "modules.openvpn.digest", fallback: "Digest")
       /// Extended verification


### PR DESCRIPTION
Integrate https://github.com/partout-io/partout/pull/351 for correct handling of `--data-ciphers`.

Fixes #1773