### PR TITLE
Android: Refactor and fix C/JNI ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.22)
 project(Passepartout LANGUAGES Swift C CXX)
 include(ExternalProject)
 

--- a/app-android/app/src/main/cpp/CMakeLists.txt
+++ b/app-android/app/src/main/cpp/CMakeLists.txt
@@ -1,20 +1,24 @@
-cmake_minimum_required(VERSION 3.21)
-project(Passepartout)
+cmake_minimum_required(VERSION 3.22)
+project(Passepartout LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
-# Include headers
-include_directories(${CMAKE_SOURCE_DIR}/include)
-
-# Library versions
-set(SWIFT_VERSION 6_2)
-set(JNI_DIR ${CMAKE_SOURCE_DIR}/libs)
-
-# Partout + dependencies (dynamic, will be loaded at runtime)
-file(GLOB PASSEPARTOUT_SOS "${JNI_DIR}/passepartout/${ANDROID_ABI}/lib*.so")
+# Copy libpassepartout and dependencies (dynamic, will be loaded at runtime)
+set(JNI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs)
+file(GLOB PASSEPARTOUT_SOS "${JNI_DIR}/${ANDROID_ABI}/lib*.so")
 set(ALL_SOS ${PASSEPARTOUT_SOS} ${SWIFT_SOS})
 
+# Native JNI wrapper
+add_library(passepartout_wrapper SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/helpers.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/passepartout.c
+)
+target_include_directories(passepartout_wrapper PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+# Link to libpassepartout and dependencies
 foreach(SO_FILE ${ALL_SOS})
     get_filename_component(SO_NAME ${SO_FILE} NAME_WE)
     string(REPLACE "lib" "" lib ${SO_NAME})
@@ -25,10 +29,6 @@ foreach(SO_FILE ${ALL_SOS})
     )
     list(APPEND AUTO_LIBS ${lib})
 endforeach()
-
-# Native wrappings for JNI
-add_library(passepartout_wrapper SHARED
-        src/passepartout.c
-        src/helpers.c
+target_link_libraries(passepartout_wrapper PRIVATE
+    ${AUTO_LIBS}
 )
-target_link_libraries(passepartout_wrapper PRIVATE ${AUTO_LIBS})

--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -6,6 +6,7 @@
 
 #include <jni.h>
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include "helpers.h"
 
@@ -14,6 +15,24 @@ JavaVM *jvm = NULL;
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
     jvm = vm;
     return JNI_VERSION_1_6;
+}
+
+static
+JNIEnv *jni_attach_thread(bool *did_attach) {
+    JNIEnv *env;
+    jint status = (*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_6);
+    switch (status) {
+        case JNI_OK:
+            *did_attach = false;
+            return env;
+        case JNI_EDETACHED:
+            status = (*jvm)->AttachCurrentThread(jvm, &env, NULL);
+            if (status != JNI_OK) return NULL;
+            *did_attach = true;
+            return env;
+        default:
+            return NULL;
+    }
 }
 
 typedef struct {
@@ -37,10 +56,13 @@ void abi_handler_free(JNIEnv *env, abi_handler *handler) {
 
 void abi_handler_proxy(void *ctx, const char *method_id, const char *json) {
     assert(ctx);
+    assert(method_id);
     assert(json);
 
-    JNIEnv *env;
-    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
+    bool did_attach;
+    JNIEnv *env = jni_attach_thread(&did_attach);
+    if (!env) return;
+
     abi_handler *handler = (abi_handler *)ctx;
     jclass cls = (*env)->GetObjectClass(env, handler->ref);
     if (cls) {
@@ -53,7 +75,7 @@ void abi_handler_proxy(void *ctx, const char *method_id, const char *json) {
         }
         (*env)->DeleteLocalRef(env, cls);
     }
-    (*jvm)->DetachCurrentThread(jvm);
+    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
 }
 
 void abi_event_handler_proxy(void *ctx, const char *event_json) {
@@ -69,8 +91,9 @@ void abi_connection_status_handler_proxy(void *ctx, const char *status_json) {
 void abi_completion_proxy(void *ctx, int code, const char *json) {
     assert(ctx);
 
-    JNIEnv *env;
-    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
+    bool did_attach;
+    JNIEnv *env = jni_attach_thread(&did_attach);
+    if (!env) return;
 
     abi_handler *handler = (abi_handler *)ctx;
     jclass cls = (*env)->GetObjectClass(env, handler->ref);
@@ -87,5 +110,5 @@ void abi_completion_proxy(void *ctx, int code, const char *json) {
     // Release handler on completion
     abi_handler_free(env, handler);
 
-    (*jvm)->DetachCurrentThread(jvm);
+    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
 }

--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -16,37 +16,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
     return JNI_VERSION_1_6;
 }
 
-void abi_completion_callback_proxy(void *ctx, int code, const char *error_msg) {
-    assert(ctx);
-
-    JNIEnv *env;
-    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
-    abi_completion_handler *handler = (abi_completion_handler *)ctx;
-    jclass cls = (*env)->GetObjectClass(env, handler->completion_cb);
-    if (cls) {
-        jmethodID methodID = (*env)->GetMethodID(env, cls, "onComplete",
-                                                 "(Ljava/lang/Object;ILjava/lang/String;)V");
-        if (methodID) {
-            if (error_msg) {
-                jstring jerrorMsg = (*env)->NewStringUTF(env, error_msg);
-                (*env)->CallVoidMethod(env, handler->completion_cb, methodID,
-                                       handler->completion_ctx, code, jerrorMsg);
-                (*env)->DeleteLocalRef(env, jerrorMsg);
-            } else {
-                (*env)->CallVoidMethod(env, handler->completion_cb, methodID,
-                                       handler->completion_ctx, code, NULL);
-            }
-        }
-        (*env)->DeleteLocalRef(env, cls);
-    }
-
-    // Clean up JNI ref to completion callback
-    (*env)->DeleteGlobalRef(env, handler->completion_cb);
-    // Clean up temporary proxy handler
-    free(handler);
-    (*jvm)->DetachCurrentThread(jvm);
-}
-
 typedef struct {
     jobject ref;
 } abi_handler;
@@ -56,6 +25,15 @@ void *abi_handler_create(JNIEnv *env, jobject ref) {
     handler->ref = (*env)->NewGlobalRef(env, ref);
     return handler;
 }
+
+static
+void abi_handler_free(JNIEnv *env, abi_handler *handler) {
+    if (!handler) return;
+    (*env)->DeleteGlobalRef(env, handler->ref);
+    free(handler);
+}
+
+/* Global */
 
 void abi_handler_proxy(void *ctx, const char *method_id, const char *json) {
     assert(ctx);
@@ -84,4 +62,30 @@ void abi_event_handler_proxy(void *ctx, const char *event_json) {
 
 void abi_connection_status_handler_proxy(void *ctx, const char *status_json) {
     abi_handler_proxy(ctx, "onStatus", status_json);
+}
+
+/* Completion (fire and release) */
+
+void abi_completion_proxy(void *ctx, int code, const char *json) {
+    assert(ctx);
+
+    JNIEnv *env;
+    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
+
+    abi_handler *handler = (abi_handler *)ctx;
+    jclass cls = (*env)->GetObjectClass(env, handler->ref);
+    if (cls) {
+        jmethodID methodID = (*env)->GetMethodID(env, cls, "onComplete", "(ILjava/lang/String;)V");
+        if (methodID) {
+            jstring jJSON = (*env)->NewStringUTF(env, json);
+            (*env)->CallVoidMethod(env, handler->ref, methodID, code, jJSON);
+            (*env)->DeleteLocalRef(env, jJSON);
+        }
+        (*env)->DeleteLocalRef(env, cls);
+    }
+
+    // Release handler on completion
+    abi_handler_free(env, handler);
+
+    (*jvm)->DetachCurrentThread(jvm);
 }

--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -35,17 +35,12 @@ JNIEnv *jni_attach_thread(bool *did_attach) {
     }
 }
 
-typedef struct {
-    jobject ref;
-} abi_handler;
-
-void *abi_handler_create(JNIEnv *env, jobject ref) {
+abi_handler *abi_handler_create(JNIEnv *env, jobject ref) {
     abi_handler *handler = malloc(sizeof(abi_handler));
     handler->ref = (*env)->NewGlobalRef(env, ref);
     return handler;
 }
 
-static
 void abi_handler_free(JNIEnv *env, abi_handler *handler) {
     if (!handler) return;
     (*env)->DeleteGlobalRef(env, handler->ref);

--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -17,11 +17,10 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 }
 
 void abi_completion_callback_proxy(void *ctx, int code, const char *error_msg) {
-    JNIEnv *env;
-    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
-
     assert(ctx);
 
+    JNIEnv *env;
+    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
     abi_completion_handler *handler = (abi_completion_handler *)ctx;
     jclass cls = (*env)->GetObjectClass(env, handler->completion_cb);
     if (cls) {
@@ -45,52 +44,44 @@ void abi_completion_callback_proxy(void *ctx, int code, const char *error_msg) {
     (*env)->DeleteGlobalRef(env, handler->completion_cb);
     // Clean up temporary proxy handler
     free(handler);
-
     (*jvm)->DetachCurrentThread(jvm);
 }
 
-void abi_event_callback_proxy(void *ctx, const char *event_json) {
+typedef struct {
+    jobject ref;
+} abi_handler;
+
+void *abi_handler_create(JNIEnv *env, jobject ref) {
+    abi_handler *handler = malloc(sizeof(abi_handler));
+    handler->ref = (*env)->NewGlobalRef(env, ref);
+    return handler;
+}
+
+void abi_handler_proxy(void *ctx, const char *method_id, const char *json) {
+    assert(ctx);
+    assert(json);
+
     JNIEnv *env;
     (*jvm)->AttachCurrentThread(jvm, &env, NULL);
-
-    assert(ctx);
-    assert(event_json);
-    abi_event_handler *handler = (abi_event_handler *)ctx;
-    jclass cls = (*env)->GetObjectClass(env, handler->event_cb);
+    abi_handler *handler = (abi_handler *)ctx;
+    jclass cls = (*env)->GetObjectClass(env, handler->ref);
     if (cls) {
-        jmethodID methodID = (*env)->GetMethodID(env, cls, "onEvent",
-                                                 "(Ljava/lang/Object;Ljava/lang/String;)V");
+        jmethodID methodID = (*env)->GetMethodID(env, cls, method_id,
+                                                 "(Ljava/lang/String;)V");
         if (methodID) {
-            jstring jeventJSON = (*env)->NewStringUTF(env, event_json);
-            (*env)->CallVoidMethod(env, handler->event_cb, methodID, handler->event_ctx,
-                                   jeventJSON);
+            jstring jeventJSON = (*env)->NewStringUTF(env, json);
+            (*env)->CallVoidMethod(env, handler->ref, methodID, jeventJSON);
             (*env)->DeleteLocalRef(env, jeventJSON);
         }
         (*env)->DeleteLocalRef(env, cls);
     }
-
     (*jvm)->DetachCurrentThread(jvm);
 }
 
-void connection_status_callback_proxy(void *ctx, const char *status_json) {
-    JNIEnv *env;
-    (*jvm)->AttachCurrentThread(jvm, &env, NULL);
+void abi_event_handler_proxy(void *ctx, const char *event_json) {
+    abi_handler_proxy(ctx, "onEvent", event_json);
+}
 
-    assert(ctx);
-    assert(status_json);
-    connection_status_handler *handler = (connection_status_handler *)ctx;
-    jclass cls = (*env)->GetObjectClass(env, handler->status_cb);
-    if (cls) {
-        jmethodID methodID = (*env)->GetMethodID(env, cls, "onStatus",
-                                                 "(Ljava/lang/Object;Ljava/lang/String;)V");
-        if (methodID) {
-            jstring jstatusJSON = (*env)->NewStringUTF(env, status_json);
-            (*env)->CallVoidMethod(env, handler->status_cb, methodID, handler->status_ctx,
-                                   jstatusJSON);
-            (*env)->DeleteLocalRef(env, jstatusJSON);
-        }
-        (*env)->DeleteLocalRef(env, cls);
-    }
-
-    (*jvm)->DetachCurrentThread(jvm);
+void abi_connection_status_handler_proxy(void *ctx, const char *status_json) {
+    abi_handler_proxy(ctx, "onStatus", status_json);
 }

--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -100,9 +100,9 @@ void abi_completion_proxy(void *ctx, int code, const char *json) {
     if (cls) {
         jmethodID methodID = (*env)->GetMethodID(env, cls, "onComplete", "(ILjava/lang/String;)V");
         if (methodID) {
-            jstring jJSON = (*env)->NewStringUTF(env, json);
+            jstring jJSON = json ? (*env)->NewStringUTF(env, json) : NULL;
             (*env)->CallVoidMethod(env, handler->ref, methodID, code, jJSON);
-            (*env)->DeleteLocalRef(env, jJSON);
+            if (jJSON) (*env)->DeleteLocalRef(env, jJSON);
         }
         (*env)->DeleteLocalRef(env, cls);
     }

--- a/app-android/app/src/main/cpp/src/helpers.h
+++ b/app-android/app/src/main/cpp/src/helpers.h
@@ -7,12 +7,11 @@
 #pragma once
 #include <jni.h>
 
-typedef struct {
-    void *completion_ctx;
-    jobject completion_cb; // Global ref to Kotlin callback
-} abi_completion_handler;
-void abi_completion_callback_proxy(void *ctx, int code, const char *error_msg);
-
 void *abi_handler_create(JNIEnv *env, jobject ref);
+
+/* Global handlers (lifescope = application). */
 void abi_event_handler_proxy(void *ctx, const char *event_json);
 void abi_connection_status_handler_proxy(void *ctx, const char *status_json);
+
+/* Completion handlers (lifescope = function call, released on call). */
+void abi_completion_proxy(void *ctx, int code, const char *json);

--- a/app-android/app/src/main/cpp/src/helpers.h
+++ b/app-android/app/src/main/cpp/src/helpers.h
@@ -7,7 +7,12 @@
 #pragma once
 #include <jni.h>
 
-void *abi_handler_create(JNIEnv *env, jobject ref);
+typedef struct {
+    jobject ref;
+} abi_handler;
+
+abi_handler *abi_handler_create(JNIEnv *env, jobject ref);
+void abi_handler_free(JNIEnv *env, abi_handler *handler);
 
 /* Global handlers (lifescope = application). */
 void abi_event_handler_proxy(void *ctx, const char *event_json);

--- a/app-android/app/src/main/cpp/src/helpers.h
+++ b/app-android/app/src/main/cpp/src/helpers.h
@@ -13,14 +13,6 @@ typedef struct {
 } abi_completion_handler;
 void abi_completion_callback_proxy(void *ctx, int code, const char *error_msg);
 
-typedef struct {
-    void *event_ctx;
-    jobject event_cb; // Global ref to Kotlin callback
-} abi_event_handler;
-void abi_event_callback_proxy(void *ctx, const char *event_json);
-
-typedef struct {
-    void *status_ctx;
-    jobject status_cb; // Global ref to Kotlin callback
-} connection_status_handler;
-void connection_status_callback_proxy(void *ctx, const char *status_json);
+void *abi_handler_create(JNIEnv *env, jobject ref);
+void abi_event_handler_proxy(void *ctx, const char *event_json);
+void abi_connection_status_handler_proxy(void *ctx, const char *status_json);

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -83,7 +83,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
-    // Store global reference of builder wrapper
+    // Store global JNI references (ownership is transferred)
     jobject jniController = (*env)->NewGlobalRef(env, controller);
 
     psp_tunnel_start_args args = { 0 };

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -37,7 +37,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
         jstring constants,
         jstring profilesDir,
         jstring cacheDir,
-        jobject eventHandler
+        jobject eventHandler,
+        jobject completion
 ) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
     const char *cConstants = (*env)->GetStringUTFChars(env, constants, NULL);
@@ -55,12 +56,21 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     args.cache_dir = cCacheDir;
     args.bindings.event_ctx = app_references.eventHandler;
     args.bindings.event_cb = abi_event_handler_proxy;
-    psp_app_init(&args);
+    psp_app_init(&args, abi_handler_create(env, completion), abi_completion_proxy);
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
     (*env)->ReleaseStringUTFChars(env, profilesDir, cProfilesDir);
     (*env)->ReleaseStringUTFChars(env, cacheDir, cCacheDir);
+}
+
+JNIEXPORT void JNICALL
+Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appDeinit(
+        JNIEnv *env,
+        jobject thiz,
+        jobject completion
+) {
+    psp_app_deinit(abi_handler_create(env, completion), abi_completion_proxy);
 }
 
 JNIEXPORT void JNICALL

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -9,6 +9,15 @@
 #include "passepartout.h"
 #include "helpers.h"
 
+struct {
+    jobject eventHandler;
+} app_references;
+
+struct {
+    jobject jniController;
+    jobject statusHandler;
+} tunnel_references;
+
 JNIEXPORT jstring JNICALL
 Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
     jstring jmsg = (*env)->NewStringUTF(env, psp_partout_version());
@@ -28,11 +37,15 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
         jstring constants,
         jstring profilesDir,
         jstring cacheDir,
-        jobject eventHandler) {
+        jobject eventHandler
+) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
     const char *cConstants = (*env)->GetStringUTFChars(env, constants, NULL);
     const char *cProfilesDir = (*env)->GetStringUTFChars(env, profilesDir, NULL);
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
+
+    // Store globally
+    app_references.eventHandler = abi_handler_create(env, eventHandler);
 
     psp_app_init_args args = { 0 };
     args.bundle = cBundle;
@@ -40,7 +53,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     args.preferences = "{\"logsPrivateData\": true}";
     args.profiles_dir = cProfilesDir;
     args.cache_dir = cCacheDir;
-    args.bindings.event_ctx = abi_handler_create(env, eventHandler);
+    args.bindings.event_ctx = app_references.eventHandler;
     args.bindings.event_cb = abi_event_handler_proxy;
     psp_app_init(&args);
 
@@ -48,6 +61,14 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
     (*env)->ReleaseStringUTFChars(env, profilesDir, cProfilesDir);
     (*env)->ReleaseStringUTFChars(env, cacheDir, cCacheDir);
+}
+
+JNIEXPORT void JNICALL
+Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appRelease(
+        JNIEnv *env,
+        jobject thiz
+) {
+    abi_handler_free(env, app_references.eventHandler);
 }
 
 JNIEXPORT void JNICALL
@@ -84,7 +105,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     // Store global JNI references (ownership is transferred)
-    jobject jniController = (*env)->NewGlobalRef(env, controller);
+    tunnel_references.jniController = (*env)->NewGlobalRef(env, controller);
+    tunnel_references.statusHandler = abi_handler_create(env, statusHandler);
 
     psp_tunnel_start_args args = { 0 };
     args.bundle = cBundle;
@@ -94,8 +116,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     args.profile = cProfile;
     args.is_interactive = true;
     args.is_daemon = false;
-    args.bindings.controller = jniController;
-    args.bindings.status_ctx = abi_handler_create(env, statusHandler);
+    args.bindings.controller = tunnel_references.jniController;
+    args.bindings.status_ctx = tunnel_references.statusHandler;
     args.bindings.status_cb = abi_connection_status_handler_proxy;
 
     void *handler = abi_handler_create(env, completion);
@@ -115,4 +137,13 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStop(
 ) {
     void *handler = abi_handler_create(env, completion);
     psp_tunnel_stop(handler, abi_completion_proxy);
+}
+
+JNIEXPORT void JNICALL
+Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelRelease(
+        JNIEnv *env,
+        jobject thiz
+) {
+    (*env)->DeleteGlobalRef(env, tunnel_references.jniController);
+    abi_handler_free(env, tunnel_references.statusHandler);
 }

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -78,7 +78,10 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appRelease(
         JNIEnv *env,
         jobject thiz
 ) {
-    abi_handler_free(env, app_references.eventHandler);
+    if (app_references.eventHandler) {
+        abi_handler_free(env, app_references.eventHandler);
+        app_references.eventHandler = NULL;
+    }
 }
 
 JNIEXPORT void JNICALL
@@ -154,6 +157,12 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelRelease(
         JNIEnv *env,
         jobject thiz
 ) {
-    (*env)->DeleteGlobalRef(env, tunnel_references.jniController);
-    abi_handler_free(env, tunnel_references.statusHandler);
+    if (tunnel_references.jniController) {
+        (*env)->DeleteGlobalRef(env, tunnel_references.jniController);
+        tunnel_references.jniController = NULL;
+    }
+    if (tunnel_references.statusHandler) {
+        abi_handler_free(env, tunnel_references.statusHandler);
+        tunnel_references.statusHandler = NULL;
+    }
 }

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -58,13 +58,10 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appImportProfileT
         jstring name,
         jobject completion
 ) {
-    abi_completion_handler *handler = malloc(sizeof(abi_completion_handler));
-    handler->completion_ctx = NULL;
-    handler->completion_cb = (*env)->NewGlobalRef(env, completion);
-
     const char *cText = (*env)->GetStringUTFChars(env, text, NULL);
     const char *cName = (*env)->GetStringUTFChars(env, name, NULL);
-    psp_app_import_profile_text(cText, cName, handler, abi_completion_callback_proxy);
+    void *handler = abi_handler_create(env, completion);
+    psp_app_import_profile_text(cText, cName, handler, abi_completion_proxy);
     (*env)->ReleaseStringUTFChars(env, text, cText);
     (*env)->ReleaseStringUTFChars(env, name, cName);
 }
@@ -101,10 +98,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     args.status_cb = abi_connection_status_handler_proxy;
     args.jni_wrapper = jniVPNWrapper;
 
-    abi_completion_handler *cmp = malloc(sizeof(abi_completion_handler));
-    cmp->completion_ctx = NULL;
-    cmp->completion_cb = (*env)->NewGlobalRef(env, completion);
-    psp_tunnel_start(&args, cmp, abi_completion_callback_proxy);
+    void *handler = abi_handler_create(env, completion);
+    psp_tunnel_start(&args, handler, abi_completion_proxy);
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
@@ -118,8 +113,6 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStop(
         jobject thiz,
         jobject completion
 ) {
-    abi_completion_handler *cmp = malloc(sizeof(abi_completion_handler));
-    cmp->completion_ctx = NULL;
-    cmp->completion_cb = (*env)->NewGlobalRef(env, completion);
-    psp_tunnel_stop(cmp, abi_completion_callback_proxy);
+    void *handler = abi_handler_create(env, completion);
+    psp_tunnel_stop(handler, abi_completion_proxy);
 }

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -56,7 +56,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     args.cache_dir = cCacheDir;
     args.bindings.event_ctx = app_references.eventHandler;
     args.bindings.event_cb = abi_event_handler_proxy;
-    psp_app_init(&args, abi_handler_create(env, completion), abi_completion_proxy);
+    psp_app_init(&args, PSP_CB(abi_handler_create(env, completion), abi_completion_proxy));
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
@@ -70,7 +70,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appDeinit(
         jobject thiz,
         jobject completion
 ) {
-    psp_app_deinit(abi_handler_create(env, completion), abi_completion_proxy);
+    psp_app_deinit(PSP_CB(abi_handler_create(env, completion), abi_completion_proxy));
 }
 
 JNIEXPORT void JNICALL
@@ -95,7 +95,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appImportProfileT
     const char *cText = (*env)->GetStringUTFChars(env, text, NULL);
     const char *cName = (*env)->GetStringUTFChars(env, name, NULL);
     void *handler = abi_handler_create(env, completion);
-    psp_app_import_profile_text(cText, cName, handler, abi_completion_proxy);
+    psp_app_import_profile_text(cText, cName, PSP_CB(handler, abi_completion_proxy));
     (*env)->ReleaseStringUTFChars(env, text, cText);
     (*env)->ReleaseStringUTFChars(env, name, cName);
 }
@@ -134,7 +134,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     args.bindings.status_cb = abi_connection_status_handler_proxy;
 
     void *handler = abi_handler_create(env, completion);
-    psp_tunnel_start(&args, handler, abi_completion_proxy);
+    psp_tunnel_start(&args, PSP_CB(handler, abi_completion_proxy));
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
@@ -149,7 +149,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStop(
         jobject completion
 ) {
     void *handler = abi_handler_create(env, completion);
-    psp_tunnel_stop(handler, abi_completion_proxy);
+    psp_tunnel_stop(PSP_CB(handler, abi_completion_proxy));
 }
 
 JNIEXPORT void JNICALL

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -18,6 +18,8 @@ struct {
     abi_handler *statusHandler;
 } tunnel_references;
 
+#define PSP_JNI_CB(e, c) PSP_CB(abi_handler_create(e, c), abi_completion_proxy)
+
 JNIEXPORT jstring JNICALL
 Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
     jstring jmsg = (*env)->NewStringUTF(env, psp_partout_version());
@@ -56,7 +58,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     args.cache_dir = cCacheDir;
     args.bindings.event_ctx = app_references.eventHandler;
     args.bindings.event_cb = abi_event_handler_proxy;
-    psp_app_init(&args, PSP_CB(abi_handler_create(env, completion), abi_completion_proxy));
+    psp_app_init(&args, PSP_JNI_CB(env, completion));
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
@@ -70,7 +72,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appDeinit(
         jobject thiz,
         jobject completion
 ) {
-    psp_app_deinit(PSP_CB(abi_handler_create(env, completion), abi_completion_proxy));
+    psp_app_deinit(PSP_JNI_CB(env, completion));
 }
 
 JNIEXPORT void JNICALL
@@ -94,8 +96,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appImportProfileT
 ) {
     const char *cText = (*env)->GetStringUTFChars(env, text, NULL);
     const char *cName = (*env)->GetStringUTFChars(env, name, NULL);
-    void *handler = abi_handler_create(env, completion);
-    psp_app_import_profile_text(cText, cName, PSP_CB(handler, abi_completion_proxy));
+    psp_app_import_profile_text(cText, cName, PSP_JNI_CB(env, completion));
     (*env)->ReleaseStringUTFChars(env, text, cText);
     (*env)->ReleaseStringUTFChars(env, name, cName);
 }
@@ -133,8 +134,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     args.bindings.status_ctx = tunnel_references.statusHandler;
     args.bindings.status_cb = abi_connection_status_handler_proxy;
 
-    void *handler = abi_handler_create(env, completion);
-    psp_tunnel_start(&args, PSP_CB(handler, abi_completion_proxy));
+    psp_tunnel_start(&args, PSP_JNI_CB(env, completion));
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
@@ -148,8 +148,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStop(
         jobject thiz,
         jobject completion
 ) {
-    void *handler = abi_handler_create(env, completion);
-    psp_tunnel_stop(PSP_CB(handler, abi_completion_proxy));
+    psp_tunnel_stop(PSP_JNI_CB(env, completion));
 }
 
 JNIEXPORT void JNICALL

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -10,12 +10,12 @@
 #include "helpers.h"
 
 struct {
-    jobject eventHandler;
+    abi_handler *eventHandler;
 } app_references;
 
 struct {
     jobject jniController;
-    jobject statusHandler;
+    abi_handler *statusHandler;
 } tunnel_references;
 
 JNIEXPORT jstring JNICALL

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -28,17 +28,11 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
         jstring constants,
         jstring profilesDir,
         jstring cacheDir,
-        jobject eventContext,
-        jobject eventCallback) {
+        jobject eventHandler) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
     const char *cConstants = (*env)->GetStringUTFChars(env, constants, NULL);
     const char *cProfilesDir = (*env)->GetStringUTFChars(env, profilesDir, NULL);
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
-
-    // JNI handler is the context of the event callback
-    abi_event_handler *handler = malloc(sizeof(abi_event_handler));
-    handler->event_ctx = (*env)->NewGlobalRef(env, eventContext);
-    handler->event_cb = (*env)->NewGlobalRef(env, eventCallback);
 
     psp_app_init_args args = { 0 };
     args.bundle = cBundle;
@@ -46,8 +40,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     args.preferences = "{\"logsPrivateData\": true}";
     args.profiles_dir = cProfilesDir;
     args.cache_dir = cCacheDir;
-    args.event_ctx = handler;
-    args.event_cb = abi_event_callback_proxy;
+    args.event_ctx = abi_handler_create(env, eventHandler);
+    args.event_cb = abi_event_handler_proxy;
     psp_app_init(&args);
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
@@ -83,8 +77,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
         jstring constants,
         jstring profile,
         jstring cacheDir,
-        jobject statusContext,
-        jobject statusCallback,
+        jobject statusHandler,
         jobject vpnWrapper,
         jobject completion
 ) {
@@ -96,11 +89,6 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     // Store global reference of builder wrapper
     jobject jniVPNWrapper = (*env)->NewGlobalRef(env, vpnWrapper);
 
-    // JNI handler is the context of the event callback
-    connection_status_handler *handler = malloc(sizeof(connection_status_handler));
-    handler->status_ctx = (*env)->NewGlobalRef(env, statusContext);
-    handler->status_cb = (*env)->NewGlobalRef(env, statusCallback);
-
     psp_tunnel_start_args args = { 0 };
     args.bundle = cBundle;
     args.constants = cConstants;
@@ -109,8 +97,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     args.profile = cProfile;
     args.is_interactive = true;
     args.is_daemon = false;
-    args.status_ctx = handler;
-    args.status_cb = connection_status_callback_proxy;
+    args.status_ctx = abi_handler_create(env, statusHandler);
+    args.status_cb = abi_connection_status_handler_proxy;
     args.jni_wrapper = jniVPNWrapper;
 
     abi_completion_handler *cmp = malloc(sizeof(abi_completion_handler));

--- a/app-android/app/src/main/cpp/src/passepartout.c
+++ b/app-android/app/src/main/cpp/src/passepartout.c
@@ -40,8 +40,8 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_appInit(
     args.preferences = "{\"logsPrivateData\": true}";
     args.profiles_dir = cProfilesDir;
     args.cache_dir = cCacheDir;
-    args.event_ctx = abi_handler_create(env, eventHandler);
-    args.event_cb = abi_event_handler_proxy;
+    args.bindings.event_ctx = abi_handler_create(env, eventHandler);
+    args.bindings.event_cb = abi_event_handler_proxy;
     psp_app_init(&args);
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
@@ -75,7 +75,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
         jstring profile,
         jstring cacheDir,
         jobject statusHandler,
-        jobject vpnWrapper,
+        jobject controller,
         jobject completion
 ) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
@@ -84,7 +84,7 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     // Store global reference of builder wrapper
-    jobject jniVPNWrapper = (*env)->NewGlobalRef(env, vpnWrapper);
+    jobject jniController = (*env)->NewGlobalRef(env, controller);
 
     psp_tunnel_start_args args = { 0 };
     args.bundle = cBundle;
@@ -94,9 +94,9 @@ Java_com_algoritmico_passepartout_helpers_NativeLibraryWrapper_tunnelStart(
     args.profile = cProfile;
     args.is_interactive = true;
     args.is_daemon = false;
-    args.status_ctx = abi_handler_create(env, statusHandler);
-    args.status_cb = abi_connection_status_handler_proxy;
-    args.jni_wrapper = jniVPNWrapper;
+    args.bindings.controller = jniController;
+    args.bindings.status_ctx = abi_handler_create(env, statusHandler);
+    args.bindings.status_cb = abi_connection_status_handler_proxy;
 
     void *handler = abi_handler_create(env, completion);
     psp_tunnel_start(&args, handler, abi_completion_proxy);

--- a/app-android/app/src/main/cpp/src/passepartout.h
+++ b/app-android/app/src/main/cpp/src/passepartout.h
@@ -44,7 +44,8 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args);
+void psp_app_init(const psp_app_init_args *args, void *ctx, psp_abi_completion completion);
+void psp_app_deinit(void *ctx, psp_abi_completion completion);
 void psp_app_on_foreground(void);
 void psp_app_import_profile_path(const char *path, void *ctx, psp_abi_completion completion);
 void psp_app_import_profile_text(const char *text, const char *filename, void *ctx, psp_abi_completion completion);

--- a/app-android/app/src/main/cpp/src/passepartout.h
+++ b/app-android/app/src/main/cpp/src/passepartout.h
@@ -21,9 +21,9 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  * - Success: code == 0, data = JSON (optional)
  * - Error:   code != 0, data = String
  */
-#define PSPABICompletionCodeOK          0
-#define PSPABICompletionCodeArgs        -2
-#define PSPABICompletionCodeFailure     -1
+#define PSPCompletionCodeOK         0
+#define PSPCompletionCodeArgs       -2
+#define PSPCompletionCodeFailure    -1
 typedef void (*psp_completion_cb)(void *ctx, int code, const char *data);
 typedef struct {
     void *ctx;

--- a/app-android/app/src/main/cpp/src/passepartout.h
+++ b/app-android/app/src/main/cpp/src/passepartout.h
@@ -8,6 +8,7 @@
 #define __PASSEPARTOUT_H
 
 #include <stdbool.h>
+#include <stdlib.h>
 
 /* Common functions. */
 const char *psp_partout_version(void);
@@ -20,7 +21,22 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  * - Success: code == 0, data = JSON (optional)
  * - Error:   code != 0, data = String
  */
-typedef void (*psp_abi_completion)(void *ctx, int code, const char *data);
+typedef void (*psp_abi_completion_cb)(void *ctx, int code, const char *data);
+typedef struct {
+    void *ctx;
+    psp_abi_completion_cb callback;
+} psp_abi_completion;
+
+/* Macros for completion blocks. */
+static inline
+psp_abi_completion PSP_CB(void *ctx, psp_abi_completion_cb callback) {
+    psp_abi_completion completion = {
+        ctx,
+        callback
+    };
+    return completion;
+}
+#define PSP_CB_NOP() PSP_CB(NULL, NULL)
 
 typedef struct {
     void *event_ctx;
@@ -44,11 +60,11 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args, void *ctx, psp_abi_completion completion);
-void psp_app_deinit(void *ctx, psp_abi_completion completion);
+void psp_app_init(const psp_app_init_args *args, psp_abi_completion completion);
+void psp_app_deinit(psp_abi_completion completion);
 void psp_app_on_foreground(void);
-void psp_app_import_profile_path(const char *path, void *ctx, psp_abi_completion completion);
-void psp_app_import_profile_text(const char *text, const char *filename, void *ctx, psp_abi_completion completion);
+void psp_app_import_profile_path(const char *path, psp_abi_completion completion);
+void psp_app_import_profile_text(const char *text, const char *filename, psp_abi_completion completion);
 void psp_app_flush_log(void);
 
 /* Daemon initialization. */
@@ -64,7 +80,7 @@ typedef struct {
 } psp_tunnel_start_args;
 
 /* Daemon functions. */
-void psp_tunnel_start(const psp_tunnel_start_args *args, void *ctx, psp_abi_completion completion);
-void psp_tunnel_stop(void *ctx, psp_abi_completion completion);
+void psp_tunnel_start(const psp_tunnel_start_args *args, psp_abi_completion completion);
+void psp_tunnel_stop(psp_abi_completion completion);
 
 #endif

--- a/app-android/app/src/main/cpp/src/passepartout.h
+++ b/app-android/app/src/main/cpp/src/passepartout.h
@@ -22,6 +22,17 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  */
 typedef void (*psp_abi_completion)(void *ctx, int code, const char *data);
 
+typedef struct {
+    void *event_ctx;
+    psp_event_callback event_cb;
+} psp_app_bindings;
+
+typedef struct {
+    void *controller;
+    void *status_ctx;
+    psp_event_callback status_cb;
+} psp_tunnel_bindings;
+
 /* App initialization. */
 typedef struct {
     const char *bundle;
@@ -29,8 +40,7 @@ typedef struct {
     const char *preferences;
     const char *profiles_dir;
     const char *cache_dir;
-    void *event_ctx;
-    psp_event_callback event_cb;
+    psp_app_bindings bindings;
 } psp_app_init_args;
 
 /* App functions. */
@@ -49,9 +59,7 @@ typedef struct {
     const char *profile;
     bool is_interactive;
     bool is_daemon;
-    void *status_ctx;
-    psp_event_callback status_cb;
-    void *jni_wrapper;
+    psp_tunnel_bindings bindings;
 } psp_tunnel_start_args;
 
 /* Daemon functions. */

--- a/app-android/app/src/main/cpp/src/passepartout.h
+++ b/app-android/app/src/main/cpp/src/passepartout.h
@@ -16,9 +16,11 @@ char *psp_readfile(const char *rel_path, const char *parent);
 /* Events callback. */
 typedef void (*psp_event_callback)(void *event_ctx, const char *event);
 
-/* Completion callbacks. */
-/* Success: code == 0. */
-typedef void (*psp_abi_completion)(void *ctx, int code, const char *error_message);
+/* Completion callback.
+ * - Success: code == 0, data = JSON (optional)
+ * - Error:   code != 0, data = String
+ */
+typedef void (*psp_abi_completion)(void *ctx, int code, const char *data);
 
 /* App initialization. */
 typedef struct {

--- a/app-android/app/src/main/cpp/src/passepartout.h
+++ b/app-android/app/src/main/cpp/src/passepartout.h
@@ -21,19 +21,19 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  * - Success: code == 0, data = JSON (optional)
  * - Error:   code != 0, data = String
  */
-typedef void (*psp_abi_completion_cb)(void *ctx, int code, const char *data);
+#define PSPABICompletionCodeOK          0
+#define PSPABICompletionCodeArgs        -2
+#define PSPABICompletionCodeFailure     -1
+typedef void (*psp_completion_cb)(void *ctx, int code, const char *data);
 typedef struct {
     void *ctx;
-    psp_abi_completion_cb callback;
-} psp_abi_completion;
+    psp_completion_cb callback;
+} psp_completion;
 
 /* Macros for completion blocks. */
 static inline
-psp_abi_completion PSP_CB(void *ctx, psp_abi_completion_cb callback) {
-    psp_abi_completion completion = {
-        ctx,
-        callback
-    };
+psp_completion PSP_CB(void *ctx, psp_completion_cb callback) {
+    psp_completion completion = { ctx, callback };
     return completion;
 }
 #define PSP_CB_NOP() PSP_CB(NULL, NULL)
@@ -60,11 +60,11 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args, psp_abi_completion completion);
-void psp_app_deinit(psp_abi_completion completion);
+void psp_app_init(const psp_app_init_args *args, psp_completion completion);
+void psp_app_deinit(psp_completion completion);
 void psp_app_on_foreground(void);
-void psp_app_import_profile_path(const char *path, psp_abi_completion completion);
-void psp_app_import_profile_text(const char *text, const char *filename, psp_abi_completion completion);
+void psp_app_import_profile_path(const char *path, psp_completion completion);
+void psp_app_import_profile_text(const char *text, const char *filename, psp_completion completion);
 void psp_app_flush_log(void);
 
 /* Daemon initialization. */
@@ -80,7 +80,7 @@ typedef struct {
 } psp_tunnel_start_args;
 
 /* Daemon functions. */
-void psp_tunnel_start(const psp_tunnel_start_args *args, psp_abi_completion completion);
-void psp_tunnel_stop(psp_abi_completion completion);
+void psp_tunnel_start(const psp_tunnel_start_args *args, psp_completion completion);
+void psp_tunnel_stop(psp_completion completion);
 
 #endif

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -35,7 +35,7 @@ val globalJsonCoder = Json {
 }
 
 class MainActivity : ComponentActivity(), ABIEventHandler {
-    private val wrapper = NativeLibraryWrapper()
+    private val library = NativeLibraryWrapper()
     private val mainHandler = Handler(Looper.getMainLooper())
     private var headers = mutableStateOf<Map<String, AppProfileHeader>>(emptyMap())
     private lateinit var tunnelStrategy: AndroidTunnelStrategy
@@ -64,7 +64,7 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
         super.onCreate(savedInstanceState)
 
         // Start easy, test Partout version
-        val version = wrapper.partoutVersion()
+        val version = library.partoutVersion()
         Log.e("Passepartout", ">>> $version")
 
         // Initialize app and event callback
@@ -74,7 +74,7 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
             mkdirs()
         }.absolutePath
         val cachePath = cacheDir.absolutePath
-        wrapper.appInit(
+        library.appInit(
             bundle,
             constants,
             profilesDir,
@@ -103,7 +103,7 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
 
     override fun onStart() {
         super.onStart()
-        wrapper.appOnForeground()
+        library.appOnForeground()
     }
 
     fun startVpnService() {
@@ -130,7 +130,7 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
     fun importProfile(connect: Boolean = false) {
 //        val file = String(assets.open("vps.conf").readBytes())
         val file = String(assets.open("vps-crypt-v2.ovpn").readBytes())
-        wrapper.appImportProfileText(file, "SomeName") { code, json ->
+        library.appImportProfileText(file, "SomeName") { code, json ->
             if (code == 0) {
                 Log.i("Passepartout", "Import success!")
             } else {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : ComponentActivity() {
     private val library = NativeLibraryWrapper()
     private var headers = mutableStateOf<Map<String, AppProfileHeader>>(emptyMap())
     private var eventSubscription: Closeable? = null
+    private var isAppInitialized = false
     private lateinit var tunnelStrategy: AndroidTunnelStrategy
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,7 +61,17 @@ class MainActivity : ComponentActivity() {
             profilesDir,
             cachePath,
             ABIEventDispatcher,
-            { _, _ -> }
+            { code, json ->
+                runOnUiThread {
+                    if (code == 0) {
+                        isAppInitialized = true
+                        Log.e("Passepartout", ">>> Started app")
+                    } else {
+                        Log.e("Passepartout", "Unable to init app (code=$code): $json")
+                        destroyApp()
+                    }
+                }
+            }
         )
         tunnelStrategy = AndroidTunnelStrategy(
             context = this,
@@ -90,10 +101,19 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         eventSubscription?.close()
         eventSubscription = null
-        library.appDeinit { _, _ ->
+        if (isAppInitialized) {
+            library.appDeinit { _, _ ->
+                library.appRelease()
+            }
+        } else {
             library.appRelease()
         }
         super.onDestroy()
+    }
+
+    private fun destroyApp() {
+        if (isFinishing || isDestroyed) return
+        finishAndRemoveTask()
     }
 
     private fun handleEvent(eventJSON: String) {
@@ -103,11 +123,9 @@ class MainActivity : ComponentActivity() {
             is ProfileEventRefresh -> {
                 headers.value = event.headers
             }
-
             is ProfileEventSave -> {
                 Log.i("Passepartout", ">>> MainActivity: profile = ${event.profile}")
             }
-
             else -> {
                 // Other events
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -18,7 +18,7 @@ import com.algoritmico.passepartout.abi.AppProfileHeader
 import com.algoritmico.passepartout.abi.Event
 import com.algoritmico.passepartout.abi.ProfileEventRefresh
 import com.algoritmico.passepartout.abi.ProfileEventSave
-import com.algoritmico.passepartout.helpers.ABIEventCallback
+import com.algoritmico.passepartout.helpers.ABIEventHandler
 import com.algoritmico.passepartout.helpers.NativeLibraryWrapper
 import io.partout.abi.TaggedProfile
 import io.partout.jni.AndroidTunnelStrategy
@@ -34,13 +34,13 @@ val globalJsonCoder = Json {
     ignoreUnknownKeys = true
 }
 
-class MainActivity : ComponentActivity(), ABIEventCallback {
+class MainActivity : ComponentActivity(), ABIEventHandler {
     private val wrapper = NativeLibraryWrapper()
     private val mainHandler = Handler(Looper.getMainLooper())
     private var headers = mutableStateOf<Map<String, AppProfileHeader>>(emptyMap())
     private lateinit var tunnelStrategy: AndroidTunnelStrategy
 
-    override fun onEvent(eventCtx: Any?, eventJSON: String) {
+    override fun onEvent(eventJSON: String) {
         mainHandler.post {
             val event: Event = globalJsonCoder.decodeFromString(eventJSON)
             Log.i("Passepartout", ">>> MainActivity: $event")
@@ -74,14 +74,12 @@ class MainActivity : ComponentActivity(), ABIEventCallback {
             mkdirs()
         }.absolutePath
         val cachePath = cacheDir.absolutePath
-        val eventHandler = this
         wrapper.appInit(
             bundle,
             constants,
             profilesDir,
             cachePath,
-            this,
-            eventHandler
+            this
         )
         tunnelStrategy = AndroidTunnelStrategy(
             context = this,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -130,11 +130,11 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
     fun importProfile(connect: Boolean = false) {
 //        val file = String(assets.open("vps.conf").readBytes())
         val file = String(assets.open("vps-crypt-v2.ovpn").readBytes())
-        wrapper.appImportProfileText(file, "SomeName") { ctx, code, errorMessage ->
+        wrapper.appImportProfileText(file, "SomeName") { code, json ->
             if (code == 0) {
                 Log.i("Passepartout", "Import success!")
             } else {
-                Log.e("Passepartout", "Import failure (code=$code): $errorMessage")
+                Log.e("Passepartout", "Import failure (code=$code): $json")
             }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -79,7 +79,8 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
             constants,
             profilesDir,
             cachePath,
-            this
+            this,
+            { _, _ -> }
         )
         tunnelStrategy = AndroidTunnelStrategy(
             context = this,
@@ -104,6 +105,13 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
     override fun onStart() {
         super.onStart()
         library.appOnForeground()
+    }
+
+    override fun onDestroy() {
+        library.appDeinit { _, _ ->
+            library.appRelease()
+        }
+        super.onDestroy()
     }
 
     fun startVpnService() {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -5,8 +5,6 @@
 package com.algoritmico.passepartout
 
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -18,7 +16,7 @@ import com.algoritmico.passepartout.abi.AppProfileHeader
 import com.algoritmico.passepartout.abi.Event
 import com.algoritmico.passepartout.abi.ProfileEventRefresh
 import com.algoritmico.passepartout.abi.ProfileEventSave
-import com.algoritmico.passepartout.helpers.ABIEventHandler
+import com.algoritmico.passepartout.helpers.ABIEventDispatcher
 import com.algoritmico.passepartout.helpers.NativeLibraryWrapper
 import io.partout.abi.TaggedProfile
 import io.partout.jni.AndroidTunnelStrategy
@@ -29,36 +27,17 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.io.Closeable
 
 val globalJsonCoder = Json {
     ignoreUnknownKeys = true
 }
 
-class MainActivity : ComponentActivity(), ABIEventHandler {
+class MainActivity : ComponentActivity() {
     private val library = NativeLibraryWrapper()
-    private val mainHandler = Handler(Looper.getMainLooper())
     private var headers = mutableStateOf<Map<String, AppProfileHeader>>(emptyMap())
+    private var eventSubscription: Closeable? = null
     private lateinit var tunnelStrategy: AndroidTunnelStrategy
-
-    override fun onEvent(eventJSON: String) {
-        mainHandler.post {
-            val event: Event = globalJsonCoder.decodeFromString(eventJSON)
-            Log.i("Passepartout", ">>> MainActivity: $event")
-            when (event) {
-                is ProfileEventRefresh -> {
-                    headers.value = event.headers
-                }
-
-                is ProfileEventSave -> {
-                    Log.i("Passepartout", ">>> MainActivity: profile = ${event.profile}")
-                }
-
-                else -> {
-                    // Other events
-                }
-            }
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,12 +53,13 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
             mkdirs()
         }.absolutePath
         val cachePath = cacheDir.absolutePath
+        eventSubscription = ABIEventDispatcher.register(::handleEvent)
         library.appInit(
             bundle,
             constants,
             profilesDir,
             cachePath,
-            this,
+            ABIEventDispatcher,
             { _, _ -> }
         )
         tunnelStrategy = AndroidTunnelStrategy(
@@ -108,10 +88,30 @@ class MainActivity : ComponentActivity(), ABIEventHandler {
     }
 
     override fun onDestroy() {
+        eventSubscription?.close()
+        eventSubscription = null
         library.appDeinit { _, _ ->
             library.appRelease()
         }
         super.onDestroy()
+    }
+
+    private fun handleEvent(eventJSON: String) {
+        val event: Event = globalJsonCoder.decodeFromString(eventJSON)
+        Log.i("Passepartout", ">>> MainActivity: $event")
+        when (event) {
+            is ProfileEventRefresh -> {
+                headers.value = event.headers
+            }
+
+            is ProfileEventSave -> {
+                Log.i("Passepartout", ">>> MainActivity: profile = ${event.profile}")
+            }
+
+            else -> {
+                // Other events
+            }
+        }
     }
 
     fun startVpnService() {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -157,10 +157,12 @@ class MainActivity : ComponentActivity() {
 //        val file = String(assets.open("vps.conf").readBytes())
         val file = String(assets.open("vps-crypt-v2.ovpn").readBytes())
         library.appImportProfileText(file, "SomeName") { code, json ->
-            if (code == 0) {
-                Log.i("Passepartout", "Import success!")
-            } else {
-                Log.e("Passepartout", "Import failure (code=$code): $json")
+            runOnUiThread {
+                if (code == 0) {
+                    Log.i("Passepartout", "Import success!")
+                } else {
+                    Log.e("Passepartout", "Import failure (code=$code): $json")
+                }
             }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
@@ -12,7 +12,7 @@ import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.algoritmico.passepartout.abi.OnConnectionStatus
-import com.algoritmico.passepartout.helpers.ConnectionStatusCallback
+import com.algoritmico.passepartout.helpers.ABIConnectionStatusHandler
 import com.algoritmico.passepartout.helpers.NativeLibraryWrapper
 import io.partout.jni.AndroidTunnelController
 import io.partout.jni.AndroidTunnelStrategy
@@ -24,7 +24,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class PassepartoutVPNService: VpnService(), ConnectionStatusCallback {
+class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
     private val library = NativeLibraryWrapper()
     private val vpnWrapper = AndroidTunnelController(this)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -78,7 +78,6 @@ class PassepartoutVPNService: VpnService(), ConnectionStatusCallback {
                     profileJSON,
                     cachePath,
                     statusHandler,
-                    statusHandler,
                     vpnWrapper
                 ) { _, code, errorMessage ->
                     serviceScope.launch {
@@ -120,7 +119,7 @@ class PassepartoutVPNService: VpnService(), ConnectionStatusCallback {
         }
     }
 
-    override fun onStatus(statusCtx: Any?, onStatusJSON: String) {
+    override fun onStatus(onStatusJSON: String) {
         val onStatus = globalJsonCoder.decodeFromString<OnConnectionStatus>(onStatusJSON)
         Log.i("Passepartout", ">>> onStatus = ${onStatus}")
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
@@ -88,6 +88,7 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
                             stopForeground(STOP_FOREGROUND_REMOVE)
                             stopSelf()
                             isRunning = false
+                            library.tunnelRelease()
                         }
                     }
                 }
@@ -113,6 +114,7 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
                         stopSelf()
                         serviceScope.cancel()
                         isRunning = false
+                        library.tunnelRelease()
                     }
                 }
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
@@ -12,7 +12,7 @@ import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.algoritmico.passepartout.abi.OnConnectionStatus
-import com.algoritmico.passepartout.helpers.ABIConnectionStatusHandler
+import com.algoritmico.passepartout.helpers.ABIStatusDispatcher
 import com.algoritmico.passepartout.helpers.NativeLibraryWrapper
 import io.partout.jni.AndroidTunnelController
 import io.partout.jni.AndroidTunnelStrategy
@@ -23,13 +23,15 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.Closeable
 
-class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
+class PassepartoutVPNService: VpnService() {
     private val library = NativeLibraryWrapper()
     private val vpnWrapper = AndroidTunnelController(this)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var startJob: Job? = null
     private var stopJob: Job? = null
+    private var statusSubscription: Closeable? = null
     private var isRunning = false
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -52,6 +54,8 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
         if (isRunning) {
             stopVpn()
         } else {
+            statusSubscription?.close()
+            statusSubscription = null
             serviceScope.cancel()
         }
         super.onDestroy()
@@ -59,7 +63,6 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
 
     private fun startVpn(profileJSON: String) {
         if (isRunning) { return }
-        val statusHandler = this
         val notification = createNotification()
         startForeground(1, notification)
         isRunning = true
@@ -71,13 +74,15 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
 
             val cachePath = cacheDir.absolutePath
             Log.e("Passepartout", ">>> Starting daemon (cache: $cachePath)")
+            statusSubscription?.close()
+            statusSubscription = ABIStatusDispatcher.register(::handleStatus)
             withContext(Dispatchers.IO) {
                 library.tunnelStart(
                     bundle,
                     constants,
                     profileJSON,
                     cachePath,
-                    statusHandler,
+                    ABIStatusDispatcher,
                     vpnWrapper
                 ) { code, json ->
                     serviceScope.launch {
@@ -88,7 +93,7 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
                             stopForeground(STOP_FOREGROUND_REMOVE)
                             stopSelf()
                             isRunning = false
-                            library.tunnelRelease()
+                            releaseTunnelReferences()
                         }
                     }
                 }
@@ -112,16 +117,22 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
                         }
                         stopForeground(STOP_FOREGROUND_REMOVE)
                         stopSelf()
-                        serviceScope.cancel()
                         isRunning = false
-                        library.tunnelRelease()
+                        releaseTunnelReferences()
+                        serviceScope.cancel()
                     }
                 }
             }
         }
     }
 
-    override fun onStatus(onStatusJSON: String) {
+    private fun releaseTunnelReferences() {
+        statusSubscription?.close()
+        statusSubscription = null
+        library.tunnelRelease()
+    }
+
+    private fun handleStatus(onStatusJSON: String) {
         val onStatus = globalJsonCoder.decodeFromString<OnConnectionStatus>(onStatusJSON)
         Log.i("Passepartout", ">>> onStatus = ${onStatus}")
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
@@ -79,12 +79,12 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
                     cachePath,
                     statusHandler,
                     vpnWrapper
-                ) { _, code, errorMessage ->
+                ) { code, json ->
                     serviceScope.launch {
                         if (code == 0) {
                             Log.e("Passepartout", ">>> Started daemon")
                         } else {
-                            Log.e("Passepartout", "Unable to start daemon (code=$code): $errorMessage")
+                            Log.e("Passepartout", "Unable to start daemon (code=$code): $json")
                             stopForeground(STOP_FOREGROUND_REMOVE)
                             stopSelf()
                             isRunning = false
@@ -102,12 +102,12 @@ class PassepartoutVPNService: VpnService(), ABIConnectionStatusHandler {
         stopJob = serviceScope.launch {
             Log.e("Passepartout", ">>> Stopping daemon")
             withContext(Dispatchers.IO) {
-                library.tunnelStop { _, code, errorMessage ->
+                library.tunnelStop { code, json ->
                     serviceScope.launch {
                         if (code == 0) {
                             Log.e("Passepartout", ">>> Stopped daemon")
                         } else {
-                            Log.e("Passepartout", "Unable to stop daemon (code=$code): $errorMessage")
+                            Log.e("Passepartout", "Unable to stop daemon (code=$code): $json")
                         }
                         stopForeground(STOP_FOREGROUND_REMOVE)
                         stopSelf()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABICompletionCallback.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABICompletionCallback.kt
@@ -5,5 +5,5 @@
 package com.algoritmico.passepartout.helpers
 
 fun interface ABICompletionCallback {
-    fun onComplete(eventCtx: Any?, code: Int, errorMessage: String?)
+    fun onComplete(code: Int, json: String?)
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABIConnectionStatusHandler.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABIConnectionStatusHandler.kt
@@ -1,0 +1,5 @@
+package com.algoritmico.passepartout.helpers
+
+fun interface ABIConnectionStatusHandler {
+    fun onStatus(onStatusJSON: String)
+}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABIDispatchers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABIDispatchers.kt
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package com.algoritmico.passepartout.helpers
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import java.io.Closeable
+import java.util.concurrent.CopyOnWriteArraySet
+
+private class ABIStringDispatcher {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val listeners = CopyOnWriteArraySet<(String) -> Unit>()
+
+    fun register(listener: (String) -> Unit): Closeable {
+        listeners.add(listener)
+        return object : Closeable {
+            override fun close() {
+                listeners.remove(listener)
+            }
+        }
+    }
+
+    fun dispatch(value: String) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            dispatchOnMain(value)
+        } else {
+            mainHandler.post {
+                dispatchOnMain(value)
+            }
+        }
+    }
+
+    private fun dispatchOnMain(value: String) {
+        listeners.forEach { listener ->
+            runCatching {
+                listener(value)
+            }.onFailure {
+                Log.e("Passepartout", "Unable to dispatch ABI callback", it)
+            }
+        }
+    }
+}
+
+object ABIEventDispatcher : ABIEventHandler {
+    private val dispatcher = ABIStringDispatcher()
+
+    override fun onEvent(eventJSON: String) {
+        dispatcher.dispatch(eventJSON)
+    }
+
+    fun register(listener: (String) -> Unit): Closeable =
+        dispatcher.register(listener)
+}
+
+object ABIStatusDispatcher : ABIConnectionStatusHandler {
+    private val dispatcher = ABIStringDispatcher()
+
+    override fun onStatus(onStatusJSON: String) {
+        dispatcher.dispatch(onStatusJSON)
+    }
+
+    fun register(listener: (String) -> Unit): Closeable =
+        dispatcher.register(listener)
+}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABIEventHandler.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ABIEventHandler.kt
@@ -4,6 +4,6 @@
 
 package com.algoritmico.passepartout.helpers
 
-fun interface ABIEventCallback {
-    fun onEvent(eventCtx: Any?, eventJSON: String)
+fun interface ABIEventHandler {
+    fun onEvent(eventJSON: String)
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ConnectionStatusCallback.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/ConnectionStatusCallback.kt
@@ -1,5 +1,0 @@
-package com.algoritmico.passepartout.helpers
-
-fun interface ConnectionStatusCallback {
-    fun onStatus(statusCtx: Any?, onStatusJSON: String)
-}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
@@ -14,8 +14,10 @@ class NativeLibraryWrapper {
         constants: String,
         profilesDir: String,
         cacheDir: String,
-        eventHandler: ABIEventHandler
+        eventHandler: ABIEventHandler,
+        completion: ABICompletionCallback
     )
+    external fun appDeinit(completion: ABICompletionCallback)
     external fun appOnForeground()
     external fun appImportProfileText(
         text: String,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
@@ -14,8 +14,7 @@ class NativeLibraryWrapper {
         constants: String,
         profilesDir: String,
         cacheDir: String,
-        eventContext: Any,
-        eventCallback: ABIEventCallback
+        eventHandler: ABIEventHandler
     )
     external fun appOnForeground()
     external fun appImportProfileText(
@@ -28,8 +27,7 @@ class NativeLibraryWrapper {
         constants: String,
         profile: String,
         cacheDir: String,
-        statusContext: Any,
-        statusCallback: ConnectionStatusCallback,
+        statusHandler: ABIConnectionStatusHandler,
         vpn: AndroidTunnelController,
         completion: ABICompletionCallback
     )

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
@@ -35,6 +35,10 @@ class NativeLibraryWrapper {
         completion: ABICompletionCallback
     )
 
+    // These are specific to Android to release JNI references
+    external fun appRelease()
+    external fun tunnelRelease()
+
     companion object {
         init {
             try {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/helpers/NativeLibraryWrapper.kt
@@ -28,7 +28,7 @@ class NativeLibraryWrapper {
         profile: String,
         cacheDir: String,
         statusHandler: ABIConnectionStatusHandler,
-        vpn: AndroidTunnelController,
+        controller: AndroidTunnelController,
         completion: ABICompletionCallback
     )
     external fun tunnelStop(

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
@@ -8,6 +8,7 @@ import Partout
 
 extension AppABI {
     public static func forCrossPlatform(
+        bindings: psp_app_bindings,
         appBundleData: Data,
         appConstantsData: Data,
         preferencesData: Data?,
@@ -73,7 +74,7 @@ extension AppABI {
         let versionChecker = VersionChecker()
         let webReceiverManager = WebReceiverManager()
 
-        return AppABI(
+        let abi = AppABI(
             apiManager: nil,
             appConfiguration: appConfiguration,
             appEncoder: appEncoder,
@@ -89,6 +90,30 @@ extension AppABI {
             versionChecker: versionChecker,
             webReceiverManager: webReceiverManager
         )
+
+        // Register for events
+        let eventContext = bindings.event_ctx
+        let eventCallback = bindings.event_cb
+        let eventHandler = ABI.EventHandler(
+            context: eventContext,
+            callback: { ctx, event in
+                guard let eventCallback else { return }
+                // Enrich event JSON with metadata for decoding
+                let wrapper = ABI.EventWrapper(event)
+                do {
+                    // Dispatch JSON event to cross-platform apps
+                    let json = try ABI.encodeWrapper(wrapper)
+                    json.withCString {
+                        eventCallback(ctx, $0)
+                    }
+                } catch {
+                    assertionFailure("Unable to encode event: \(event), \(error)")
+                }
+            }
+        )
+        abi.registerEvents(eventHandler)
+
+        return abi
     }
 }
 #endif

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
@@ -41,6 +41,7 @@ public final class AppABI: Sendable {
     private var launchTask: Task<Void, Error>?
     private var pendingTask: Task<Void, Never>?
     private var didLoadReceiptDate: Date?
+    private var handler: ABI.EventHandler?
     private var subscriptions: [Task<Void, Never>]
 
     public init(
@@ -105,13 +106,16 @@ public final class AppABI: Sendable {
 }
 
 extension AppABI {
-    public func registerEvents(_ handler: ABI.EventHandler?) {
+    public func registerEvents(_ newHandler: ABI.EventHandler?) {
         let configEvents = configManager.didChange.subscribe()
         let iapEvents = iapManager.didChange.subscribe()
         let profileEvents = profileManager.didChange.subscribe()
         let tunnelEvents = tunnelManager.observeObjects()
         let versionEvents = versionChecker.didChange.subscribe()
         let webReceiverEvents = webReceiverManager.didChange.subscribe()
+
+        // Set new handler
+        handler = newHandler
 
         // Post initial state AFTER events registration (in case it was missed)
         iapManager.postInitialState()
@@ -160,6 +164,10 @@ extension AppABI {
                 }
             }
         })
+    }
+
+    public func unregisterEvents() {
+        handler = nil
     }
 
     func dispatch(_ event: ABI.Event, _ handler: ABI.EventHandler?) {

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -38,7 +38,7 @@ public func __psp_app_init(
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
-            callback(0, nil)
+            callback(PSPABICompletionCodeOK, nil)
         } catch {
             fatalError("Unable to start app: \(error)")
         }
@@ -50,7 +50,7 @@ public func __psp_app_deinit(completion: psp_abi_completion) {
     ABI.run(completion) { callback in
         abi?.unregisterEvents()
         abi = nil
-        callback(0, nil)
+        callback(PSPABICompletionCodeOK, nil)
     }
 }
 
@@ -66,14 +66,17 @@ public func __psp_app_import_profile_path(
     path: UnsafePointer<CChar>?,
     completion: psp_abi_completion
 ) {
-    guard let abi, let path else { return }
+    guard let abi, let path else {
+        completion.callback?(completion.ctx, PSPABICompletionCodeArgs, nil)
+        return
+    }
     let swiftPath = String(cString: path)
     ABI.run(completion) { callback in
         do {
             try await abi.profile.importFile(swiftPath, passphrase: nil)
-            callback(0, nil)
+            callback(PSPABICompletionCodeOK, nil)
         } catch {
-            callback(-1, error.localizedDescription)
+            callback(PSPABICompletionCodeFailure, error.localizedDescription)
         }
     }
 }
@@ -84,15 +87,18 @@ public func __psp_app_import_profile_text(
     filename: UnsafePointer<CChar>?,
     completion: psp_abi_completion
 ) {
-    guard let abi, let text, let filename else { return }
+    guard let abi, let text, let filename else {
+        completion.callback?(completion.ctx, PSPABICompletionCodeArgs, nil)
+        return
+    }
     let swiftText = String(cString: text)
     let swiftFilename = String(cString: filename)
     ABI.run(completion) { callback in
         do {
             try await abi.profile.importText(swiftText, filename: swiftFilename, passphrase: nil)
-            callback(0, nil)
+            callback(PSPABICompletionCodeOK, nil)
         } catch {
-            callback(-1, error.localizedDescription)
+            callback(PSPABICompletionCodeFailure, error.localizedDescription)
         }
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -12,8 +12,7 @@ private var abi: AppABI?
 @c(psp_app_init)
 public func __psp_app_init(
     args: UnsafePointer<psp_app_init_args>?,
-    context: UnsafeMutableRawPointer?,
-    completion: psp_abi_completion?
+    completion: psp_abi_completion
 ) {
     guard let args,
           let appBundleData = args.pointee.bundle?.asJSONData,
@@ -29,8 +28,7 @@ public func __psp_app_init(
     let profilesDir = String(cString: cProfilesDir)
     let cachesURL = URL(filePath: String(cString: cCacheDir))
     nonisolated(unsafe) let bindings = args.pointee.bindings
-    nonisolated(unsafe) let unsafeCtx = context
-    ABI.run {
+    ABI.run(completion) { callback in
         do {
             abi = try AppABI.forCrossPlatform(
                 bindings: bindings,
@@ -40,7 +38,7 @@ public func __psp_app_init(
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
-            completion?(unsafeCtx, 0, nil)
+            callback(0, nil)
         } catch {
             fatalError("Unable to start app: \(error)")
         }
@@ -48,15 +46,11 @@ public func __psp_app_init(
 }
 
 @c(psp_app_deinit)
-public func __psp_app_deinit(
-    context: UnsafeMutableRawPointer?,
-    completion: psp_abi_completion?
-) {
-    nonisolated(unsafe) let unsafeCtx = context
-    ABI.run {
+public func __psp_app_deinit(completion: psp_abi_completion) {
+    ABI.run(completion) { callback in
         abi?.unregisterEvents()
         abi = nil
-        completion?(unsafeCtx, 0, nil)
+        callback(0, nil)
     }
 }
 
@@ -70,17 +64,16 @@ public func __psp_app_on_foreground() {
 @c(psp_app_import_profile_path)
 public func __psp_app_import_profile_path(
     path: UnsafePointer<CChar>?,
-    context: UnsafeMutableRawPointer?,
-    completion: psp_abi_completion?
+    completion: psp_abi_completion
 ) {
     guard let abi, let path else { return }
     let swiftPath = String(cString: path)
-    ABI.run(context) { ctx in
+    ABI.run(completion) { callback in
         do {
             try await abi.profile.importFile(swiftPath, passphrase: nil)
-            completion?(ctx, 0, nil)
+            callback(0, nil)
         } catch {
-            completion?(ctx, -1, error.localizedDescription)
+            callback(-1, error.localizedDescription)
         }
     }
 }
@@ -89,18 +82,17 @@ public func __psp_app_import_profile_path(
 public func __psp_app_import_profile_text(
     text: UnsafePointer<CChar>?,
     filename: UnsafePointer<CChar>?,
-    context: UnsafeMutableRawPointer?,
-    completion: psp_abi_completion?
+    completion: psp_abi_completion
 ) {
     guard let abi, let text, let filename else { return }
     let swiftText = String(cString: text)
     let swiftFilename = String(cString: filename)
-    ABI.run(context) { ctx in
+    ABI.run(completion) { callback in
         do {
             try await abi.profile.importText(swiftText, filename: swiftFilename, passphrase: nil)
-            completion?(ctx, 0, nil)
+            callback(0, nil)
         } catch {
-            completion?(ctx, -1, error.localizedDescription)
+            callback(-1, error.localizedDescription)
         }
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -22,37 +22,19 @@ public func __psp_app_init(args: UnsafePointer<psp_app_init_args>?) {
     if args.pointee.preferences != nil {
         assert(preferencesData != nil, "Unable to decode preferences")
     }
-    let eventContext = args.pointee.bindings.event_ctx
-    let eventCallback = args.pointee.bindings.event_cb
-    let eventHandler = ABI.EventHandler(
-        context: eventContext,
-        callback: { ctx, event in
-            guard let eventCallback else { return }
-            // Enrich event JSON with metadata for decoding
-            let wrapper = ABI.EventWrapper(event)
-            do {
-                // Dispatch JSON event to cross-platform apps
-                let json = try ABI.encodeWrapper(wrapper)
-                json.withCString {
-                    eventCallback(ctx, $0)
-                }
-            } catch {
-                assertionFailure("Unable to encode event: \(event), \(error)")
-            }
-        }
-    )
     let profilesDir = String(cString: cProfilesDir)
     let cachesURL = URL(filePath: String(cString: cCacheDir))
+    nonisolated(unsafe) let bindings = args.pointee.bindings
     ABI.run {
         do {
             abi = try AppABI.forCrossPlatform(
+                bindings: bindings,
                 appBundleData: appBundleData,
                 appConstantsData: appConstantsData,
                 preferencesData: preferencesData,
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
-            abi?.registerEvents(eventHandler)
         } catch {
             fatalError("Unable to start app: \(error)")
         }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -10,7 +10,11 @@ nonisolated(unsafe)
 private var abi: AppABI?
 
 @c(psp_app_init)
-public func __psp_app_init(args: UnsafePointer<psp_app_init_args>?) {
+public func __psp_app_init(
+    args: UnsafePointer<psp_app_init_args>?,
+    context: UnsafeMutableRawPointer?,
+    completion: psp_abi_completion?
+) {
     guard let args,
           let appBundleData = args.pointee.bundle?.asJSONData,
           let appConstantsData = args.pointee.constants?.asJSONData,
@@ -25,6 +29,7 @@ public func __psp_app_init(args: UnsafePointer<psp_app_init_args>?) {
     let profilesDir = String(cString: cProfilesDir)
     let cachesURL = URL(filePath: String(cString: cCacheDir))
     nonisolated(unsafe) let bindings = args.pointee.bindings
+    nonisolated(unsafe) let unsafeCtx = context
     ABI.run {
         do {
             abi = try AppABI.forCrossPlatform(
@@ -35,6 +40,7 @@ public func __psp_app_init(args: UnsafePointer<psp_app_init_args>?) {
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
+            completion?(unsafeCtx, 0, nil)
         } catch {
             fatalError("Unable to start app: \(error)")
         }
@@ -42,8 +48,16 @@ public func __psp_app_init(args: UnsafePointer<psp_app_init_args>?) {
 }
 
 @c(psp_app_deinit)
-public func __psp_app_deinit() {
-    abi = nil
+public func __psp_app_deinit(
+    context: UnsafeMutableRawPointer?,
+    completion: psp_abi_completion?
+) {
+    nonisolated(unsafe) let unsafeCtx = context
+    ABI.run {
+        abi?.unregisterEvents()
+        abi = nil
+        completion?(unsafeCtx, 0, nil)
+    }
 }
 
 @c(psp_app_on_foreground)

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -12,7 +12,7 @@ private var abi: AppABI?
 @c(psp_app_init)
 public func __psp_app_init(
     args: UnsafePointer<psp_app_init_args>?,
-    completion: psp_abi_completion
+    completion: psp_completion
 ) {
     guard let args,
           let appBundleData = args.pointee.bundle?.asJSONData,
@@ -38,7 +38,7 @@ public func __psp_app_init(
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
-            callback(PSPABICompletionCodeOK, nil)
+            callback(PSPCompletionCodeOK, nil)
         } catch {
             fatalError("Unable to start app: \(error)")
         }
@@ -46,11 +46,11 @@ public func __psp_app_init(
 }
 
 @c(psp_app_deinit)
-public func __psp_app_deinit(completion: psp_abi_completion) {
+public func __psp_app_deinit(completion: psp_completion) {
     ABI.run(completion) { callback in
         abi?.unregisterEvents()
         abi = nil
-        callback(PSPABICompletionCodeOK, nil)
+        callback(PSPCompletionCodeOK, nil)
     }
 }
 
@@ -64,19 +64,19 @@ public func __psp_app_on_foreground() {
 @c(psp_app_import_profile_path)
 public func __psp_app_import_profile_path(
     path: UnsafePointer<CChar>?,
-    completion: psp_abi_completion
+    completion: psp_completion
 ) {
     guard let abi, let path else {
-        completion.callback?(completion.ctx, PSPABICompletionCodeArgs, nil)
+        completion.callback?(completion.ctx, PSPCompletionCodeArgs, nil)
         return
     }
     let swiftPath = String(cString: path)
     ABI.run(completion) { callback in
         do {
             try await abi.profile.importFile(swiftPath, passphrase: nil)
-            callback(PSPABICompletionCodeOK, nil)
+            callback(PSPCompletionCodeOK, nil)
         } catch {
-            callback(PSPABICompletionCodeFailure, error.localizedDescription)
+            callback(PSPCompletionCodeFailure, error.localizedDescription)
         }
     }
 }
@@ -85,10 +85,10 @@ public func __psp_app_import_profile_path(
 public func __psp_app_import_profile_text(
     text: UnsafePointer<CChar>?,
     filename: UnsafePointer<CChar>?,
-    completion: psp_abi_completion
+    completion: psp_completion
 ) {
     guard let abi, let text, let filename else {
-        completion.callback?(completion.ctx, PSPABICompletionCodeArgs, nil)
+        completion.callback?(completion.ctx, PSPCompletionCodeArgs, nil)
         return
     }
     let swiftText = String(cString: text)
@@ -96,9 +96,9 @@ public func __psp_app_import_profile_text(
     ABI.run(completion) { callback in
         do {
             try await abi.profile.importText(swiftText, filename: swiftFilename, passphrase: nil)
-            callback(PSPABICompletionCodeOK, nil)
+            callback(PSPCompletionCodeOK, nil)
         } catch {
-            callback(PSPABICompletionCodeFailure, error.localizedDescription)
+            callback(PSPCompletionCodeFailure, error.localizedDescription)
         }
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -38,7 +38,7 @@ public func __psp_app_init(
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
-            callback(PSPCompletionCodeOK, nil)
+            callback?(PSPCompletionCodeOK, nil)
         } catch {
             fatalError("Unable to start app: \(error)")
         }
@@ -50,7 +50,7 @@ public func __psp_app_deinit(completion: psp_completion) {
     ABI.run(completion) { callback in
         abi?.unregisterEvents()
         abi = nil
-        callback(PSPCompletionCodeOK, nil)
+        callback?(PSPCompletionCodeOK, nil)
     }
 }
 
@@ -74,9 +74,9 @@ public func __psp_app_import_profile_path(
     ABI.run(completion) { callback in
         do {
             try await abi.profile.importFile(swiftPath, passphrase: nil)
-            callback(PSPCompletionCodeOK, nil)
+            callback?(PSPCompletionCodeOK, nil)
         } catch {
-            callback(PSPCompletionCodeFailure, error.localizedDescription)
+            callback?(PSPCompletionCodeFailure, error.localizedDescription)
         }
     }
 }
@@ -96,9 +96,9 @@ public func __psp_app_import_profile_text(
     ABI.run(completion) { callback in
         do {
             try await abi.profile.importText(swiftText, filename: swiftFilename, passphrase: nil)
-            callback(PSPCompletionCodeOK, nil)
+            callback?(PSPCompletionCodeOK, nil)
         } catch {
-            callback(PSPCompletionCodeFailure, error.localizedDescription)
+            callback?(PSPCompletionCodeFailure, error.localizedDescription)
         }
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -22,8 +22,8 @@ public func __psp_app_init(args: UnsafePointer<psp_app_init_args>?) {
     if args.pointee.preferences != nil {
         assert(preferencesData != nil, "Unable to decode preferences")
     }
-    let eventContext = args.pointee.event_ctx
-    let eventCallback = args.pointee.event_cb
+    let eventContext = args.pointee.bindings.event_ctx
+    let eventCallback = args.pointee.bindings.event_cb
     let eventHandler = ABI.EventHandler(
         context: eventContext,
         callback: { ctx, event in

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -19,7 +19,7 @@ enum ABIError: Error {
 }
 
 extension ABI {
-    typealias RunCallbackBlock = @Sendable (_ code: Int32, _ json: String?) -> Void
+    typealias RunCallback = @Sendable (_ code: Int32, _ json: String?) -> Void
 
     static func run(
         _ block: @escaping @Sendable @BusinessActor () async -> Void
@@ -31,19 +31,19 @@ extension ABI {
 
     static func run(
         _ completion: psp_completion,
-        _ block: @escaping @Sendable @BusinessActor (RunCallbackBlock?) async -> Void
+        _ block: @escaping @Sendable @BusinessActor (RunCallback?) async -> Void
     ) {
         nonisolated(unsafe) let completion = completion
         Task { @Sendable @BusinessActor in
-            let callback: RunCallbackBlock?
+            let runCallback: RunCallback?
             if let cb = completion.callback {
-                callback = { code, json in
+                runCallback = { code, json in
                     cb(completion.ctx, code, json)
                 }
             } else {
-                callback = nil
+                runCallback = nil
             }
-            await block(callback)
+            await block(runCallback)
         }
     }
 

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -19,6 +19,8 @@ enum ABIError: Error {
 }
 
 extension ABI {
+    typealias RunCallbackBlock = @Sendable (_ code: Int32, _ json: String?) -> Void
+
     static func run(
         _ block: @escaping @Sendable @BusinessActor () async -> Void
     ) {
@@ -28,12 +30,15 @@ extension ABI {
     }
 
     static func run(
-        _ ctx: UnsafeMutableRawPointer?,
-        _ block: @escaping @Sendable @BusinessActor (UnsafeMutableRawPointer?) async -> Void
+        _ completion: psp_abi_completion,
+        _ block: @escaping @Sendable @BusinessActor (RunCallbackBlock) async -> Void
     ) {
-        nonisolated(unsafe) let unsafeCtx = ctx
+        nonisolated(unsafe) let completion = completion
         Task { @Sendable @BusinessActor in
-            await block(unsafeCtx)
+            let callback: RunCallbackBlock = { code, json in
+                completion.callback?(completion.ctx, code, json)
+            }
+            await block(callback)
         }
     }
 

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -30,7 +30,7 @@ extension ABI {
     }
 
     static func run(
-        _ completion: psp_abi_completion,
+        _ completion: psp_completion,
         _ block: @escaping @Sendable @BusinessActor (RunCallbackBlock) async -> Void
     ) {
         nonisolated(unsafe) let completion = completion

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -31,12 +31,17 @@ extension ABI {
 
     static func run(
         _ completion: psp_completion,
-        _ block: @escaping @Sendable @BusinessActor (RunCallbackBlock) async -> Void
+        _ block: @escaping @Sendable @BusinessActor (RunCallbackBlock?) async -> Void
     ) {
         nonisolated(unsafe) let completion = completion
         Task { @Sendable @BusinessActor in
-            let callback: RunCallbackBlock = { code, json in
-                completion.callback?(completion.ctx, code, json)
+            let callback: RunCallbackBlock?
+            if let cb = completion.callback {
+                callback = { code, json in
+                    cb(completion.ctx, code, json)
+                }
+            } else {
+                callback = nil
             }
             await block(callback)
         }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -14,8 +14,7 @@ extension TunnelABI {
         appConstantsData: Data,
         preferencesData: Data?,
         profileInput: ABI.ProfileImporterInput,
-        cachesURL: URL,
-        onStatus: SimpleConnectionDaemon.StatusCallback?
+        cachesURL: URL
     ) throws -> TunnelABI {
         let decoder = JSONDecoder()
 
@@ -61,6 +60,25 @@ extension TunnelABI {
         }
         // FIXME: #1656, C ABI, reachability observer
         let reachability = DummyReachabilityObserver()
+
+        // Wrap onStatus callback
+        nonisolated(unsafe) let statusContext = bindings.status_ctx
+        let statusCallback = bindings.status_cb
+        let onStatus: SimpleConnectionDaemon.StatusCallback = { profileId, status in
+            guard let statusCallback else { return }
+            let wrapper = ABI.OnConnectionStatus(
+                profileId: profileId.uuidString,
+                status: status
+            )
+            do {
+                let json = try ABI.encodeWrapper(wrapper)
+                json.withCString {
+                    statusCallback(statusContext, $0)
+                }
+            } catch {
+                assertionFailure("Unable to encode status: \(status), \(error)")
+            }
+        }
 
         let connectionOptions = ConnectionParameters.Options()
         let connectionParameters = ConnectionParameters(

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -30,7 +30,8 @@ extension TunnelABI {
             newDeviceId: true,
             deviceIdLength: constants.deviceIdLength
         )
-        preferences.configFlags = [.wgCrossV2]
+        // FIXME: ###, Cross, Hardcoded config flags
+        preferences.configFlags = [.ovpnCrossV2, .wgCrossV2]
 
         // Initialize objects from global configuration
         // TODO: #218, this directory must be per-profile

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -9,13 +9,13 @@ import Partout
 extension TunnelABI {
     // TODO: #218, cachesURL must be per-profile
     public static func forCrossPlatform(
+        bindings: psp_tunnel_bindings,
         appBundleData: Data,
         appConstantsData: Data,
         preferencesData: Data?,
         profileInput: ABI.ProfileImporterInput,
         cachesURL: URL,
-        onStatus: SimpleConnectionDaemon.StatusCallback?,
-        jniWrapper: UnsafeMutableRawPointer?
+        onStatus: SimpleConnectionDaemon.StatusCallback?
     ) throws -> TunnelABI {
         let decoder = JSONDecoder()
 
@@ -54,7 +54,7 @@ extension TunnelABI {
         )
 
         // Create platform-specific objects
-        let controller = try VirtualTunnelController(ctx, impl: jniWrapper)
+        let controller = try VirtualTunnelController(ctx, impl: bindings.controller)
         let factory = BSDSocketFactory(ctx) {
             // FIXME: #1656, C ABI, better path block
             PassthroughStream()

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -12,8 +12,7 @@ private var globalABI: TunnelABIProtocol?
 @c(psp_tunnel_start)
 public func __psp_tunnel_start(
     args: UnsafePointer<psp_tunnel_start_args>?,
-    context: UnsafeMutableRawPointer?,
-    completion: psp_abi_completion?
+    completion: psp_abi_completion
 ) {
     guard let args,
           let appBundleData = args.pointee.bundle?.asJSONData,
@@ -37,7 +36,7 @@ public func __psp_tunnel_start(
     let isDaemon = args.pointee.is_daemon
     nonisolated(unsafe) let bindings = args.pointee.bindings
     // Start tunnel ABI
-    ABI.run(context) { ctx in
+    ABI.run(completion) { callback in
         defer { pspUnlock() }
         do {
             globalABI = try TunnelABI.forCrossPlatform(
@@ -49,9 +48,9 @@ public func __psp_tunnel_start(
                 cachesURL: cachesURL
             )
             try await globalABI?.start(isInteractive: isInteractive)
-            completion?(ctx, 0, nil)
+            callback(0, nil)
         } catch {
-            completion?(ctx, -1, error.localizedDescription)
+            callback(-1, error.localizedDescription)
             fatalError("Unable to start tunnel: \(error)")
         }
     }
@@ -59,14 +58,11 @@ public func __psp_tunnel_start(
 }
 
 @c(psp_tunnel_stop)
-public func __psp_tunnel_stop(
-    context: UnsafeMutableRawPointer?,
-    completion: psp_abi_completion?
-) {
-    ABI.run(context) { ctx in
+public func __psp_tunnel_stop(completion: psp_abi_completion) {
+    ABI.run(completion) { callback in
         await globalABI?.stop()
         globalABI = nil
-        completion?(ctx, 0, nil)
+        callback(0, nil)
     }
 }
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -48,9 +48,9 @@ public func __psp_tunnel_start(
                 cachesURL: cachesURL
             )
             try await globalABI?.start(isInteractive: isInteractive)
-            callback(0, nil)
+            callback(PSPABICompletionCodeOK, nil)
         } catch {
-            callback(-1, error.localizedDescription)
+            callback(PSPABICompletionCodeFailure, error.localizedDescription)
             fatalError("Unable to start tunnel: \(error)")
         }
     }
@@ -62,7 +62,7 @@ public func __psp_tunnel_stop(completion: psp_abi_completion) {
     ABI.run(completion) { callback in
         await globalABI?.stop()
         globalABI = nil
-        callback(0, nil)
+        callback(PSPABICompletionCodeOK, nil)
     }
 }
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -12,7 +12,7 @@ private var globalABI: TunnelABIProtocol?
 @c(psp_tunnel_start)
 public func __psp_tunnel_start(
     args: UnsafePointer<psp_tunnel_start_args>?,
-    completion: psp_abi_completion
+    completion: psp_completion
 ) {
     guard let args,
           let appBundleData = args.pointee.bundle?.asJSONData,
@@ -48,9 +48,9 @@ public func __psp_tunnel_start(
                 cachesURL: cachesURL
             )
             try await globalABI?.start(isInteractive: isInteractive)
-            callback(PSPABICompletionCodeOK, nil)
+            callback(PSPCompletionCodeOK, nil)
         } catch {
-            callback(PSPABICompletionCodeFailure, error.localizedDescription)
+            callback(PSPCompletionCodeFailure, error.localizedDescription)
             fatalError("Unable to start tunnel: \(error)")
         }
     }
@@ -58,11 +58,11 @@ public func __psp_tunnel_start(
 }
 
 @c(psp_tunnel_stop)
-public func __psp_tunnel_stop(completion: psp_abi_completion) {
+public func __psp_tunnel_stop(completion: psp_completion) {
     ABI.run(completion) { callback in
         await globalABI?.stop()
         globalABI = nil
-        callback(PSPABICompletionCodeOK, nil)
+        callback(PSPCompletionCodeOK, nil)
     }
 }
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -35,23 +35,6 @@ public func __psp_tunnel_start(
     let cachesURL = URL(filePath: String(cString: cCacheDir))
     let isInteractive = args.pointee.is_interactive
     let isDaemon = args.pointee.is_daemon
-    nonisolated(unsafe) let statusContext = args.pointee.bindings.status_ctx
-    let statusCallback = args.pointee.bindings.status_cb
-    let onStatus: SimpleConnectionDaemon.StatusCallback = { profileId, status in
-        guard let statusCallback else { return }
-        let wrapper = ABI.OnConnectionStatus(
-            profileId: profileId.uuidString,
-            status: status
-        )
-        do {
-            let json = try ABI.encodeWrapper(wrapper)
-            json.withCString {
-                statusCallback(statusContext, $0)
-            }
-        } catch {
-            assertionFailure("Unable to encode status: \(status), \(error)")
-        }
-    }
     nonisolated(unsafe) let bindings = args.pointee.bindings
     // Start tunnel ABI
     ABI.run(context) { ctx in
@@ -63,8 +46,7 @@ public func __psp_tunnel_start(
                 appConstantsData: appConstantsData,
                 preferencesData: preferencesData,
                 profileInput: profileInput,
-                cachesURL: cachesURL,
-                onStatus: onStatus
+                cachesURL: cachesURL
             )
             try await globalABI?.start(isInteractive: isInteractive)
             completion?(ctx, 0, nil)

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -48,9 +48,9 @@ public func __psp_tunnel_start(
                 cachesURL: cachesURL
             )
             try await globalABI?.start(isInteractive: isInteractive)
-            callback(PSPCompletionCodeOK, nil)
+            callback?(PSPCompletionCodeOK, nil)
         } catch {
-            callback(PSPCompletionCodeFailure, error.localizedDescription)
+            callback?(PSPCompletionCodeFailure, error.localizedDescription)
             fatalError("Unable to start tunnel: \(error)")
         }
     }
@@ -62,7 +62,7 @@ public func __psp_tunnel_stop(completion: psp_completion) {
     ABI.run(completion) { callback in
         await globalABI?.stop()
         globalABI = nil
-        callback(PSPCompletionCodeOK, nil)
+        callback?(PSPCompletionCodeOK, nil)
     }
 }
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -35,8 +35,8 @@ public func __psp_tunnel_start(
     let cachesURL = URL(filePath: String(cString: cCacheDir))
     let isInteractive = args.pointee.is_interactive
     let isDaemon = args.pointee.is_daemon
-    nonisolated(unsafe) let statusContext = args.pointee.status_ctx
-    let statusCallback = args.pointee.status_cb
+    nonisolated(unsafe) let statusContext = args.pointee.bindings.status_ctx
+    let statusCallback = args.pointee.bindings.status_cb
     let onStatus: SimpleConnectionDaemon.StatusCallback = { profileId, status in
         guard let statusCallback else { return }
         let wrapper = ABI.OnConnectionStatus(
@@ -52,19 +52,19 @@ public func __psp_tunnel_start(
             assertionFailure("Unable to encode status: \(status), \(error)")
         }
     }
-    nonisolated(unsafe) let jniWrapper = args.pointee.jni_wrapper
+    nonisolated(unsafe) let bindings = args.pointee.bindings
     // Start tunnel ABI
     ABI.run(context) { ctx in
         defer { pspUnlock() }
         do {
             globalABI = try TunnelABI.forCrossPlatform(
+                bindings: bindings,
                 appBundleData: appBundleData,
                 appConstantsData: appConstantsData,
                 preferencesData: preferencesData,
                 profileInput: profileInput,
                 cachesURL: cachesURL,
-                onStatus: onStatus,
-                jniWrapper: jniWrapper
+                onStatus: onStatus
             )
             try await globalABI?.start(isInteractive: isInteractive)
             completion?(ctx, 0, nil)

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -44,7 +44,8 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args);
+void psp_app_init(const psp_app_init_args *args, void *ctx, psp_abi_completion completion);
+void psp_app_deinit(void *ctx, psp_abi_completion completion);
 void psp_app_on_foreground(void);
 void psp_app_import_profile_path(const char *path, void *ctx, psp_abi_completion completion);
 void psp_app_import_profile_text(const char *text, const char *filename, void *ctx, psp_abi_completion completion);

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -21,22 +21,19 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  * - Success: code == 0, data = JSON (optional)
  * - Error:   code != 0, data = String
  */
-#define PSPABICompletionCodeOK          0
-#define PSPABICompletionCodeArgs        -2
-#define PSPABICompletionCodeFailure     -1
-typedef void (*psp_abi_completion_cb)(void *ctx, int code, const char *data);
+#define PSPCompletionCodeOK         0
+#define PSPCompletionCodeArgs       -2
+#define PSPCompletionCodeFailure    -1
+typedef void (*psp_completion_cb)(void *ctx, int code, const char *data);
 typedef struct {
     void *ctx;
-    psp_abi_completion_cb callback;
-} psp_abi_completion;
+    psp_completion_cb callback;
+} psp_completion;
 
 /* Macros for completion blocks. */
 static inline
-psp_abi_completion PSP_CB(void *ctx, psp_abi_completion_cb callback) {
-    psp_abi_completion completion = {
-        ctx,
-        callback
-    };
+psp_completion PSP_CB(void *ctx, psp_completion_cb callback) {
+    psp_completion completion = { ctx, callback };
     return completion;
 }
 #define PSP_CB_NOP() PSP_CB(NULL, NULL)
@@ -63,11 +60,11 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args, psp_abi_completion completion);
-void psp_app_deinit(psp_abi_completion completion);
+void psp_app_init(const psp_app_init_args *args, psp_completion completion);
+void psp_app_deinit(psp_completion completion);
 void psp_app_on_foreground(void);
-void psp_app_import_profile_path(const char *path, psp_abi_completion completion);
-void psp_app_import_profile_text(const char *text, const char *filename, psp_abi_completion completion);
+void psp_app_import_profile_path(const char *path, psp_completion completion);
+void psp_app_import_profile_text(const char *text, const char *filename, psp_completion completion);
 void psp_app_flush_log(void);
 
 /* Daemon initialization. */
@@ -83,7 +80,7 @@ typedef struct {
 } psp_tunnel_start_args;
 
 /* Daemon functions. */
-void psp_tunnel_start(const psp_tunnel_start_args *args, psp_abi_completion completion);
-void psp_tunnel_stop(psp_abi_completion completion);
+void psp_tunnel_start(const psp_tunnel_start_args *args, psp_completion completion);
+void psp_tunnel_stop(psp_completion completion);
 
 #endif

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -8,6 +8,7 @@
 #define __PASSEPARTOUT_H
 
 #include <stdbool.h>
+#include <stdlib.h>
 
 /* Common functions. */
 const char *psp_partout_version(void);
@@ -20,7 +21,22 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  * - Success: code == 0, data = JSON (optional)
  * - Error:   code != 0, data = String
  */
-typedef void (*psp_abi_completion)(void *ctx, int code, const char *data);
+typedef void (*psp_abi_completion_cb)(void *ctx, int code, const char *data);
+typedef struct {
+    void *ctx;
+    psp_abi_completion_cb callback;
+} psp_abi_completion;
+
+/* Macros for completion blocks. */
+static inline
+psp_abi_completion PSP_CB(void *ctx, psp_abi_completion_cb callback) {
+    psp_abi_completion completion = {
+        ctx,
+        callback
+    };
+    return completion;
+}
+#define PSP_CB_NOP() PSP_CB(NULL, NULL)
 
 typedef struct {
     void *event_ctx;
@@ -44,11 +60,11 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args, void *ctx, psp_abi_completion completion);
-void psp_app_deinit(void *ctx, psp_abi_completion completion);
+void psp_app_init(const psp_app_init_args *args, psp_abi_completion completion);
+void psp_app_deinit(psp_abi_completion completion);
 void psp_app_on_foreground(void);
-void psp_app_import_profile_path(const char *path, void *ctx, psp_abi_completion completion);
-void psp_app_import_profile_text(const char *text, const char *filename, void *ctx, psp_abi_completion completion);
+void psp_app_import_profile_path(const char *path, psp_abi_completion completion);
+void psp_app_import_profile_text(const char *text, const char *filename, psp_abi_completion completion);
 void psp_app_flush_log(void);
 
 /* Daemon initialization. */
@@ -64,7 +80,7 @@ typedef struct {
 } psp_tunnel_start_args;
 
 /* Daemon functions. */
-void psp_tunnel_start(const psp_tunnel_start_args *args, void *ctx, psp_abi_completion completion);
-void psp_tunnel_stop(void *ctx, psp_abi_completion completion);
+void psp_tunnel_start(const psp_tunnel_start_args *args, psp_abi_completion completion);
+void psp_tunnel_stop(psp_abi_completion completion);
 
 #endif

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -22,6 +22,17 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  */
 typedef void (*psp_abi_completion)(void *ctx, int code, const char *data);
 
+typedef struct {
+    void *event_ctx;
+    psp_event_callback event_cb;
+} psp_app_bindings;
+
+typedef struct {
+    void *controller;
+    void *status_ctx;
+    psp_event_callback status_cb;
+} psp_tunnel_bindings;
+
 /* App initialization. */
 typedef struct {
     const char *bundle;
@@ -29,8 +40,7 @@ typedef struct {
     const char *preferences;
     const char *profiles_dir;
     const char *cache_dir;
-    void *event_ctx;
-    psp_event_callback event_cb;
+    psp_app_bindings bindings;
 } psp_app_init_args;
 
 /* App functions. */
@@ -49,9 +59,7 @@ typedef struct {
     const char *profile;
     bool is_interactive;
     bool is_daemon;
-    void *status_ctx;
-    psp_event_callback status_cb;
-    void *jni_wrapper;
+    psp_tunnel_bindings bindings;
 } psp_tunnel_start_args;
 
 /* Daemon functions. */

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -21,6 +21,9 @@ typedef void (*psp_event_callback)(void *event_ctx, const char *event);
  * - Success: code == 0, data = JSON (optional)
  * - Error:   code != 0, data = String
  */
+#define PSPABICompletionCodeOK          0
+#define PSPABICompletionCodeArgs        -2
+#define PSPABICompletionCodeFailure     -1
 typedef void (*psp_abi_completion_cb)(void *ctx, int code, const char *data);
 typedef struct {
     void *ctx;

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -16,9 +16,11 @@ char *psp_readfile(const char *rel_path, const char *parent);
 /* Events callback. */
 typedef void (*psp_event_callback)(void *event_ctx, const char *event);
 
-/* Completion callbacks. */
-/* Success: code == 0. */
-typedef void (*psp_abi_completion)(void *ctx, int code, const char *error_message);
+/* Completion callback.
+ * - Success: code == 0, data = JSON (optional)
+ * - Error:   code != 0, data = String
+ */
+typedef void (*psp_abi_completion)(void *ctx, int code, const char *data);
 
 /* App initialization. */
 typedef struct {

--- a/app-cross/passepartout/app/app.cc
+++ b/app-cross/passepartout/app/app.cc
@@ -48,8 +48,8 @@ bool MyApp::OnInit()
     args.preferences = NULL;
     args.profiles_dir = profiles_dir;
     args.cache_dir = cache_dir;
-    args.event_ctx = this;
-    args.event_cb = onABIEvent;
+    args.bindings.event_ctx = this;
+    args.bindings.event_cb = onABIEvent;
     psp_app_init(&args);
     free(bundle);
     free(constants);

--- a/app-cross/passepartout/app/app.cc
+++ b/app-cross/passepartout/app/app.cc
@@ -50,7 +50,7 @@ bool MyApp::OnInit()
     args.cache_dir = cache_dir;
     args.bindings.event_ctx = this;
     args.bindings.event_cb = onABIEvent;
-    psp_app_init(&args);
+    psp_app_init(&args, NULL, NULL);
     free(bundle);
     free(constants);
 

--- a/app-cross/passepartout/app/app.cc
+++ b/app-cross/passepartout/app/app.cc
@@ -50,7 +50,7 @@ bool MyApp::OnInit()
     args.cache_dir = cache_dir;
     args.bindings.event_ctx = this;
     args.bindings.event_cb = onABIEvent;
-    psp_app_init(&args, NULL, NULL);
+    psp_app_init(&args, PSP_CB_NOP());
     free(bundle);
     free(constants);
 
@@ -112,10 +112,10 @@ void MyFrame::OnImportProfile(wxCommandEvent &)
     const wxString path = openFileDialog.GetPath();
     const char *cPath = path.utf8_str().data();
     printf("Path: %s\n", cPath);
-    psp_app_import_profile_path(cPath, this, [](void *ctx, int code, const char *error) {
-        printf(">>> ABI Result: (ctx=%p), %d, %s\n", ctx, code, error);
+    psp_app_import_profile_path(cPath, PSP_CB(this, [](void *ctx, int code, const char *json) {
+        printf(">>> ABI Result: (ctx=%p), %d, %p\n", ctx, code, json);
         wxMessageBox("Import done.", "Import", wxOK | wxICON_INFORMATION);
-    });
+    }));
 }
 
 void MyFrame::OnFlushLog(wxCommandEvent &)

--- a/app-cross/passepartout/tunnel/main.c
+++ b/app-cross/passepartout/tunnel/main.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
     args.bindings.controller = NULL;
 
     /* Will block indefinitely. */
-    psp_tunnel_start(&args, NULL, start_callback);
+    psp_tunnel_start(&args, PSP_CB(NULL, start_callback));
 
     free(bundle);
     free(constants);

--- a/app-cross/passepartout/tunnel/main.c
+++ b/app-cross/passepartout/tunnel/main.c
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
     args.profile = profile;
     args.is_interactive = true;
     args.is_daemon = true;
-    args.jni_wrapper = NULL;
+    args.bindings.controller = NULL;
 
     /* Will block indefinitely. */
     psp_tunnel_start(&args, NULL, start_callback);

--- a/scripts/pull-android-libraries.sh
+++ b/scripts/pull-android-libraries.sh
@@ -6,19 +6,19 @@ if [ -z $ANDROID_NDK_ROOT ]; then
     echo "Android NDK not found (missing \$ANDROID_NDK_ROOT)"
     exit 1
 fi
-cmake_bin_path="bin/android-aarch64/dist"
+cmake_bin_path="bin/android-$ANDROID_NDK_ARCH/dist"
 cpp_path=`realpath app-android/app/src/main/cpp`
 headers_path="$cpp_path/src"
-swift_version="6_2"
 
 set -e
 
-# Rebuild library (unless "gen" argument)
+# Rebuild library
 rm -f $headers_path/passepartout.h
 rm -rf $cpp_path/libs/passepartout-*
 rm -rf $cpp_path/libs/swift-*
 
-libs_path="$cpp_path/libs/passepartout/arm64-v8a"
+# Copy to JNI folder
+libs_path="$cpp_path/libs/arm64-v8a"
 mkdir -p $libs_path
 cp -f $cmake_bin_path/passepartout.h $headers_path
 cp -f $cmake_bin_path/libpassepartout.so $libs_path
@@ -26,7 +26,7 @@ cp -f $cmake_bin_path/libssl.so $libs_path
 cp -f $cmake_bin_path/libcrypto.so $libs_path
 cp -f $cmake_bin_path/libwg-go.so $libs_path
 # Pull C++ runtime (Swift runtime linked statically)
-cp -f $ANDROID_NDK_SYSROOT/usr/lib/aarch64-linux-android/libc++_shared.so $libs_path
+cp -f ${ANDROID_NDK_SYSROOT}/usr/lib/${ANDROID_NDK_ARCH}-linux-android/libc++_shared.so $libs_path
 
 # Generate ABI entities
 scripts/gen-abi-kotlin.sh


### PR DESCRIPTION
ABI design:

- Simplify and reuse ABI and completion handlers
- Pack C/JNI bindings into a `bindings` field of the app/tunnel ABI input
- Pack completion context + callback into `psp_completion`
- Add PSP_CB macros for completion creation (with PSP_JNI_CB to use JNI completion proxy)
- Decouple ABI event/status handlers from MainActivity and PassepartoutVpnService
- Unregister event handler on appDeinit
- Unregister status handler on tunnelStop
- Release global JNI refs on app/tunnel release

JNI correctness:

- Fix unbalanced attach/detach JVM thread
- CMake: Lower version requirement for gradle consistency and fix stale configuration code