### PR TITLE
Android: Optimize release .apk

### DIFF
--- a/app-android/app/.gitignore
+++ b/app-android/app/.gitignore
@@ -1,1 +1,3 @@
 /build
+/debug
+/release

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -27,6 +27,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
+    lint {
+        checkReleaseBuilds = false
+        abortOnError = false
+    }
     buildTypes {
         release {
             isMinifyEnabled = true

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -29,7 +29,8 @@ android {
     }
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -38,7 +38,6 @@ android {
         }
     }
     buildFeatures {
-        viewBinding = true
         compose = true
     }
     ndkVersion = "29.0.13846066"
@@ -64,11 +63,6 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.androidx.constraintlayout)
-    implementation(libs.androidx.navigation.fragment.ktx)
-    implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.androidx.runtime.android)
     implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.ui.tooling.preview.android)

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.androidx.runtime.android)
     implementation(libs.androidx.activity.ktx)
+    implementation(libs.androidx.ui.tooling.preview.android)
     implementation(libs.androidx.material3.android)
     implementation(libs.androidx.activity.compose)
     implementation(libs.kotlinx.serialization.json)

--- a/app-android/app/proguard-rules.pro
+++ b/app-android/app/proguard-rules.pro
@@ -19,3 +19,25 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# JNI entry points are exported with static Java_* symbols, so their Kotlin
+# owner and method names must remain stable after R8.
+-keep class com.algoritmico.passepartout.helpers.NativeLibraryWrapper {
+    native <methods>;
+}
+
+# The native core calls these handlers by method name through GetMethodID.
+-keepclassmembers class * implements com.algoritmico.passepartout.helpers.ABIEventHandler {
+    public void onEvent(java.lang.String);
+}
+-keepclassmembers class * implements com.algoritmico.passepartout.helpers.ABIConnectionStatusHandler {
+    public void onStatus(java.lang.String);
+}
+-keepclassmembers class * implements com.algoritmico.passepartout.helpers.ABICompletionCallback {
+    public void onComplete(int, java.lang.String);
+}
+
+# The native tunnel backend receives this object and calls into it by name.
+-keep class io.partout.jni.AndroidTunnelController {
+    public *;
+}

--- a/app-android/app/proguard-rules.pro
+++ b/app-android/app/proguard-rules.pro
@@ -27,13 +27,24 @@
 }
 
 # The native core calls these handlers by method name through GetMethodID.
--keepclassmembers class * implements com.algoritmico.passepartout.helpers.ABIEventHandler {
+# Keep both the fun-interface methods and their generated lambda/object
+# implementors so R8 cannot rename the callback entry points.
+-keep interface com.algoritmico.passepartout.helpers.ABIEventHandler {
     public void onEvent(java.lang.String);
 }
--keepclassmembers class * implements com.algoritmico.passepartout.helpers.ABIConnectionStatusHandler {
+-keep class * implements com.algoritmico.passepartout.helpers.ABIEventHandler {
+    public void onEvent(java.lang.String);
+}
+-keep interface com.algoritmico.passepartout.helpers.ABIConnectionStatusHandler {
     public void onStatus(java.lang.String);
 }
--keepclassmembers class * implements com.algoritmico.passepartout.helpers.ABICompletionCallback {
+-keep class * implements com.algoritmico.passepartout.helpers.ABIConnectionStatusHandler {
+    public void onStatus(java.lang.String);
+}
+-keep interface com.algoritmico.passepartout.helpers.ABICompletionCallback {
+    public void onComplete(int, java.lang.String);
+}
+-keep class * implements com.algoritmico.passepartout.helpers.ABICompletionCallback {
     public void onComplete(int, java.lang.String);
 }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -167,7 +167,8 @@ class MainActivity : ComponentActivity() {
             Log.e("Passepartout", "Unable to start missing profile: $profileId")
             return false
         }
-        return tunnelStrategy.connect(profile)
+        tunnelStrategy.connect(profile)
+        return true
     }
 
     private fun openProfileImporter() {

--- a/app-android/app/src/main/res/values-night-v23/themes.xml
+++ b/app-android/app/src/main/res/values-night-v23/themes.xml
@@ -2,7 +2,7 @@
     <style name="Theme.Passepartout" parent="Base.Theme.Passepartout">
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowLightNavigationBar">true</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/app-android/app/src/main/res/values-night/themes.xml
+++ b/app-android/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,3 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Base.Theme.Passepartout" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your dark theme here. -->
-        <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
-    </style>
+<resources>
+    <style name="Base.Theme.Passepartout" parent="@android:style/Theme.Material.NoActionBar" />
 </resources>

--- a/app-android/app/src/main/res/values/themes.xml
+++ b/app-android/app/src/main/res/values/themes.xml
@@ -1,9 +1,5 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Base.Theme.Passepartout" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
-    </style>
+<resources>
+    <style name="Base.Theme.Passepartout" parent="@android:style/Theme.Material.Light.NoActionBar" />
 
     <style name="Theme.Passepartout" parent="Base.Theme.Passepartout" />
 </resources>

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -6,11 +6,6 @@ coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-appcompat = "1.7.1"
-material = "1.12.0"
-constraintlayout = "2.2.1"
-navigationFragmentKtx = "2.9.3"
-navigationUiKtx = "2.9.3"
 runtimeAndroid = "1.8.3"
 uiToolingPreviewAndroidVersion = "1.8.3"
 material3AndroidVersion = "1.3.2"
@@ -24,11 +19,6 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
-androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
-androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroidVersion" }
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3AndroidVersion" }


### PR DESCRIPTION
- Optimize dependencies
- Minify and shrink resources
- Preserve JNI names in ProGuard rules
- Skip lint (it always fails on AndroidTunnelController.kt, review this later)

With these changes (plus CMake "Release" build_type in env.sh), the uncompressed .apk goes from 55MB to 31MB. Compressed size is 12MB.