### PR TITLE
IAP: Skip purchases verification alert

### DIFF
--- a/app-apple/Sources/AppLibrary/Extensions/ProfileEditor+Save.swift
+++ b/app-apple/Sources/AppLibrary/Extensions/ProfileEditor+Save.swift
@@ -25,13 +25,11 @@ extension ProfileEditor {
             do {
                 try iapObservable.verify(profileToSave, extra: extraFeatures)
             } catch ABI.AppError.ineligibleProfile(let requiredFeatures) {
-
-                // still loading receipt
+                // Still loading receipt
                 guard !iapObservable.isLoadingReceipt else {
                     throw ABI.AppError.verificationReceiptIsLoading
                 }
-
-                // purchase required
+                // Purchase required
                 guard requiredFeatures.isEmpty else {
                     throw ABI.AppError.verificationRequiredFeatures(requiredFeatures)
                 }

--- a/app-apple/Sources/AppLibraryMain/Views/Profile/ProfileCoordinator.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Profile/ProfileCoordinator.swift
@@ -156,11 +156,11 @@ private extension ProfileCoordinator {
             return savedProfile
         } catch ABI.AppError.verificationReceiptIsLoading {
             pspLog(.profiles, .error, "Unable to commit profile: loading receipt")
-            let V = Strings.Views.Paywall.Alerts.self
-            errorHandler.handle(
-                title: V.Confirmation.title,
-                message: [V.Verification.edit, V.Verification.boot].joined(separator: "\n\n")
-            )
+//            let V = Strings.Views.Paywall.Alerts.self
+//            errorHandler.handle(
+//                title: V.Confirmation.title,
+//                message: [V.Verification.edit, V.Verification.boot].joined(separator: "\n\n")
+//            )
             return nil
         } catch ABI.AppError.verificationRequiredFeatures(let requiredFeatures) {
             pspLog(.profiles, .error, "Unable to commit profile: required features \(requiredFeatures)")

--- a/app-apple/Sources/AppResources/Resources/Constants.json
+++ b/app-apple/Sources/AppResources/Resources/Constants.json
@@ -38,7 +38,7 @@
         ],
         "verification": {
             "production": {
-                "defaultDelay": 120.0,
+                "defaultDelay": 240.0,
                 "tvDelay": 900.0,
                 "interval": 21600.0,
                 "attempts": 3,

--- a/app-cross/passepartout/shared/assets/constants.json
+++ b/app-cross/passepartout/shared/assets/constants.json
@@ -38,16 +38,16 @@
         ],
         "verification": {
             "production": {
-                "defaultDelay": 120.0,
+                "defaultDelay": 240.0,
                 "tvDelay": 900.0,
                 "interval": 21600.0,
                 "attempts": 3,
                 "retryInterval": 300.0
             },
             "beta": {
-                "defaultDelay": 600.0,
-                "interval": 600.0,
-                "attempts": 3,
+                "defaultDelay": 1800.0,
+                "interval": 1800.0,
+                "attempts": 6,
                 "retryInterval": 10.0
             }
         }


### PR DESCRIPTION
The specific error is still printed to the app log, for what it's worth. Mitigates #1777 