### PR TITLE
NE: Implement better path block in .bsdSockets

### DIFF
--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -76,10 +76,8 @@ extension TunnelABI {
         // Create daemon
         let factory: NetworkInterfaceFactory
         if preferences.isFlagEnabled(.bsdSockets) {
-            factory = BSDSocketFactory(ctx) {
-                // FIXME: #190, BetterPathBlock via NWPathMonitor
-                PassthroughStream()
-            }
+            let betterPathBlock = NEBetterPathBlock(ctx).block
+            factory = BSDSocketFactory(ctx, betterPathBlock: betterPathBlock)
         } else {
             // MUST enable .withReadPackets for OpenVPN V2 to work!
             var options = NEInterfaceFactory.Options()

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -55,10 +55,16 @@ extension TunnelABI {
 
         // Create platform-specific objects
         let controller = try VirtualTunnelController(ctx, impl: bindings.controller)
-        let factory = BSDSocketFactory(ctx) {
+        let betterPathBlock: BetterPathBlock
+#if !PSP_CROSS
+        betterPathBlock = NEBetterPathBlock(ctx).block
+#else
+        betterPathBlock = {
             // FIXME: #1656, C ABI, better path block
             PassthroughStream()
         }
+#endif
+        let factory = BSDSocketFactory(ctx, betterPathBlock: betterPathBlock)
         // FIXME: #1656, C ABI, reachability observer
         let reachability = DummyReachabilityObserver()
 


### PR DESCRIPTION
With this in place, BSD sockets should serve as a cross-platform replacement of deprecated NE sockets (unavailable in Swift 6).