### PR TITLE
Fix Foundation bloat in libpassepartout

### DIFF
--- a/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
@@ -37,7 +37,7 @@ private extension OpenVPNImplementationBuilder {
         module: OpenVPNModule
     ) throws -> Connection {
         let ctx = PartoutLoggerContext(parameters.profile.id)
-        var options = OpenVPNConnection.Options()
+        var options = OpenVPNConnectionOptions()
         options.writeTimeout = TimeInterval(parameters.options.linkWriteTimeout) / 1000.0
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
 #if !PSP_CROSS

--- a/app-cross/Sources/CommonLibraryCore/Strategy/FileProfileRepository.swift
+++ b/app-cross/Sources/CommonLibraryCore/Strategy/FileProfileRepository.swift
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-import Foundation
 import Partout
 
 public actor FileProfileRepository: ProfileRepository {
@@ -98,10 +97,7 @@ public actor FileProfileRepository: ProfileRepository {
     }
 
     public func removeAllProfiles() async throws {
-        let existingFiles = try FileManager.default.contentsOfDirectory(
-            at: objectsURL,
-            includingPropertiesForKeys: nil
-        )
+        let existingFiles = try FileManager.default.contentsOfDirectory(at: objectsURL)
         for fileURL in existingFiles where fileURL.pathExtension == "json" {
             try? FileManager.default.removeItem(at: fileURL)
         }
@@ -241,10 +237,7 @@ private extension FileProfileRepository {
         objectsURL: URL,
         decoder: JSONDecoder
     ) throws -> [String: Profile] {
-        let fileURLs = try FileManager.default.contentsOfDirectory(
-            at: objectsURL,
-            includingPropertiesForKeys: nil
-        )
+        let fileURLs = try FileManager.default.contentsOfDirectory(at: objectsURL)
         var profilesById: [String: Profile] = [:]
         for fileURL in fileURLs where fileURL.pathExtension == "json" {
             let data = try Data(contentsOf: fileURL)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,7 @@ fi
 mkdir -p bin
 
 # To be 100% sure
-rm -f bin/*/libpassepartout.*
+rm -rf bin/*/libpassepartout.*
 
 if [ "$android_flag" == "-android" ]; then
     source $cwd/env-android.sh

--- a/scripts/env-android.sh
+++ b/scripts/env-android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ANDROID_NDK_ROOT=
-export SWIFT_SDK=~/.swiftpm/swift-sdks/swift-6.3-RELEASE_android.artifactbundle
+export SWIFT_SDK=~/.swiftpm/swift-sdks/swift-6.3.1-RELEASE_android.artifactbundle
 export SWIFT_RESOURCE_DIR=$SWIFT_SDK/swift-android/swift-resources/usr/lib/swift_static-aarch64
 export ANDROID_NDK_TOOLCHAIN=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/darwin-x86_64/bin
 export ANDROID_NDK_SYSROOT=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/darwin-x86_64/sysroot


### PR DESCRIPTION
The CMake libpassepartout was bloated in size (Android 19MB → 63MB) because of a stale Foundation import in FileProfileRepository.

Use the compatible version of `FileManager.contentsOfDirectory(at: URL)` from MiniFoundation, because FoundationEssentials as is only provides `FileManager.contentsOfDirectory(atPath: String)`.