### PR TITLE
Test VPN over BSD sockets in development

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -130,8 +130,8 @@ class MainActivity : ComponentActivity(), ABIEventCallback {
     }
 
     fun importProfile(connect: Boolean = false) {
-        val file = String(assets.open("vps.conf").readBytes())
-//        val file = String(assets.open("vps-crypt-v2.ovpn").readBytes())
+//        val file = String(assets.open("vps.conf").readBytes())
+        val file = String(assets.open("vps-crypt-v2.ovpn").readBytes())
         wrapper.appImportProfileText(file, "SomeName") { ctx, code, errorMessage ->
             if (code == 0) {
                 Log.i("Passepartout", "Import success!")

--- a/app-apple/Passepartout/App/Context/test-bundle.json
+++ b/app-apple/Passepartout/App/Context/test-bundle.json
@@ -1,6 +1,6 @@
 {
     "bsdSockets": {
-        "rate": 0
+        "rate": 100
     },
     "wgCrossV2": {
         "rate": 100

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -75,7 +75,7 @@ extension TunnelABI {
         // Create daemon
         let factory: NetworkInterfaceFactory
         if preferences.isFlagEnabled(.bsdSockets) {
-            factory = POSIXInterfaceFactory(ctx) {
+            factory = BSDSocketFactory(ctx) {
                 // FIXME: #190, BetterPathBlock via NWPathMonitor
                 PassthroughStream()
             }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -55,7 +55,7 @@ extension TunnelABI {
 
         // Create platform-specific objects
         let controller = try VirtualTunnelController(ctx, impl: jniWrapper)
-        let factory = POSIXInterfaceFactory(ctx) {
+        let factory = BSDSocketFactory(ctx) {
             // FIXME: #1656, C ABI, better path block
             PassthroughStream()
         }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -13,7 +13,7 @@ private var globalABI: TunnelABIProtocol?
 public func __psp_tunnel_start(
     args: UnsafePointer<psp_tunnel_start_args>?,
     context: UnsafeMutableRawPointer?,
-    callback: psp_abi_completion?
+    completion: psp_abi_completion?
 ) {
     guard let args,
           let appBundleData = args.pointee.bundle?.asJSONData,
@@ -67,9 +67,9 @@ public func __psp_tunnel_start(
                 jniWrapper: jniWrapper
             )
             try await globalABI?.start(isInteractive: isInteractive)
-            callback?(ctx, 0, nil)
+            completion?(ctx, 0, nil)
         } catch {
-            callback?(ctx, -1, error.localizedDescription)
+            completion?(ctx, -1, error.localizedDescription)
             fatalError("Unable to start tunnel: \(error)")
         }
     }
@@ -79,12 +79,12 @@ public func __psp_tunnel_start(
 @c(psp_tunnel_stop)
 public func __psp_tunnel_stop(
     context: UnsafeMutableRawPointer?,
-    callback: psp_abi_completion?
+    completion: psp_abi_completion?
 ) {
     ABI.run(context) { ctx in
         await globalABI?.stop()
         globalABI = nil
-        callback?(ctx, 0, nil)
+        completion?(ctx, 0, nil)
     }
 }
 

--- a/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
@@ -42,7 +42,7 @@ private extension OpenVPNImplementationBuilder {
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
 #if !PSP_CROSS
         let flags = configBlock()
-        if flags.contains(.ovpnCrossV2) {
+        if flags.contains(.ovpnCrossV2) || flags.contains(.bsdSockets) {
             return try OpenVPNConnectionV2(
                 ctx,
                 parameters: parameters,

--- a/scripts/speed-test.sh
+++ b/scripts/speed-test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+iperf3-darwin -c 10.12.0.1 -P 8 -t 600 -R


### PR DESCRIPTION
Do not enable .bsdSockets until "better path monitor" implementation, at least on Apple.