### PR TITLE
Fix tunnel occasionally stuck on incorrect status

### DIFF
--- a/app-cross/Sources/CommonLibraryCore/Domain/AppProfile.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppProfile.swift
@@ -83,14 +83,12 @@ extension ABI {
         }
 
         public func with(environment: TunnelEnvironmentReader) -> Self {
-            var copy = self
-            copy.transfer = environment.environmentValue(
-                forKey: TunnelEnvironmentKeys.dataCount
-            )?.abiTransfer
-            copy.lastErrorCode = environment.environmentValue(
-                forKey: TunnelEnvironmentKeys.lastErrorCode
+            Self(
+                id: id,
+                tunnelStatus: tunnelStatus,
+                onDemand: onDemand,
+                environment: environment
             )
-            return copy
         }
     }
 }

--- a/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
@@ -175,6 +175,25 @@ extension TunnelManagerTests {
                 #expect($0.considering(env) == $0)
             }
     }
+
+    @Test
+    func givenTunnelInfo_whenEnvironmentConnectionStatusChanges_thenProfileStatusIsRecomputed() async throws {
+        let env = SharedTunnelEnvironment(profileId: nil)
+        env.setEnvironmentValue(.connecting, forKey: TunnelEnvironmentKeys.connectionStatus)
+
+        let info = ABI.AppTunnelInfo(
+            id: UniqueID(),
+            tunnelStatus: .active,
+            onDemand: false,
+            environment: env
+        )
+        #expect(info.status == .connecting)
+
+        env.setEnvironmentValue(.connected, forKey: TunnelEnvironmentKeys.connectionStatus)
+
+        let updated = info.with(environment: env)
+        #expect(updated.status == .connected)
+    }
 }
 
 private extension AsyncStream where Element == ABI.TunnelEvent {


### PR DESCRIPTION
AppProfile was only updating `transfer` and `lastErrorCode`, but `status` is also affected by a new environment.

`AppProfileStatus` is inferred from the NE `TunnelStatus`, but then considers the environment `ConnectionStatus` for a more precise view of the VPN, because the NE VPN may be active while the connection is not. The `ConnectionStatus` is fetched periodically from the environment, that's why `status` must be recalculated on each new environment. See TunnelStatus.considering()

Regression in #1730