### PR TITLE
Refactor build script to handle multiple flags

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -10,14 +10,11 @@ $swift_arch = switch ($env:PROCESSOR_ARCHITECTURE) {
 }
 
 $swift_root = "$env:USERPROFILE/AppData/Local/Programs/Swift"
-$swift_version = "6.2.1"
+$swift_version = "6.3.1"
 $env:SWIFT_SDK = "$swift_root/Platforms/$swift_version/Windows.platform/Developer/SDKs/Windows.sdk/usr/lib/swift/windows/$swift_arch"
 $env:SWIFT_RUNTIME = "$swift_root/Runtimes/$swift_version/usr/bin"
 
 try {
-    # Remove all .txt files in the build folder
-    Remove-Item -Path "$build_dir\*.txt" -ErrorAction SilentlyContinue
-
     # Create build folder if it doesn't exist
     if (-not (Test-Path -Path "$build_dir")) {
         New-Item -ItemType Directory -Path "$build_dir" | Out-Null

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,40 +2,58 @@
 cwd=`dirname $0`
 source $cwd/env.sh
 set -e
+build_dir=.cmake
+bin_dir=bin
 
-# Use switch statement later for more flags
-android_flag="$1"
-if [[ -n "$android_flag" && "$android_flag" != "-android" ]]; then
-    echo "Either pass -android or nothing"
-    exit 1
+positional_args=()
+cmake_opts=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -gen)
+            gen_build=1
+            shift
+            ;;
+        -config)
+            cmake_opts+=("-DCMAKE_BUILD_TYPE=$2")
+            shift
+            shift
+            ;;
+        -app)
+            cmake_opts+=("-DBUILD_APP=ON")
+            shift
+            ;;
+        -android)
+            if [[ ! -d $ANDROID_NDK_HOME ]]; then
+                echo "\$ANDROID_NDK_HOME must point to the Android NDK"
+                exit 1
+            fi
+            source $cwd/env-android.sh
+            build_dir=${build_dir}-android
+            for_android=1
+            cmake_opts+=("-DCMAKE_TOOLCHAIN_FILE=$partout_toolchains_path/android.toolchain.cmake")
+            shift
+            ;;
+    esac
+done
+set -- "${positional_args[@]}"
+
+if [[ $(uname -s) == "Linux" && $for_android != 1 ]]; then
+    source $cwd/env-linux.sh
+    cmake_opts+=("-DCMAKE_TOOLCHAIN_FILE=$partout_toolchains_path/linux.toolchain.cmake")
 fi
 
-build_dir=".cmake${android_flag}"
-toolchain_dir=`realpath $toolchains_path`
-if [ ! -d $build_dir ]; then
+if [[ ! -d $build_dir ]]; then
     mkdir $build_dir
 fi
-mkdir -p bin
-
-if [ "$android_flag" == "-android" ]; then
-    if [[ ! -d $ANDROID_NDK_HOME ]]; then
-        echo "\$ANDROID_NDK_HOME must point to the Android NDK"
-        exit 1
-    fi
-    source $cwd/env-android.sh
-    toolchain_arg="-DCMAKE_TOOLCHAIN_FILE=$toolchain_dir/android.toolchain.cmake"
+if [[ ! -d $bin_dir ]]; then
+    mkdir $bin_dir
+fi
+if [[ $gen_build == 1 ]]; then
     scripts/gen-cmake-files.sh
     pushd $build_dir
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=$build_type $toolchain_arg ..
-    cmake --build .
-    popd
+    cmake -G Ninja "${cmake_opts[@]}" ..
 else
-    if [ $(uname -s) == "Linux" ]; then
-        source $cwd/env-linux.sh
-        toolchain_arg="-DCMAKE_TOOLCHAIN_FILE=$toolchain_dir/linux.toolchain.cmake"
-    fi
     pushd $build_dir
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=$build_type $toolchain_arg -DBUILD_APP=ON ..
-    cmake --build .
-    popd
 fi
+cmake --build .
+popd

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -5,6 +5,5 @@ metadata_root="fastlane/metadata"
 metadata_path="default/release_notes.txt"
 translations_input_path="l10n"
 translations_output_path="app-apple/Sources/AppStrings/Resources"
-build_type=Debug
-toolchains_path="app-cross/partout/toolchains"
+partout_toolchains_path="app-cross/partout/toolchains"
 codegen=$(pwd)/node_modules/.bin/openapi-generator-cli


### PR DESCRIPTION
Make configuration generation and app building opt-in with `-gen` and `-app` respectively. Pass `-config` rather than from `env.sh`.