### PR TITLE
Android: Fix NDK build issues with CMP0157

### DIFF
--- a/app-cross/CMakeLists.txt
+++ b/app-cross/CMakeLists.txt
@@ -63,11 +63,6 @@ if(LINUX)
 endif()
 
 # Distribute with dependencies
-if(ANDROID)
-    set(STRIP "${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-strip")
-else()
-    set(STRIP ${CMAKE_STRIP})
-endif()
 if(WIN32)
     set(LIBEXT lib)
 elseif(APPLE)
@@ -82,7 +77,8 @@ add_custom_command(
         -DABI_INCLUDE=${ABI_INCLUDE}
         -DOUTPUT_DIR=${OUTPUT_DIR}
         -DDIST_DIR=${DIST_DIR}
-        -DSTRIP=${STRIP} -DLIBEXT=${LIBEXT}
+        -DSTRIP=${CMAKE_STRIP}
+        -DLIBEXT=${LIBEXT}
         -P "${CMAKE_CURRENT_SOURCE_DIR}/distribute.cmake"
 )
 


### PR DESCRIPTION
- Override swiftc flags to avoid LINK_FLAGS in build.ninja
- Assume correct strip path (now inherited from NDK toolchain)