### PR TITLE
Override config flags in beta and Developer ID builds

### DIFF
--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -9,6 +9,9 @@ struct PreferencesAdvancedView: View {
     @Environment(ConfigObservable.self)
     private var configObservable
 
+    @Environment(IAPObservable.self)
+    private var iapObservable
+
     @Binding
     var experimental: ABI.AppPreferenceValues.Experimental
 
@@ -45,7 +48,7 @@ private extension PreferencesAdvancedView {
     }
 
     var remoteSection: some View {
-        ForEach(Self.flags, id: \.rawValue) { flag in
+        ForEach(visibleFlags, id: \.rawValue) { flag in
             Toggle(isOn: isOnBinding(for: flag)) {
                 flagView(for: flag)
             }
@@ -56,11 +59,24 @@ private extension PreferencesAdvancedView {
         )
     }
 
+    var visibleFlags: [ABI.ConfigFlag] {
+        Self.flags.filter {
+            iapObservable.isBeta || configObservable.isActive($0)
+        }
+    }
+
     func isOnBinding(for flag: ABI.ConfigFlag) -> Binding<Bool> {
         Binding {
-            experimental.isUsed(flag)
+            experimental.isUsed(
+                flag,
+                isActive: configObservable.isActive(flag)
+            )
         } set: {
-            experimental.setUsed(flag, isUsed: $0)
+            experimental.setUsed(
+                flag,
+                isUsed: $0,
+                isActive: configObservable.isActive(flag)
+            )
         }
     }
 
@@ -74,14 +90,32 @@ private extension PreferencesAdvancedView {
 }
 
 private extension ABI.AppPreferenceValues.Experimental {
-    func isUsed(_ flag: ABI.ConfigFlag) -> Bool {
-        !ignoredConfigFlags.contains(flag)
+    func isUsed(
+        _ flag: ABI.ConfigFlag,
+        isActive: Bool
+    ) -> Bool {
+        if isActive {
+            return !ignoredConfigFlags.contains(flag)
+        }
+        return enabledConfigFlags.contains(flag)
     }
 
-    mutating func setUsed(_ flag: ABI.ConfigFlag, isUsed: Bool) {
-        if isUsed {
-            ignoredConfigFlags.remove(flag)
-        } else {
+    mutating func setUsed(
+        _ flag: ABI.ConfigFlag,
+        isUsed: Bool,
+        isActive: Bool
+    ) {
+        ignoredConfigFlags.remove(flag)
+        enabledConfigFlags.remove(flag)
+
+        guard !isUsed else {
+            if !isActive {
+                enabledConfigFlags.insert(flag)
+            }
+            return
+        }
+
+        if isActive {
             ignoredConfigFlags.insert(flag)
         }
     }

--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -23,6 +23,27 @@ struct PreferencesAdvancedView: View {
     }
 }
 
+private enum ConfigFlagPreference: String, CaseIterable, Identifiable {
+    case enable
+    case disable
+    case remote
+
+    var id: Self {
+        self
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .enable:
+            return Strings.Global.Actions.enable
+        case .disable:
+            return Strings.Global.Actions.disable
+        case .remote:
+            return Strings.Global.Nouns.default
+        }
+    }
+}
+
 private extension PreferencesAdvancedView {
     static let flags: [ABI.ConfigFlag] = [
         .bsdSockets,
@@ -48,9 +69,11 @@ private extension PreferencesAdvancedView {
     }
 
     var remoteSection: some View {
-        ForEach(visibleFlags, id: \.rawValue) { flag in
-            Toggle(isOn: isOnBinding(for: flag)) {
-                flagView(for: flag)
+        ForEach(Self.flags, id: \.rawValue) { flag in
+            if iapObservable.isBeta {
+                configPicker(for: flag)
+            } else {
+                configToggle(for: flag)
             }
         }
         .themeSection(
@@ -59,24 +82,36 @@ private extension PreferencesAdvancedView {
         )
     }
 
-    var visibleFlags: [ABI.ConfigFlag] {
-        Self.flags.filter {
-            iapObservable.isBeta || configObservable.isActive($0)
+    func configPicker(for flag: ABI.ConfigFlag) -> some View {
+        Picker(selection: preferenceBinding(for: flag)) {
+            ForEach(ConfigFlagPreference.allCases) { pref in
+                Text(pref.localizedDescription)
+                    .tag(pref)
+            }
+        } label: {
+            flagView(for: flag)
         }
     }
 
-    func isOnBinding(for flag: ABI.ConfigFlag) -> Binding<Bool> {
+    func configToggle(for flag: ABI.ConfigFlag) -> some View {
+        Toggle(isOn: isAllowedBinding(for: flag)) {
+            flagView(for: flag)
+        }
+    }
+
+    func isAllowedBinding(for flag: ABI.ConfigFlag) -> Binding<Bool> {
         Binding {
-            experimental.isUsed(
-                flag,
-                isActive: configObservable.isActive(flag)
-            )
+            experimental.isAllowed(flag)
         } set: {
-            experimental.setUsed(
-                flag,
-                isUsed: $0,
-                isActive: configObservable.isActive(flag)
-            )
+            experimental.setAllowed(flag, isAllowed: $0)
+        }
+    }
+
+    func preferenceBinding(for flag: ABI.ConfigFlag) -> Binding<ConfigFlagPreference> {
+        Binding {
+            experimental.preference(for: flag)
+        } set: {
+            experimental.setPreference($0, for: flag)
         }
     }
 
@@ -90,33 +125,39 @@ private extension PreferencesAdvancedView {
 }
 
 private extension ABI.AppPreferenceValues.Experimental {
-    func isUsed(
-        _ flag: ABI.ConfigFlag,
-        isActive: Bool
-    ) -> Bool {
-        if isActive {
-            return !ignoredConfigFlags.contains(flag)
-        }
-        return enabledConfigFlags.contains(flag)
+    func isAllowed(_ flag: ABI.ConfigFlag) -> Bool {
+        !ignoredConfigFlags.contains(flag)
     }
 
-    mutating func setUsed(
-        _ flag: ABI.ConfigFlag,
-        isUsed: Bool,
-        isActive: Bool
-    ) {
+    mutating func setAllowed(_ flag: ABI.ConfigFlag, isAllowed: Bool) {
+        if isAllowed {
+            ignoredConfigFlags.remove(flag)
+        } else {
+            ignoredConfigFlags.insert(flag)
+        }
+    }
+
+    func preference(for flag: ABI.ConfigFlag) -> ConfigFlagPreference {
+        if ignoredConfigFlags.contains(flag) {
+            return .disable
+        }
+        if enabledConfigFlags.contains(flag) {
+            return .enable
+        }
+        return .remote
+    }
+
+    mutating func setPreference(_ preference: ConfigFlagPreference, for flag: ABI.ConfigFlag) {
         ignoredConfigFlags.remove(flag)
         enabledConfigFlags.remove(flag)
 
-        guard !isUsed else {
-            if !isActive {
-                enabledConfigFlags.insert(flag)
-            }
-            return
-        }
-
-        if isActive {
+        switch preference {
+        case .enable:
+            enabledConfigFlags.insert(flag)
+        case .disable:
             ignoredConfigFlags.insert(flag)
+        case .remote:
+            break
         }
     }
 }

--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -17,30 +17,19 @@ struct PreferencesAdvancedView: View {
 
     var body: some View {
         Form {
-            remoteSection
+            configSection
         }
         .themeForm()
     }
 }
 
 private enum ConfigFlagPreference: String, CaseIterable, Identifiable {
+    case remote
     case enable
     case disable
-    case remote
 
     var id: Self {
         self
-    }
-
-    var localizedDescription: String {
-        switch self {
-        case .enable:
-            return Strings.Global.Actions.enable
-        case .disable:
-            return Strings.Global.Actions.disable
-        case .remote:
-            return Strings.Global.Nouns.default
-        }
     }
 }
 
@@ -52,29 +41,27 @@ private extension PreferencesAdvancedView {
         .wgCrossV2
     ]
 
-    static func description(for flag: ABI.ConfigFlag) -> String {
-        switch flag {
-        case .bsdSockets:
-            return "BSD sockets"
-        case .newProfileEncoding:
-            return "New profile encoding"
-        case .ovpnCrossV2:
-            return "Cross-platform OpenVPN v2"
-        case .wgCrossV2:
-            return "Cross-platform WireGuard v2"
-        default:
-            assertionFailure()
-            return ""
+    @ViewBuilder
+    var configSection: some View {
+        if iapObservable.isBeta {
+            overrideSection
+        } else {
+            remoteSection
         }
+    }
+
+    var overrideSection: some View {
+        ForEach(Self.flags, id: \.rawValue) { flag in
+            configPicker(for: flag)
+        }
+        .themeSection(
+            footer: Strings.Views.Preferences.Advanced.Override.footer
+        )
     }
 
     var remoteSection: some View {
         ForEach(Self.flags, id: \.rawValue) { flag in
-            if iapObservable.isBeta {
-                configPicker(for: flag)
-            } else {
-                configToggle(for: flag)
-            }
+            configToggle(for: flag)
         }
         .themeSection(
             header: Strings.Global.Actions.allow,
@@ -117,7 +104,7 @@ private extension PreferencesAdvancedView {
 
     func flagView(for flag: ABI.ConfigFlag) -> some View {
         VStack(alignment: .leading) {
-            Text(Self.description(for: flag))
+            Text(flag.localizedDescription)
             Text(configObservable.isActive(flag) ? Strings.Global.Nouns.enabled : Strings.Global.Nouns.disabled)
                 .themeSubtitle()
         }
@@ -158,6 +145,39 @@ private extension ABI.AppPreferenceValues.Experimental {
             ignoredConfigFlags.insert(flag)
         case .remote:
             break
+        }
+    }
+}
+
+// MARK: - Localization
+
+private extension ABI.ConfigFlag {
+    public var localizedDescription: String {
+        switch self {
+        case .bsdSockets:
+            return "BSD sockets"
+        case .newProfileEncoding:
+            return "New profile encoding"
+        case .ovpnCrossV2:
+            return "Cross-platform OpenVPN v2"
+        case .wgCrossV2:
+            return "Cross-platform WireGuard v2"
+        default:
+            assertionFailure()
+            return ""
+        }
+    }
+}
+
+private extension ConfigFlagPreference {
+    var localizedDescription: String {
+        switch self {
+        case .remote:
+            return Strings.Views.Preferences.Advanced.Override.Picker.remote
+        case .enable:
+            return Strings.Global.Actions.enable
+        case .disable:
+            return Strings.Global.Actions.disable
         }
     }
 }

--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -12,6 +12,9 @@ struct PreferencesAdvancedView: View {
     @Environment(IAPObservable.self)
     private var iapObservable
 
+    @Environment(\.appConfiguration)
+    private var appConfiguration
+
     @Binding
     var experimental: ABI.AppPreferenceValues.Experimental
 
@@ -41,9 +44,13 @@ private extension PreferencesAdvancedView {
         .wgCrossV2
     ]
 
+    var canOverride: Bool {
+        iapObservable.isBeta || appConfiguration.bundle.distributionTarget == .developerID
+    }
+
     @ViewBuilder
     var configSection: some View {
-        if iapObservable.isBeta {
+        if canOverride {
             overrideSection
         } else {
             remoteSection

--- a/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Aktiviere den VPN %@.";
 "modules.on_demand.policy" = "Richtlinie";
 "modules.on_demand.ssid.add" = "SSID hinzufügen";
-"modules.openvpn.data_ciphers" = "Datenverschlüsselung";
 "modules.openvpn.cipher" = "Verschlüsselung";
 "modules.openvpn.communication" = "Kommunikation";
 "modules.openvpn.compression_algorithm" = "Algorithmus";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "Das OTP wird an das Passwort angehängt.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "Das OTP wird zusammen mit dem Passwort in Base64 kodiert.";
 "modules.openvpn.credentials" = "Anmeldeinformationen";
+"modules.openvpn.data_ciphers" = "Datenverschlüsselung";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.eku" = "Erweiterte Überprüfung";
 "modules.openvpn.pull" = "Abrufen";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Erforderliche Funktionen";
 "views.paywall.sections.restore.footer" = "Wenn Sie in der Vergangenheit Einkäufe getätigt haben, können Sie sie hier wiederherstellen.";
 "views.paywall.sections.restore.header" = "Wiederherstellen";
+"views.preferences.advanced.override.footer" = "Diese Funktionen werden remote gesteuert, du kannst ihren Aktivierungsstatus jedoch zu Testzwecken überschreiben.";
+"views.preferences.advanced.override.picker.remote" = "Remote";
 "views.preferences.advanced.remote.footer" = "Diese Funktionen werden aus der Ferne gesteuert. Schalten Sie die Schalter aus, wenn etwas nicht funktioniert.";
 "views.preferences.dns_falls_back.footer" = "Fällt auf CloudFlare-Server zurück, wenn das VPN keine DNS-Einstellungen bereitstellt.";
 "views.preferences.dns_falls_back" = "DNS-Fallback";

--- a/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Ενεργοποιήστε το VPN %@.";
 "modules.on_demand.policy" = "Πολιτική";
 "modules.on_demand.ssid.add" = "Προσθήκη SSID";
-"modules.openvpn.data_ciphers" = "Κρυπτογράφηση δεδομένων";
 "modules.openvpn.cipher" = "Κρυπτογράφηση";
 "modules.openvpn.communication" = "Επικοινωνία";
 "modules.openvpn.compression_algorithm" = "Αλγόριθμος";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "Το OTP θα προστεθεί στον κωδικό πρόσβασης.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "Το OTP θα κωδικοποιηθεί σε Base64 μαζί με τον κωδικό πρόσβασης.";
 "modules.openvpn.credentials" = "Διαπιστευτήρια";
+"modules.openvpn.data_ciphers" = "Κρυπτογράφηση δεδομένων";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.eku" = "Εκτεταμένη επαλήθευση";
 "modules.openvpn.pull" = "Ανάκτηση";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Απαιτούμενες λειτουργίες";
 "views.paywall.sections.restore.footer" = "Αν έχετε πραγματοποιήσει αγορές στο παρελθόν, μπορείτε να τις επαναφέρετε εδώ.";
 "views.paywall.sections.restore.header" = "Επαναφορά";
+"views.preferences.advanced.override.footer" = "Αυτές οι λειτουργίες ελέγχονται απομακρυσμένα, αλλά μπορείτε να παρακάμψετε την ενεργοποίησή τους για δοκιμαστικούς σκοπούς.";
+"views.preferences.advanced.override.picker.remote" = "Απομακρυσμένο";
 "views.preferences.advanced.remote.footer" = "Αυτές οι λειτουργίες ελέγχονται απομακρυσμένα. Απενεργοποιήστε τους διακόπτες αν κάτι δεν λειτουργεί.";
 "views.preferences.dns_falls_back.footer" = "Χρησιμοποιεί τους διακομιστές CloudFlare όταν το VPN δεν παρέχει ρυθμίσεις DNS.";
 "views.preferences.dns_falls_back" = "Εναλλακτικό DNS";

--- a/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
@@ -103,6 +103,8 @@
 "views.preferences.erase_icloud" = "Erase profiles from iCloud";
 "views.preferences.erase_icloud.footer" = "To erase all profiles from the iCloud store securely, do so on all your synced devices. This will not affect local profiles.";
 
+"views.preferences.advanced.override.picker.remote" = "Remote";
+"views.preferences.advanced.override.footer" = "These features are controlled remotely, but you may override their enabled status for testing purposes.";
 "views.preferences.advanced.remote.footer" = "These features are controlled remotely. Turn off the toggles if something does not work.";
 
 "views.profile.sections.name.footer" = "Use this name to create your VPN automations from the Shortcuts app.";

--- a/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Activa la VPN %@.";
 "modules.on_demand.policy" = "Política";
 "modules.on_demand.ssid.add" = "Añadir SSID";
-"modules.openvpn.data_ciphers" = "Cifrados de datos";
 "modules.openvpn.cipher" = "Cifrado";
 "modules.openvpn.communication" = "Comunicación";
 "modules.openvpn.compression_algorithm" = "Algoritmo";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "El OTP se añadirá a la contraseña.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "El OTP será codificado en Base64 con la contraseña.";
 "modules.openvpn.credentials" = "Credenciales";
+"modules.openvpn.data_ciphers" = "Cifrados de datos";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.eku" = "Verificación extendida";
 "modules.openvpn.pull" = "Extraer";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Características requeridas";
 "views.paywall.sections.restore.footer" = "Si has realizado compras en el pasado, puedes restaurarlas aquí.";
 "views.paywall.sections.restore.header" = "Restaurar";
+"views.preferences.advanced.override.footer" = "Estas funciones se controlan de forma remota, pero puedes sobrescribir su estado de activación con fines de prueba.";
+"views.preferences.advanced.override.picker.remote" = "Remoto";
 "views.preferences.advanced.remote.footer" = "Estas funciones se controlan de forma remota. Desactiva los interruptores si algo no funciona.";
 "views.preferences.dns_falls_back.footer" = "Usa los servidores de CloudFlare cuando el VPN no proporciona configuraciones de DNS.";
 "views.preferences.dns_falls_back" = "DNS de respaldo";

--- a/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Activez le VPN %@.";
 "modules.on_demand.policy" = "Politique";
 "modules.on_demand.ssid.add" = "Ajouter un SSID";
-"modules.openvpn.data_ciphers" = "Chiffrement des données";
 "modules.openvpn.cipher" = "Chiffrement";
 "modules.openvpn.communication" = "Communication";
 "modules.openvpn.compression_algorithm" = "Algorithme";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "L'OTP sera ajouté au mot de passe.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "L'OTP sera encodé en Base64 avec le mot de passe.";
 "modules.openvpn.credentials" = "Identifiants";
+"modules.openvpn.data_ciphers" = "Chiffrement des données";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.eku" = "Vérification étendue";
 "modules.openvpn.pull" = "Tirer";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Fonctionnalités requises";
 "views.paywall.sections.restore.footer" = "Si vous avez effectué des achats par le passé, vous pouvez les restaurer ici.";
 "views.paywall.sections.restore.header" = "Restaurer";
+"views.preferences.advanced.override.footer" = "Ces fonctionnalités sont contrôlées à distance, mais vous pouvez remplacer leur état d’activation à des fins de test.";
+"views.preferences.advanced.override.picker.remote" = "À distance";
 "views.preferences.advanced.remote.footer" = "Ces fonctionnalités sont contrôlées à distance. Désactivez les commutateurs si quelque chose ne fonctionne pas.";
 "views.preferences.dns_falls_back.footer" = "Bascule vers les serveurs CloudFlare lorsque le VPN ne fournit pas de paramètres DNS.";
 "views.preferences.dns_falls_back" = "Basculement DNS";

--- a/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Attiva la VPN %@.";
 "modules.on_demand.policy" = "Politica";
 "modules.on_demand.ssid.add" = "Aggiungi SSID";
-"modules.openvpn.data_ciphers" = "Cifratura dati";
 "modules.openvpn.cipher" = "Cifratura";
 "modules.openvpn.communication" = "Comunicazione";
 "modules.openvpn.compression_algorithm" = "Algoritmo";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "L'OTP sarà aggiunto alla password.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "L'OTP sarà codificato in Base64 con la password.";
 "modules.openvpn.credentials" = "Credenziali";
+"modules.openvpn.data_ciphers" = "Cifratura dati";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.eku" = "Verifica estesa";
 "modules.openvpn.pull" = "Ottieni";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Funzionalità richieste";
 "views.paywall.sections.restore.footer" = "Se hai effettuato acquisti in passato, puoi ripristinarli qui.";
 "views.paywall.sections.restore.header" = "Ripristina";
+"views.preferences.advanced.override.footer" = "Queste funzionalità sono controllate da remoto, ma puoi sovrascrivere il loro stato di attivazione a scopo di test.";
+"views.preferences.advanced.override.picker.remote" = "Remoto";
 "views.preferences.advanced.remote.footer" = "Queste funzionalità sono controllate da remoto. Disattiva gli interruttori se qualcosa non funziona.";
 "views.preferences.dns_falls_back.footer" = "Ripiega sui server CloudFlare quando il VPN non fornisce impostazioni DNS.";
 "views.preferences.dns_falls_back" = "DNS di fallback";

--- a/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Activeer de VPN %@.";
 "modules.on_demand.policy" = "Beleid";
 "modules.on_demand.ssid.add" = "SSID toevoegen";
-"modules.openvpn.data_ciphers" = "Data ciphers";
 "modules.openvpn.cipher" = "Cipher";
 "modules.openvpn.communication" = "Communicatie";
 "modules.openvpn.compression_algorithm" = "Algoritme";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "De OTP wordt aan het wachtwoord toegevoegd.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "De OTP wordt gecodeerd in Base64 met het wachtwoord.";
 "modules.openvpn.credentials" = "Inloggegevens";
+"modules.openvpn.data_ciphers" = "Data ciphers";
 "modules.openvpn.digest" = "Digest";
 "modules.openvpn.eku" = "Uitgebreide verificatie";
 "modules.openvpn.pull" = "Ophalen";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Vereiste functies";
 "views.paywall.sections.restore.footer" = "Als je eerder aankopen hebt gedaan, kun je ze hier herstellen.";
 "views.paywall.sections.restore.header" = "Herstellen";
+"views.preferences.advanced.override.footer" = "Deze functies worden extern aangestuurd, maar je kunt hun ingeschakelde status overschrijven voor testdoeleinden.";
+"views.preferences.advanced.override.picker.remote" = "Extern";
 "views.preferences.advanced.remote.footer" = "Deze functies worden op afstand beheerd. Zet de schakelaars uit als iets niet werkt.";
 "views.preferences.dns_falls_back.footer" = "Valt terug op CloudFlare-servers wanneer het VPN geen DNS-instellingen biedt.";
 "views.preferences.dns_falls_back" = "DNS-terugval";

--- a/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Aktywuj VPN %@.";
 "modules.on_demand.policy" = "Polityka";
 "modules.on_demand.ssid.add" = "Dodaj SSID";
-"modules.openvpn.data_ciphers" = "Szyfry danych";
 "modules.openvpn.cipher" = "Szyfr";
 "modules.openvpn.communication" = "Komunikacja";
 "modules.openvpn.compression_algorithm" = "Algorytm";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "OTP zostanie dodane do hasła.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "OTP zostanie zakodowane w Base64 z hasłem.";
 "modules.openvpn.credentials" = "Dane uwierzytelniające";
+"modules.openvpn.data_ciphers" = "Szyfry danych";
 "modules.openvpn.digest" = "Skrót";
 "modules.openvpn.eku" = "Rozszerzona weryfikacja";
 "modules.openvpn.pull" = "Pobierz";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Wymagane funkcje";
 "views.paywall.sections.restore.footer" = "Jeśli wcześniej dokonałeś zakupów, możesz je tutaj przywrócić.";
 "views.paywall.sections.restore.header" = "Przywróć";
+"views.preferences.advanced.override.footer" = "Te funkcje są kontrolowane zdalnie, ale możesz nadpisać ich stan włączenia do celów testowych.";
+"views.preferences.advanced.override.picker.remote" = "Zdalnie";
 "views.preferences.advanced.remote.footer" = "Te funkcje są sterowane zdalnie. Wyłącz przełączniki, jeśli coś nie działa.";
 "views.preferences.dns_falls_back.footer" = "Przełącza się na serwery CloudFlare, gdy VPN nie zapewnia ustawień DNS.";
 "views.preferences.dns_falls_back" = "Awaryjny DNS";

--- a/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Ative o VPN %@.";
 "modules.on_demand.policy" = "Política";
 "modules.on_demand.ssid.add" = "Adicionar SSID";
-"modules.openvpn.data_ciphers" = "Cifras de dados";
 "modules.openvpn.cipher" = "Cifra";
 "modules.openvpn.communication" = "Comunicação";
 "modules.openvpn.compression_algorithm" = "Algoritmo";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "O OTP será anexado à senha.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "O OTP será codificado em Base64 com a senha.";
 "modules.openvpn.credentials" = "Credenciais";
+"modules.openvpn.data_ciphers" = "Cifras de dados";
 "modules.openvpn.digest" = "Resumo";
 "modules.openvpn.eku" = "Verificação estendida";
 "modules.openvpn.pull" = "Puxar";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Recursos necessários";
 "views.paywall.sections.restore.footer" = "Se você fez compras anteriormente, pode restaurá-las aqui.";
 "views.paywall.sections.restore.header" = "Restaurar";
+"views.preferences.advanced.override.footer" = "Estas funcionalidades são controladas remotamente, mas pode substituir o seu estado de ativação para fins de teste.";
+"views.preferences.advanced.override.picker.remote" = "Remoto";
 "views.preferences.advanced.remote.footer" = "Esses recursos são controlados remotamente. Desative as opções se algo não funcionar.";
 "views.preferences.dns_falls_back.footer" = "Reverte para os servidores CloudFlare quando o VPN não fornece configurações de DNS.";
 "views.preferences.dns_falls_back" = "Fallback de DNS";

--- a/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Активировать VPN %@.";
 "modules.on_demand.policy" = "Политика";
 "modules.on_demand.ssid.add" = "Добавить SSID";
-"modules.openvpn.data_ciphers" = "Шифры данных";
 "modules.openvpn.cipher" = "Шифр";
 "modules.openvpn.communication" = "Коммуникация";
 "modules.openvpn.compression_algorithm" = "Алгоритм";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "OTP будет добавлено к паролю.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "OTP будет закодировано в Base64 вместе с паролем.";
 "modules.openvpn.credentials" = "Учетные данные";
+"modules.openvpn.data_ciphers" = "Шифры данных";
 "modules.openvpn.digest" = "Контрольная сумма";
 "modules.openvpn.eku" = "Расширенная проверка";
 "modules.openvpn.pull" = "Получить";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Необходимые функции";
 "views.paywall.sections.restore.footer" = "Если вы совершали покупки ранее, вы можете восстановить их здесь.";
 "views.paywall.sections.restore.header" = "Восстановить";
+"views.preferences.advanced.override.footer" = "Эти функции управляются удалённо, но вы можете переопределить их состояние включения в целях тестирования.";
+"views.preferences.advanced.override.picker.remote" = "Удалённо";
 "views.preferences.advanced.remote.footer" = "Эти функции управляются удалённо. Отключите переключатели, если что-то не работает.";
 "views.preferences.dns_falls_back.footer" = "Переключается на серверы CloudFlare, если VPN не предоставляет настройки DNS.";
 "views.preferences.dns_falls_back" = "Резервный DNS";

--- a/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Aktivera VPN %@.";
 "modules.on_demand.policy" = "Policy";
 "modules.on_demand.ssid.add" = "Lägg till SSID";
-"modules.openvpn.data_ciphers" = "Datachiffer";
 "modules.openvpn.cipher" = "Chiffer";
 "modules.openvpn.communication" = "Kommunikation";
 "modules.openvpn.compression_algorithm" = "Algoritm";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "OTP läggs till i lösenordet.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "OTP kodas i Base64 med lösenordet.";
 "modules.openvpn.credentials" = "Uppgifter";
+"modules.openvpn.data_ciphers" = "Datachiffer";
 "modules.openvpn.digest" = "Sammanfattning";
 "modules.openvpn.eku" = "Utökad verifiering";
 "modules.openvpn.pull" = "Hämta";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Krävda funktioner";
 "views.paywall.sections.restore.footer" = "Om du har gjort köp tidigare kan du återställa dem här.";
 "views.paywall.sections.restore.header" = "Återställ";
+"views.preferences.advanced.override.footer" = "Dessa funktioner styrs på distans, men du kan åsidosätta deras aktiveringsstatus för teständamål.";
+"views.preferences.advanced.override.picker.remote" = "Fjärr";
 "views.preferences.advanced.remote.footer" = "Dessa funktioner styrs på distans. Stäng av växlarna om något inte fungerar.";
 "views.preferences.dns_falls_back.footer" = "Återgår till CloudFlare-servrar när VPN inte tillhandahåller DNS-inställningar.";
 "views.preferences.dns_falls_back" = "DNS-backup";

--- a/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "Активуйте VPN %@.";
 "modules.on_demand.policy" = "Політика";
 "modules.on_demand.ssid.add" = "Додати SSID";
-"modules.openvpn.data_ciphers" = "Шифри даних";
 "modules.openvpn.cipher" = "Шифр";
 "modules.openvpn.communication" = "Зв'язок";
 "modules.openvpn.compression_algorithm" = "Алгоритм";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "OTP буде додано до пароля.";
 "modules.openvpn.credentials.otp_method.approach.encode" = "OTP буде закодовано в Base64 разом із паролем.";
 "modules.openvpn.credentials" = "Облікові дані";
+"modules.openvpn.data_ciphers" = "Шифри даних";
 "modules.openvpn.digest" = "Контрольна сума";
 "modules.openvpn.eku" = "Розширена перевірка";
 "modules.openvpn.pull" = "Отримати";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "Необхідні функції";
 "views.paywall.sections.restore.footer" = "Якщо ви раніше здійснювали покупки, ви можете відновити їх тут.";
 "views.paywall.sections.restore.header" = "Відновлення";
+"views.preferences.advanced.override.footer" = "Ці функції керуються віддалено, але ви можете перевизначити їхній стан увімкнення для тестування.";
+"views.preferences.advanced.override.picker.remote" = "Віддалено";
 "views.preferences.advanced.remote.footer" = "Ці функції керуються віддалено. Вимкніть перемикачі, якщо щось не працює.";
 "views.preferences.dns_falls_back.footer" = "Перемикається на сервери CloudFlare, коли VPN не надає налаштування DNS.";
 "views.preferences.dns_falls_back" = "Резервний DNS";

--- a/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
@@ -253,7 +253,6 @@
 "modules.on_demand.policy.footer" = "激活 VPN %@。";
 "modules.on_demand.policy" = "策略";
 "modules.on_demand.ssid.add" = "添加 SSID";
-"modules.openvpn.data_ciphers" = "数据加密算法";
 "modules.openvpn.cipher" = "加密算法";
 "modules.openvpn.communication" = "通信";
 "modules.openvpn.compression_algorithm" = "算法";
@@ -267,6 +266,7 @@
 "modules.openvpn.credentials.otp_method.approach.append" = "OTP 将附加到密码后面。";
 "modules.openvpn.credentials.otp_method.approach.encode" = "OTP 将与密码一起编码为 Base64。";
 "modules.openvpn.credentials" = "凭证";
+"modules.openvpn.data_ciphers" = "数据加密算法";
 "modules.openvpn.digest" = "摘要";
 "modules.openvpn.eku" = "扩展验证";
 "modules.openvpn.pull" = "拉取";
@@ -357,6 +357,8 @@
 "views.paywall.sections.required_features.header" = "必需功能";
 "views.paywall.sections.restore.footer" = "如果您过去有购买记录，可以在此恢复。";
 "views.paywall.sections.restore.header" = "恢复";
+"views.preferences.advanced.override.footer" = "这些功能由远程控制，但你可以为测试目的覆盖其启用状态。";
+"views.preferences.advanced.override.picker.remote" = "远程";
 "views.preferences.advanced.remote.footer" = "这些功能由远程控制。如果某些功能无法正常工作，请关闭开关。";
 "views.preferences.dns_falls_back.footer" = "当 VPN 不提供 DNS 设置时，回退到 CloudFlare 服务器。";
 "views.preferences.dns_falls_back" = "DNS 备用";

--- a/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
+++ b/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
@@ -1109,6 +1109,14 @@ public enum Strings {
       /// Appearance
       public static let systemAppearance = Strings.tr("Localizable", "views.preferences.system_appearance", fallback: "Appearance")
       public enum Advanced {
+        public enum Override {
+          /// These features are controlled remotely, but you may override their enabled status for testing purposes.
+          public static let footer = Strings.tr("Localizable", "views.preferences.advanced.override.footer", fallback: "These features are controlled remotely, but you may override their enabled status for testing purposes.")
+          public enum Picker {
+            /// Remote
+            public static let remote = Strings.tr("Localizable", "views.preferences.advanced.override.picker.remote", fallback: "Remote")
+          }
+        }
         public enum Remote {
           /// These features are controlled remotely. Turn off the toggles if something does not work.
           public static let footer = Strings.tr("Localizable", "views.preferences.advanced.remote.footer", fallback: "These features are controlled remotely. Turn off the toggles if something does not work.")

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -58,6 +58,7 @@ extension TunnelABI {
         let configFlags = preferences.configFlags
         pspLog(ctx.profileId, .core, .info, "\tActive config flags: \(configFlags)")
         pspLog(ctx.profileId, .core, .info, "\tIgnored config flags: \(preferences.experimental.ignoredConfigFlags)")
+        pspLog(ctx.profileId, .core, .info, "\tEnabled config flags: \(preferences.experimental.enabledConfigFlags)")
 
         // Create TunnelController for connnection management
         let neTunnelController = NETunnelController(

--- a/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
@@ -54,6 +54,12 @@ extension ABI.AppConfiguration {
         )
     }
 
+    public func newFileProfileRepository(path: String) throws -> ProfileRepository {
+        try FileProfileRepository(
+           directoryURL: URL(filePath: path, directoryHint: .isDirectory)
+       )
+    }
+
     public func newIAPManager(
         inAppHelper: InAppHelper,
         receiptReader: UserInAppReceiptReader,
@@ -128,12 +134,6 @@ extension ABI.AppConfiguration {
                 preferences.enabledFlags()
             }
         )
-    }
-
-    public func newFileProfileRepository(path: String) throws -> ProfileRepository {
-        try FileProfileRepository(
-           directoryURL: URL(filePath: path, directoryHint: .isDirectory)
-       )
     }
 
     @BusinessActor

--- a/app-cross/Sources/CommonLibraryCore/Domain/AppPreference.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppPreference.swift
@@ -129,7 +129,10 @@ extension ABI.AppPreferenceValues {
     }
 
     public func isFlagEnabled(_ flag: ABI.ConfigFlag) -> Bool {
-        enabledFlags().contains(flag)
+        var result = configFlags.contains(flag)
+        result = result || experimental.enabledConfigFlags.contains(flag)
+        result = result && !experimental.ignoredConfigFlags.contains(flag)
+        return result
     }
 
     public func enabledFlags(of flags: Set<ABI.ConfigFlag>? = nil) -> Set<ABI.ConfigFlag> {

--- a/app-cross/Sources/CommonLibraryCore/Domain/AppPreference.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppPreference.swift
@@ -79,7 +79,15 @@ extension ABI {
 extension ABI.AppPreferenceValues {
     public struct Experimental: Hashable, Codable, Sendable {
         public var ignoredConfigFlags: Set<ABI.ConfigFlag> = []
+        public var enabledConfigFlags: Set<ABI.ConfigFlag> = []
+
         public init() {}
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            ignoredConfigFlags = try container.decodeIfPresent(Set<ABI.ConfigFlag>.self, forKey: .ignoredConfigFlags) ?? []
+            enabledConfigFlags = try container.decodeIfPresent(Set<ABI.ConfigFlag>.self, forKey: .enabledConfigFlags) ?? []
+        }
     }
 
     public var configFlags: Set<ABI.ConfigFlag> {
@@ -121,11 +129,14 @@ extension ABI.AppPreferenceValues {
     }
 
     public func isFlagEnabled(_ flag: ABI.ConfigFlag) -> Bool {
-        configFlags.contains(flag) && !experimental.ignoredConfigFlags.contains(flag)
+        enabledFlags().contains(flag)
     }
 
     public func enabledFlags(of flags: Set<ABI.ConfigFlag>? = nil) -> Set<ABI.ConfigFlag> {
-        (flags ?? configFlags).subtracting(experimental.ignoredConfigFlags)
+        var result = flags ?? configFlags
+        result.formUnion(experimental.enabledConfigFlags)
+        result.subtract(experimental.ignoredConfigFlags)
+        return result
     }
 }
 

--- a/app-cross/Tests/CommonLibraryTests/Domain/AppPreferenceTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Domain/AppPreferenceTests.swift
@@ -11,6 +11,7 @@ struct AppPreferenceTests {
         var sut = ABI.AppPreferenceValues()
         sut.configFlags = [.bsdSockets, .newProfileEncoding]
         sut.experimental.ignoredConfigFlags = [.appNotWorking, .bsdSockets]
+        sut.experimental.enabledConfigFlags = [.ovpnCrossV2]
 
         let configFlagsData = try #require(sut.configFlagsData)
         let experimentalData = try #require(sut.experimentalData)
@@ -44,5 +45,35 @@ struct AppPreferenceTests {
         #expect(sut.isFlagEnabled(.newProfileEncoding))
         #expect(!sut.isFlagEnabled(.bsdSockets))
         #expect(!sut.isFlagEnabled(.appNotWorking))
+    }
+
+    @Test
+    func givenExperimental_whenDecodeWithoutEnabledFlags_thenUsesEmptySet() throws {
+        let data = #"{"ignoredConfigFlags":["bsdSockets"]}"#.data(using: .utf8)!
+        let sut = try JSONDecoder().decode(ABI.AppPreferenceValues.Experimental.self, from: data)
+        #expect(sut.ignoredConfigFlags == [.bsdSockets])
+        #expect(sut.enabledConfigFlags.isEmpty)
+    }
+
+    @Test
+    func givenExperimental_whenEnableFlags_thenIsApplied() {
+        var sut = ABI.AppPreferenceValues()
+        sut.configFlags = [.bsdSockets]
+        sut.experimental.enabledConfigFlags = [.ovpnCrossV2]
+
+        #expect(sut.isFlagEnabled(.bsdSockets))
+        #expect(sut.isFlagEnabled(.ovpnCrossV2))
+        #expect(sut.enabledFlags() == [.bsdSockets, .ovpnCrossV2])
+    }
+
+    @Test
+    func givenExperimental_whenEnableAndIgnoreSameFlag_thenIgnoreWins() {
+        var sut = ABI.AppPreferenceValues()
+        sut.configFlags = [.bsdSockets]
+        sut.experimental.ignoredConfigFlags = [.ovpnCrossV2]
+        sut.experimental.enabledConfigFlags = [.ovpnCrossV2]
+
+        #expect(!sut.isFlagEnabled(.ovpnCrossV2))
+        #expect(sut.enabledFlags() == [.bsdSockets])
     }
 }


### PR DESCRIPTION
Make toggles tristate pickers where the user is allowed to enable some specific config flags for testing purposes.