### PR TITLE
OpenVPN: Improve loops performance in V2

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/ConfigFlag.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/ConfigFlag.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
 /**
  * 
  *
- * Values: allowsRelaxedVerification,appNotWorking,forcesRelaxedVerification,neSocketUDP,neSocketTCP,newProfileEncoding,ovpnCrossV2,wgCrossV2,unknown
+ * Values: allowsRelaxedVerification,appNotWorking,bsdSockets,forcesRelaxedVerification,newProfileEncoding,ovpnCrossV2,wgCrossV2,unknown
  */
 @Serializable
 enum class ConfigFlag(val value: kotlin.String) {
@@ -34,14 +34,11 @@ enum class ConfigFlag(val value: kotlin.String) {
     @SerialName(value = "appNotWorking")
     appNotWorking("appNotWorking"),
 
+    @SerialName(value = "bsdSockets")
+    bsdSockets("bsdSockets"),
+
     @SerialName(value = "forcesRelaxedVerification")
     forcesRelaxedVerification("forcesRelaxedVerification"),
-
-    @SerialName(value = "neSocketUDP")
-    neSocketUDP("neSocketUDP"),
-
-    @SerialName(value = "neSocketTCP")
-    neSocketTCP("neSocketTCP"),
 
     @SerialName(value = "newProfileEncoding")
     newProfileEncoding("newProfileEncoding"),

--- a/app-apple/Passepartout/App/Context/test-bundle.json
+++ b/app-apple/Passepartout/App/Context/test-bundle.json
@@ -1,8 +1,11 @@
 {
+    "bsdSockets": {
+        "rate": 0
+    },
     "wgCrossV2": {
         "rate": 100
     },
-    "bsdSockets": {
+    "ovpnCrossV2": {
         "rate": 100
     },
     "newProfileEncoding": {

--- a/app-apple/Passepartout/App/Context/test-bundle.json
+++ b/app-apple/Passepartout/App/Context/test-bundle.json
@@ -2,13 +2,10 @@
     "wgCrossV2": {
         "rate": 100
     },
+    "bsdSockets": {
+        "rate": 100
+    },
     "newProfileEncoding": {
-        "rate": 100
-    },
-    "neSocketUDP": {
-        "rate": 100
-    },
-    "neSocketTCP": {
         "rate": 100
     },
     "allowsRelaxedVerification": {

--- a/app-apple/Sources/AppLibrary/Observables/ConfigObservable.swift
+++ b/app-apple/Sources/AppLibrary/Observables/ConfigObservable.swift
@@ -33,3 +33,13 @@ public final class ConfigObservable {
         }
     }
 }
+
+extension ConfigObservable {
+    public var isUsingExperimentalFeatures: Bool {
+        !activeFlags.isDisjoint(with: [
+            .bsdSockets,
+            .ovpnCrossV2,
+            .wgCrossV2
+        ])
+    }
+}

--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -22,19 +22,15 @@ struct PreferencesAdvancedView: View {
 
 private extension PreferencesAdvancedView {
     static let flags: [ABI.ConfigFlag] = [
-        .neSocketUDP,
-        .neSocketTCP,
+        .bsdSockets,
         .newProfileEncoding,
         .wgCrossV2
     ]
 
     static func description(for flag: ABI.ConfigFlag) -> String {
-        let V = Strings.Entities.Ui.ConfigFlag.self
         switch flag {
-        case .neSocketUDP:
-            return V.neSocketUDP
-        case .neSocketTCP:
-            return V.neSocketTCP
+        case .bsdSockets:
+            return "BSD sockets"
         case .newProfileEncoding:
             return "New profile encoding"
         case .wgCrossV2:

--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -24,6 +24,7 @@ private extension PreferencesAdvancedView {
     static let flags: [ABI.ConfigFlag] = [
         .bsdSockets,
         .newProfileEncoding,
+        .ovpnCrossV2,
         .wgCrossV2
     ]
 
@@ -33,6 +34,8 @@ private extension PreferencesAdvancedView {
             return "BSD sockets"
         case .newProfileEncoding:
             return "New profile encoding"
+        case .ovpnCrossV2:
+            return "Cross-platform OpenVPN v2"
         case .wgCrossV2:
             return "Cross-platform WireGuard v2"
         default:

--- a/app-apple/Sources/AppLibraryMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Diagnostics/DiagnosticsView.swift
@@ -162,8 +162,7 @@ private extension DiagnosticsView {
 
     var isUsingExperimentalFeatures: Bool {
         !configObservable.activeFlags.isDisjoint(with: [
-            .neSocketUDP,
-            .neSocketTCP
+            .bsdSockets
         ])
     }
 

--- a/app-apple/Sources/AppLibraryMain/Views/Diagnostics/DiagnosticsView.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Diagnostics/DiagnosticsView.swift
@@ -157,13 +157,7 @@ private extension DiagnosticsView {
         AppCommandLine.contains(.withReportIssue) ||
             iapObservable.isEligibleForFeedback ||
             appConfiguration.bundle.distributionTarget.canAlwaysReportIssue ||
-            isUsingExperimentalFeatures
-    }
-
-    var isUsingExperimentalFeatures: Bool {
-        !configObservable.activeFlags.isDisjoint(with: [
-            .bsdSockets
-        ])
+            configObservable.isUsingExperimentalFeatures
     }
 
     func computedTunnelLogs() async -> [ABI.LogEntry] {

--- a/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Aktiv";
 "entities.tunnel_status.deactivating" = "Deaktivierung";
 "entities.tunnel_status.inactive" = "Inaktiv";
-"entities.ui.config_flag.neSocketTCP" = "Moderner TCP";
-"entities.ui.config_flag.neSocketUDP" = "Moderner UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Plattformübergreifendes OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Plattformübergreifendes WireGuard";
 "entities.ui.system_appearance.dark" = "Dunkel";
 "entities.ui.system_appearance.light" = "Hell";
 "entities.ui.system_appearance.system" = "System";

--- a/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Ενεργό";
 "entities.tunnel_status.deactivating" = "Απενεργοποίηση";
 "entities.tunnel_status.inactive" = "Ανενεργό";
-"entities.ui.config_flag.neSocketTCP" = "Σύγχρονο TCP";
-"entities.ui.config_flag.neSocketUDP" = "Σύγχρονο UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Διαπλατφορμικό OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Διαπλατφορμικό WireGuard";
 "entities.ui.system_appearance.dark" = "Σκούρο";
 "entities.ui.system_appearance.light" = "Φωτεινό";
 "entities.ui.system_appearance.system" = "Σύστημα";

--- a/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
@@ -286,11 +286,6 @@
 
 // MARK: Entities (Library)
 
-"entities.ui.config_flag.neSocketUDP" = "Modern UDP";
-"entities.ui.config_flag.neSocketTCP" = "Modern TCP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Cross-platform OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Cross-platform WireGuard";
-
 "entities.ui.system_appearance.system" = "System";
 "entities.ui.system_appearance.light" = "Light";
 "entities.ui.system_appearance.dark" = "Dark";

--- a/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Activo";
 "entities.tunnel_status.deactivating" = "Desactivando";
 "entities.tunnel_status.inactive" = "Inactivo";
-"entities.ui.config_flag.neSocketTCP" = "TCP moderno";
-"entities.ui.config_flag.neSocketUDP" = "UDP moderno";
-"entities.ui.config_flag.ovpnCrossConnection" = "OpenVPN multiplataforma";
-"entities.ui.config_flag.wgCrossConnection" = "WireGuard multiplataforma";
 "entities.ui.system_appearance.dark" = "Oscuro";
 "entities.ui.system_appearance.light" = "Claro";
 "entities.ui.system_appearance.system" = "Sistema";

--- a/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Actif";
 "entities.tunnel_status.deactivating" = "Désactivation";
 "entities.tunnel_status.inactive" = "Inactif";
-"entities.ui.config_flag.neSocketTCP" = "TCP moderne";
-"entities.ui.config_flag.neSocketUDP" = "UDP moderne";
-"entities.ui.config_flag.ovpnCrossConnection" = "OpenVPN multiplateforme";
-"entities.ui.config_flag.wgCrossConnection" = "WireGuard multiplateforme";
 "entities.ui.system_appearance.dark" = "Sombre";
 "entities.ui.system_appearance.light" = "Clair";
 "entities.ui.system_appearance.system" = "Système";

--- a/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Attivo";
 "entities.tunnel_status.deactivating" = "Disattivazione";
 "entities.tunnel_status.inactive" = "Inattivo";
-"entities.ui.config_flag.neSocketTCP" = "TCP moderno";
-"entities.ui.config_flag.neSocketUDP" = "UDP moderno";
-"entities.ui.config_flag.ovpnCrossConnection" = "OpenVPN multipiattaforma";
-"entities.ui.config_flag.wgCrossConnection" = "WireGuard multipiattaforma";
 "entities.ui.system_appearance.dark" = "Scuro";
 "entities.ui.system_appearance.light" = "Chiaro";
 "entities.ui.system_appearance.system" = "Sistema";

--- a/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Actief";
 "entities.tunnel_status.deactivating" = "Deactiveren";
 "entities.tunnel_status.inactive" = "Inactief";
-"entities.ui.config_flag.neSocketTCP" = "Moderne TCP";
-"entities.ui.config_flag.neSocketUDP" = "Moderne UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Platformonafhankelijke OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Platformonafhankelijke WireGuard";
 "entities.ui.system_appearance.dark" = "Donker";
 "entities.ui.system_appearance.light" = "Licht";
 "entities.ui.system_appearance.system" = "Systeem";

--- a/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Aktywne";
 "entities.tunnel_status.deactivating" = "Dezaktywowanie";
 "entities.tunnel_status.inactive" = "Nieaktywne";
-"entities.ui.config_flag.neSocketTCP" = "Nowoczesny TCP";
-"entities.ui.config_flag.neSocketUDP" = "Nowoczesny UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Wieloplatformowy OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Wieloplatformowy WireGuard";
 "entities.ui.system_appearance.dark" = "Ciemny";
 "entities.ui.system_appearance.light" = "Jasny";
 "entities.ui.system_appearance.system" = "System";

--- a/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Ativo";
 "entities.tunnel_status.deactivating" = "Desativando";
 "entities.tunnel_status.inactive" = "Inativo";
-"entities.ui.config_flag.neSocketTCP" = "TCP moderno";
-"entities.ui.config_flag.neSocketUDP" = "UDP moderno";
-"entities.ui.config_flag.ovpnCrossConnection" = "OpenVPN multiplataforma";
-"entities.ui.config_flag.wgCrossConnection" = "WireGuard multiplataforma";
 "entities.ui.system_appearance.dark" = "Escuro";
 "entities.ui.system_appearance.light" = "Claro";
 "entities.ui.system_appearance.system" = "Sistema";

--- a/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Активный";
 "entities.tunnel_status.deactivating" = "Деактивация";
 "entities.tunnel_status.inactive" = "Неактивный";
-"entities.ui.config_flag.neSocketTCP" = "Современный TCP";
-"entities.ui.config_flag.neSocketUDP" = "Современный UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Кроссплатформенный OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Кроссплатформенный WireGuard";
 "entities.ui.system_appearance.dark" = "Тёмная";
 "entities.ui.system_appearance.light" = "Светлая";
 "entities.ui.system_appearance.system" = "Система";

--- a/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Aktiv";
 "entities.tunnel_status.deactivating" = "Inaktiverar";
 "entities.tunnel_status.inactive" = "Inaktiv";
-"entities.ui.config_flag.neSocketTCP" = "Modern TCP";
-"entities.ui.config_flag.neSocketUDP" = "Modern UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Plattformsoberoende OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Plattformsoberoende WireGuard";
 "entities.ui.system_appearance.dark" = "Mörk";
 "entities.ui.system_appearance.light" = "Ljus";
 "entities.ui.system_appearance.system" = "System";

--- a/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "Активний";
 "entities.tunnel_status.deactivating" = "Деактивація";
 "entities.tunnel_status.inactive" = "Неактивний";
-"entities.ui.config_flag.neSocketTCP" = "Сучасний TCP";
-"entities.ui.config_flag.neSocketUDP" = "Сучасний UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "Кросплатформенний OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "Кросплатформенний WireGuard";
 "entities.ui.system_appearance.dark" = "Темна";
 "entities.ui.system_appearance.light" = "Світла";
 "entities.ui.system_appearance.system" = "Система";

--- a/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
@@ -19,10 +19,6 @@
 "entities.tunnel_status.active" = "已激活";
 "entities.tunnel_status.deactivating" = "停用中";
 "entities.tunnel_status.inactive" = "未激活";
-"entities.ui.config_flag.neSocketTCP" = "现代 TCP";
-"entities.ui.config_flag.neSocketUDP" = "现代 UDP";
-"entities.ui.config_flag.ovpnCrossConnection" = "跨平台 OpenVPN";
-"entities.ui.config_flag.wgCrossConnection" = "跨平台 WireGuard";
 "entities.ui.system_appearance.dark" = "深色";
 "entities.ui.system_appearance.light" = "浅色";
 "entities.ui.system_appearance.system" = "系统";

--- a/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
+++ b/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
@@ -84,16 +84,6 @@ public enum Strings {
       public static let inactive = Strings.tr("Localizable", "entities.tunnel_status.inactive", fallback: "Inactive")
     }
     public enum Ui {
-      public enum ConfigFlag {
-        /// Modern TCP
-        public static let neSocketTCP = Strings.tr("Localizable", "entities.ui.config_flag.neSocketTCP", fallback: "Modern TCP")
-        /// Modern UDP
-        public static let neSocketUDP = Strings.tr("Localizable", "entities.ui.config_flag.neSocketUDP", fallback: "Modern UDP")
-        /// Cross-platform OpenVPN
-        public static let ovpnCrossConnection = Strings.tr("Localizable", "entities.ui.config_flag.ovpnCrossConnection", fallback: "Cross-platform OpenVPN")
-        /// Cross-platform WireGuard
-        public static let wgCrossConnection = Strings.tr("Localizable", "entities.ui.config_flag.wgCrossConnection", fallback: "Cross-platform WireGuard")
-      }
       public enum SystemAppearance {
         /// Dark
         public static let dark = Strings.tr("Localizable", "entities.ui.system_appearance.dark", fallback: "Dark")

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -75,10 +75,10 @@ extension TunnelABI {
         // Create daemon
         let factory: NetworkInterfaceFactory
         if preferences.isFlagEnabled(.bsdSockets) {
-            factory = POSIXInterfaceFactory(ctx, betterPathBlock: {
+            factory = POSIXInterfaceFactory(ctx) {
                 // FIXME: #190, BetterPathBlock via NWPathMonitor
                 PassthroughStream()
-            })
+            }
         } else {
             // MUST enable .withReadPackets for OpenVPN V2 to work!
             var options = NEInterfaceFactory.Options()

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -72,13 +72,19 @@ extension TunnelABI {
             }()
         )
 
-        // Pick socket and crypto strategy from preferences
-        var factoryOptions = NEInterfaceFactory.Options()
-        factoryOptions.usesNEUDP = preferences.isFlagEnabled(.neSocketUDP)
-        factoryOptions.usesNETCP = preferences.isFlagEnabled(.neSocketTCP)
-
         // Create daemon
-        let factory = NEInterfaceFactory(ctx, provider: neProvider, options: factoryOptions)
+        let factory: NetworkInterfaceFactory
+        if preferences.isFlagEnabled(.bsdSockets) {
+            factory = POSIXInterfaceFactory(ctx, betterPathBlock: {
+                // FIXME: #190, BetterPathBlock via NWPathMonitor
+                PassthroughStream()
+            })
+        } else {
+            // MUST enable .withReadPackets for OpenVPN V2 to work!
+            var options = NEInterfaceFactory.Options()
+            options.withReadPackets = preferences.isFlagEnabled(.ovpnCrossV2)
+            factory = NEInterfaceFactory(ctx, provider: neProvider, options: options)
+        }
         let reachability = NEObservablePath(ctx)
         let environment = appConfiguration.newTunnelEnvironment(profileId: processedProfile.id)
         let connectionOptions = ConnectionParameters.Options()

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -55,8 +55,10 @@ extension TunnelABI {
 
         // Create platform-specific objects
         let controller = try VirtualTunnelController(ctx, impl: jniWrapper)
-        // FIXME: #1656, C ABI, better path block
-        let factory = POSIXInterfaceFactory(ctx, betterPathBlock: { PassthroughStream() })
+        let factory = POSIXInterfaceFactory(ctx) {
+            // FIXME: #1656, C ABI, better path block
+            PassthroughStream()
+        }
         // FIXME: #1656, C ABI, reachability observer
         let reachability = DummyReachabilityObserver()
 

--- a/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIConfigFlag.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIConfigFlag.swift
@@ -10,9 +10,8 @@ import Partout
 public enum OpenAPIConfigFlag: String, Sendable, Codable, CaseIterable {
     case allowsRelaxedVerification = "allowsRelaxedVerification"
     case appNotWorking = "appNotWorking"
+    case bsdSockets = "bsdSockets"
     case forcesRelaxedVerification = "forcesRelaxedVerification"
-    case neSocketUDP = "neSocketUDP"
-    case neSocketTCP = "neSocketTCP"
     case newProfileEncoding = "newProfileEncoding"
     case ovpnCrossV2 = "ovpnCrossV2"
     case wgCrossV2 = "wgCrossV2"

--- a/app-cross/Tests/CommonLibraryTests/Business/KeyValueStoreTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/KeyValueStoreTests.swift
@@ -31,7 +31,7 @@ struct KeyValueStoreTests {
 
     @Test
     func givenKeyValue_whenSetConfigFlags_thenIsExpected() throws {
-        let flags: Set<ABI.ConfigFlag> = [.neSocketUDP, .allowsRelaxedVerification]
+        let flags: Set<ABI.ConfigFlag> = [.newProfileEncoding, .allowsRelaxedVerification]
         let sut = InMemoryStore()
         sut.preferences.configFlags = flags
         #expect(sut.preferences.configFlags == flags)

--- a/app-cross/Tests/CommonLibraryTests/Domain/AppPreferenceTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Domain/AppPreferenceTests.swift
@@ -9,8 +9,8 @@ struct AppPreferenceTests {
     @Test
     func givenFlags_whenSet_thenDataMatches() throws {
         var sut = ABI.AppPreferenceValues()
-        sut.configFlags = [.neSocketUDP, .neSocketTCP]
-        sut.experimental.ignoredConfigFlags = [.appNotWorking, .neSocketUDP]
+        sut.configFlags = [.bsdSockets, .newProfileEncoding]
+        sut.experimental.ignoredConfigFlags = [.appNotWorking, .bsdSockets]
 
         let configFlagsData = try #require(sut.configFlagsData)
         let experimentalData = try #require(sut.experimentalData)
@@ -39,10 +39,10 @@ struct AppPreferenceTests {
     @Test
     func givenExperimental_whenIgnoreFlags_thenIsApplied() {
         var sut = ABI.AppPreferenceValues()
-        sut.configFlags = [.neSocketUDP, .neSocketTCP]
-        sut.experimental.ignoredConfigFlags = [.appNotWorking, .neSocketUDP]
-        #expect(sut.isFlagEnabled(.neSocketTCP))
-        #expect(!sut.isFlagEnabled(.neSocketUDP))
+        sut.configFlags = [.bsdSockets, .newProfileEncoding]
+        sut.experimental.ignoredConfigFlags = [.appNotWorking, .bsdSockets]
+        #expect(sut.isFlagEnabled(.newProfileEncoding))
+        #expect(!sut.isFlagEnabled(.bsdSockets))
         #expect(!sut.isFlagEnabled(.appNotWorking))
     }
 }

--- a/app-cross/abi.yaml
+++ b/app-cross/abi.yaml
@@ -402,9 +402,8 @@ components:
       x-enum-varnames:
       - allowsRelaxedVerification
       - appNotWorking
+      - bsdSockets
       - forcesRelaxedVerification
-      - neSocketUDP
-      - neSocketTCP
       - newProfileEncoding
       - ovpnCrossV2
       - wgCrossV2
@@ -412,9 +411,8 @@ components:
       enum:
       - allowsRelaxedVerification
       - appNotWorking
+      - bsdSockets
       - forcesRelaxedVerification
-      - neSocketUDP
-      - neSocketTCP
       - newProfileEncoding
       - ovpnCrossV2
       - wgCrossV2


### PR DESCRIPTION
- Make sure that `.withReadPackets` is enabled in NEInterfaceFactory when `.ovpnCrossV2` is.
- Add `.ovpnCrossV2` to the advanced preferences screen.
- Discontinue NESocket and replace related config flags (UDP/TCP) with the single `.bsdSockets`.