### PR TITLE
Fix inconsistent enabled status of profile toggles

### DIFF
--- a/app-apple/Sources/AppLibrary/Views/Shared/TunnelToggle.swift
+++ b/app-apple/Sources/AppLibrary/Views/Shared/TunnelToggle.swift
@@ -88,8 +88,7 @@ private extension TunnelToggle {
     }
 
     var isOn: Bool {
-        guard let tunnelProfile else { return false }
-        return tunnelProfile.status != .disconnected || tunnelProfile.onDemand
+        tunnelProfile?.isEnabled == true
     }
 
     var canInteract: Bool {

--- a/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
@@ -243,6 +243,7 @@ private extension TunnelManager {
         }
         return TunnelSnapshot(
             id: uuid,
+            isEnabled: false,
             status: .inactive,
             onDemand: false
         )

--- a/app-cross/Sources/CommonLibraryCore/Domain/AppProfile.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppProfile.swift
@@ -55,6 +55,7 @@ extension ABI {
 
     public struct AppTunnelInfo: Identifiable, Hashable, Sendable {
         public let id: Profile.ID
+        public let isEnabled: Bool
         public let status: AppProfileStatus
         public let tunnelStatus: TunnelStatus
         public let onDemand: Bool
@@ -63,11 +64,13 @@ extension ABI {
 
         public init(
             id: Profile.ID,
+            isEnabled: Bool,
             tunnelStatus: TunnelStatus,
             onDemand: Bool,
             environment: TunnelEnvironmentReader?
         ) {
             self.id = id
+            self.isEnabled = isEnabled
             status = tunnelStatus.considering(environment).abiStatus
             self.tunnelStatus = tunnelStatus
             self.onDemand = onDemand
@@ -85,6 +88,7 @@ extension ABI {
         public func with(environment: TunnelEnvironmentReader) -> Self {
             Self(
                 id: id,
+                isEnabled: isEnabled,
                 tunnelStatus: tunnelStatus,
                 onDemand: onDemand,
                 environment: environment

--- a/app-cross/Sources/CommonLibraryCore/Mappers/Partout+Tunnel.swift
+++ b/app-cross/Sources/CommonLibraryCore/Mappers/Partout+Tunnel.swift
@@ -39,6 +39,7 @@ extension TunnelSnapshot {
     func abiInfo(withEnvironment environment: TunnelEnvironmentReader?) -> ABI.AppTunnelInfo {
         ABI.AppTunnelInfo(
             id: id,
+            isEnabled: isEnabled,
             tunnelStatus: status,
             onDemand: onDemand,
             environment: environment

--- a/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
@@ -183,6 +183,7 @@ extension TunnelManagerTests {
 
         let info = ABI.AppTunnelInfo(
             id: UniqueID(),
+            isEnabled: true,
             tunnelStatus: .active,
             onDemand: false,
             environment: env


### PR DESCRIPTION
The toggle turns off when a profile becomes inactive and is not on-demand, despite the associated tunnel being enabled in the system. Fix this inconsistency, because it also prevents the user from disabling a profile that is never able to connect, e.g., for persistent failures. In fact, in those cases, the toggle is OFF and the profile can't be disabled.