### PR TITLE
ABI: Initialize synchronously and add tunnel connect/disconnect

### DIFF
--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -17,24 +17,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
     return JNI_VERSION_1_6;
 }
 
-static
-JNIEnv *jni_attach_thread(bool *did_attach) {
-    JNIEnv *env;
-    jint status = (*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_6);
-    switch (status) {
-        case JNI_OK:
-            *did_attach = false;
-            return env;
-        case JNI_EDETACHED:
-            status = (*jvm)->AttachCurrentThread(jvm, &env, NULL);
-            if (status != JNI_OK) return NULL;
-            *did_attach = true;
-            return env;
-        default:
-            return NULL;
-    }
-}
-
 abi_handler *abi_handler_create(JNIEnv *env, jobject ref) {
     abi_handler *handler = malloc(sizeof(abi_handler));
     handler->ref = (*env)->NewGlobalRef(env, ref);
@@ -53,10 +35,7 @@ void abi_handler_proxy(void *ctx, const char *method_id, const char *json) {
     assert(ctx);
     assert(method_id);
     assert(json);
-
-    bool did_attach;
-    JNIEnv *env = jni_attach_thread(&did_attach);
-    if (!env) return;
+    JNI_ATTACH_OR_RETURN_VOID(env);
 
     abi_handler *handler = (abi_handler *)ctx;
     jclass cls = (*env)->GetObjectClass(env, handler->ref);
@@ -70,7 +49,8 @@ void abi_handler_proxy(void *ctx, const char *method_id, const char *json) {
         }
         (*env)->DeleteLocalRef(env, cls);
     }
-    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
+
+    JNI_DETACH(env);
 }
 
 void abi_event_handler_proxy(void *ctx, const char *event_json) {
@@ -85,10 +65,7 @@ void abi_connection_status_handler_proxy(void *ctx, const char *status_json) {
 
 void abi_completion_proxy(void *ctx, int code, const char *json) {
     assert(ctx);
-
-    bool did_attach;
-    JNIEnv *env = jni_attach_thread(&did_attach);
-    if (!env) return;
+    JNI_ATTACH_OR_RETURN_VOID(env);
 
     abi_handler *handler = (abi_handler *)ctx;
     jclass cls = (*env)->GetObjectClass(env, handler->ref);
@@ -105,10 +82,27 @@ void abi_completion_proxy(void *ctx, int code, const char *json) {
     // Release handler on completion
     abi_handler_free(env, handler);
 
-    if (did_attach) (*jvm)->DetachCurrentThread(jvm);
+    JNI_DETACH(env);
 }
 
-/* Types */
+/* JNI */
+
+JNIEnv *jni_attach_thread(bool *did_attach) {
+    JNIEnv *env;
+    jint status = (*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_6);
+    switch (status) {
+        case JNI_OK:
+            *did_attach = false;
+            return env;
+        case JNI_EDETACHED:
+            status = (*jvm)->AttachCurrentThread(jvm, &env, NULL);
+            if (status != JNI_OK) return NULL;
+            *did_attach = true;
+            return env;
+        default:
+            return NULL;
+    }
+}
 
 jni_string_array *jni_string_array_create(JNIEnv *env, jobjectArray v) {
     if (env == NULL || v == NULL) return NULL;

--- a/app-android/app/src/main/cpp/src/helpers.h
+++ b/app-android/app/src/main/cpp/src/helpers.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include <jni.h>
+#include <stdbool.h>
 
 typedef struct {
     jobject ref;
@@ -21,7 +22,8 @@ void abi_connection_status_handler_proxy(void *ctx, const char *status_json);
 /* Completion handlers (lifescope = function call, released on call). */
 void abi_completion_proxy(void *ctx, int code, const char *json);
 
-/* Type helpers. */
+/* JNI helpers. */
+
 typedef struct {
     const char **cs;
     jstring *js;
@@ -29,3 +31,29 @@ typedef struct {
 } jni_string_array;
 jni_string_array *jni_string_array_create(JNIEnv *env, jobjectArray v);
 void jni_string_array_free(JNIEnv *env, jni_string_array *ja);
+
+extern JavaVM *jvm;
+JNIEnv *jni_attach_thread(bool *did_attach);
+
+#define JNI_ATTACH_OR_RETURN(env_name, return_value) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) return return_value
+
+#define JNI_ATTACH_OR_RETURN_VOID(env_name) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) return
+
+#define JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
+    bool env_name##_did_attach; \
+    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    if (!(env_name)) { \
+        if (completion) completion(ctx, -1); \
+        return; \
+    }
+
+#define JNI_DETACH(env_name) \
+    do { \
+        if (env_name##_did_attach) (*jvm)->DetachCurrentThread(jvm); \
+    } while (0)

--- a/app-android/app/src/main/cpp/src/helpers.h
+++ b/app-android/app/src/main/cpp/src/helpers.h
@@ -47,7 +47,7 @@ JNIEnv *jni_attach_thread(bool *did_attach);
 
 #define JNI_ATTACH_OR_COMPLETE(env_name, completion, ctx) \
     bool env_name##_did_attach; \
-    JNIEnv *env_name = pp_jni_attach_thread(&env_name##_did_attach); \
+    JNIEnv *env_name = jni_attach_thread(&env_name##_did_attach); \
     if (!(env_name)) { \
         if (completion) completion(ctx, -1); \
         return; \

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -111,6 +111,30 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appDeleteProfiles(
 }
 
 JNIEXPORT void JNICALL
+Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appConnect(
+        JNIEnv *env,
+        jobject thiz,
+        jstring profile,
+        jobject completion
+) {
+    const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
+    psp_app_connect(cProfile, PSP_JNI_CB(env, completion));
+    (*env)->ReleaseStringUTFChars(env, profile, cProfile);
+}
+
+JNIEXPORT void JNICALL
+Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appDisconnect(
+        JNIEnv *env,
+        jobject thiz,
+        jstring profileId,
+        jobject completion
+) {
+    const char *cProfileId = (*env)->GetStringUTFChars(env, profileId, NULL);
+    psp_app_disconnect(cProfileId, PSP_JNI_CB(env, completion));
+    (*env)->ReleaseStringUTFChars(env, profileId, cProfileId);
+}
+
+JNIEXPORT jint JNICALL
 Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStart(
         JNIEnv *env,
         jobject thiz,

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -9,16 +9,9 @@
 #include "passepartout.h"
 #include "helpers.h"
 
-struct {
-    abi_handler *eventHandler;
-} app_references;
-
-struct {
-    jobject jniController;
-    abi_handler *statusHandler;
-} tunnel_references;
-
 #define PSP_JNI_CB(e, c) PSP_CB(abi_handler_create(e, c), abi_completion_proxy)
+static void app_bindings_free(psp_app_bindings *b);
+static void tunnel_bindings_free(psp_tunnel_bindings *b);
 
 JNIEXPORT jstring JNICALL
 Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
@@ -31,7 +24,7 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appOnForeground(JNIEnv
     psp_app_on_foreground();
 }
 
-JNIEXPORT void JNICALL
+JNIEXPORT jint JNICALL
 Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appInit(
         JNIEnv *env,
         jobject thiz,
@@ -39,16 +32,19 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appInit(
         jstring constants,
         jstring profilesDir,
         jstring cacheDir,
-        jobject eventHandler,
-        jobject completion
+        jobject tunnel,
+        jobject eventHandler
 ) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
     const char *cConstants = (*env)->GetStringUTFChars(env, constants, NULL);
     const char *cProfilesDir = (*env)->GetStringUTFChars(env, profilesDir, NULL);
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
-    // Store globally
-    app_references.eventHandler = abi_handler_create(env, eventHandler);
+    psp_app_bindings bindings = { 0 };
+    bindings.tunnel = (*env)->NewGlobalRef(env, tunnel);
+    bindings.event_ctx = abi_handler_create(env, eventHandler);
+    bindings.event_cb = abi_event_handler_proxy;
+    bindings.free = app_bindings_free;
 
     psp_app_init_args args = { 0 };
     args.bundle = cBundle;
@@ -56,14 +52,14 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appInit(
     args.preferences = "{\"logsPrivateData\": true}";
     args.profiles_dir = cProfilesDir;
     args.cache_dir = cCacheDir;
-    args.bindings.event_ctx = app_references.eventHandler;
-    args.bindings.event_cb = abi_event_handler_proxy;
-    psp_app_init(&args, PSP_JNI_CB(env, completion));
+    args.bindings = bindings;
+    const jint result = psp_app_init(&args);
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
     (*env)->ReleaseStringUTFChars(env, profilesDir, cProfilesDir);
     (*env)->ReleaseStringUTFChars(env, cacheDir, cCacheDir);
+    return result;
 }
 
 JNIEXPORT void JNICALL
@@ -73,17 +69,6 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appDeinit(
         jobject completion
 ) {
     psp_app_deinit(PSP_JNI_CB(env, completion));
-}
-
-JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appRelease(
-        JNIEnv *env,
-        jobject thiz
-) {
-    if (app_references.eventHandler) {
-        abi_handler_free(env, app_references.eventHandler);
-        app_references.eventHandler = NULL;
-    }
 }
 
 JNIEXPORT void JNICALL
@@ -133,18 +118,19 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStart(
         jstring constants,
         jstring profile,
         jstring cacheDir,
-        jobject statusHandler,
         jobject controller,
-        jobject completion
+        jobject statusHandler
 ) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
     const char *cConstants = (*env)->GetStringUTFChars(env, constants, NULL);
     const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
-    // Store global JNI references (ownership is transferred)
-    tunnel_references.jniController = (*env)->NewGlobalRef(env, controller);
-    tunnel_references.statusHandler = abi_handler_create(env, statusHandler);
+    psp_tunnel_bindings bindings = { 0 };
+    bindings.controller = (*env)->NewGlobalRef(env, controller);
+    bindings.status_ctx = abi_handler_create(env, statusHandler);
+    bindings.status_cb = abi_connection_status_handler_proxy;
+    bindings.free = tunnel_bindings_free;
 
     psp_tunnel_start_args args = { 0 };
     args.bundle = cBundle;
@@ -154,16 +140,15 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStart(
     args.profile = cProfile;
     args.is_interactive = true;
     args.is_daemon = false;
-    args.bindings.controller = tunnel_references.jniController;
-    args.bindings.status_ctx = tunnel_references.statusHandler;
-    args.bindings.status_cb = abi_connection_status_handler_proxy;
+    args.bindings = bindings;
 
-    psp_tunnel_start(&args, PSP_JNI_CB(env, completion));
+    const jint result = psp_tunnel_start(&args);
 
     (*env)->ReleaseStringUTFChars(env, bundle, cBundle);
     (*env)->ReleaseStringUTFChars(env, constants, cConstants);
     (*env)->ReleaseStringUTFChars(env, profile, cProfile);
     (*env)->ReleaseStringUTFChars(env, cacheDir, cCacheDir);
+    return result;
 }
 
 JNIEXPORT void JNICALL
@@ -175,17 +160,28 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStop(
     psp_tunnel_stop(PSP_JNI_CB(env, completion));
 }
 
-JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelRelease(
-        JNIEnv *env,
-        jobject thiz
-) {
-    if (tunnel_references.jniController) {
-        (*env)->DeleteGlobalRef(env, tunnel_references.jniController);
-        tunnel_references.jniController = NULL;
+void app_bindings_free(psp_app_bindings *b) {
+    JNI_ATTACH_OR_RETURN_VOID(env);
+    if (b->tunnel) {
+        (*env)->DeleteGlobalRef(env, b->tunnel);
+        b->tunnel = NULL;
     }
-    if (tunnel_references.statusHandler) {
-        abi_handler_free(env, tunnel_references.statusHandler);
-        tunnel_references.statusHandler = NULL;
+    if (b->event_ctx) {
+        abi_handler_free(env, b->event_ctx);
+        b->event_ctx = NULL;
     }
+    JNI_DETACH(env);
+}
+
+void tunnel_bindings_free(psp_tunnel_bindings *b) {
+    JNI_ATTACH_OR_RETURN_VOID(env);
+    if (b->controller) {
+        (*env)->DeleteGlobalRef(env, b->controller);
+        b->controller = NULL;
+    }
+    if (b->status_ctx) {
+        abi_handler_free(env, b->status_ctx);
+        b->status_ctx = NULL;
+    }
+    JNI_DETACH(env);
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -13,23 +13,24 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
 import com.algoritmico.passepartout.abi.AppABIProfile
+import com.algoritmico.passepartout.abi.PassepartoutWrapper
+import com.algoritmico.passepartout.abi.helpers.ABIConnectionStatusDispatcher
+import com.algoritmico.passepartout.abi.helpers.ABIEventDispatcher
 import com.algoritmico.passepartout.abi.models.AppProfileStatus
 import com.algoritmico.passepartout.abi.models.AppTunnelInfo
 import com.algoritmico.passepartout.abi.models.Event
 import com.algoritmico.passepartout.abi.models.OnConnectionStatus
 import com.algoritmico.passepartout.abi.models.TunnelEventRefresh
-import com.algoritmico.passepartout.abi.helpers.ABIEventDispatcher
-import com.algoritmico.passepartout.abi.helpers.ABIConnectionStatusDispatcher
-import com.algoritmico.passepartout.abi.PassepartoutWrapper
 import com.algoritmico.passepartout.ui.PassepartoutApp
 import com.algoritmico.passepartout.ui.ProfileObservable
 import io.partout.abi.ConnectionStatus
-import io.partout.abi.TaggedProfile
-import io.partout.jni.AndroidTunnelStrategy
+import io.partout.jni.AndroidTunnel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.Closeable
 import java.io.File
+import kotlin.coroutines.resume
 
 class MainActivity : ComponentActivity() {
     private val library = PassepartoutWrapper()
@@ -41,7 +42,7 @@ class MainActivity : ComponentActivity() {
 
     private lateinit var profileObservable: ProfileObservable
 
-    private lateinit var tunnelStrategy: AndroidTunnelStrategy
+    private lateinit var tunnel: AndroidTunnel
 
     private var eventSubscription: Closeable? = null
 
@@ -65,34 +66,31 @@ class MainActivity : ComponentActivity() {
             abi = AppABIProfile(library),
             coroutineScope = lifecycleScope
         )
-
-        eventSubscription = ABIEventDispatcher.register(::handleEvent)
-        statusSubscription = ABIConnectionStatusDispatcher.register(::handleConnectionStatus)
-        library.appInit(
-            bundle,
-            constants,
-            profilesDirectory.absolutePath,
-            cacheDir.absolutePath,
-            ABIEventDispatcher,
-            { code, json ->
-                runOnUiThread {
-                    if (code == 0) {
-                        isAppInitialized = true
-                        Log.e("Passepartout", ">>> Started app")
-                    } else {
-                        Log.e("Passepartout", "Unable to init app (code=$code): $json")
-                        destroyApp()
-                    }
-                }
-            }
-        )
-        tunnelStrategy = AndroidTunnelStrategy(
+        tunnel = AndroidTunnel(
             context = this,
             vpnServiceClass = PassepartoutVPNService::class.java,
             requestVpnPermission = { permissionIntent ->
                 vpnPermissionLauncher.launch(permissionIntent)
             }
         )
+
+        eventSubscription = ABIEventDispatcher.register(::handleEvent)
+        statusSubscription = ABIConnectionStatusDispatcher.register(::handleConnectionStatus)
+        val appInitCode = library.appInit(
+            bundle,
+            constants,
+            profilesDirectory.absolutePath,
+            cacheDir.absolutePath,
+            tunnel,
+            ABIEventDispatcher
+        )
+        if (appInitCode == 0) {
+            isAppInitialized = true
+            Log.e("Passepartout", ">>> Started app")
+        } else {
+            Log.e("Passepartout", "Unable to init app (code=$appInitCode)")
+            destroyApp()
+        }
 
         setContent {
             PassepartoutApp(
@@ -117,11 +115,7 @@ class MainActivity : ComponentActivity() {
         profileObservable.close()
         appEventChannel.close()
         if (isAppInitialized) {
-            library.appDeinit { _, _ ->
-                library.appRelease()
-            }
-        } else {
-            library.appRelease()
+            library.appDeinit { _, _ -> }
         }
         super.onDestroy()
     }
@@ -162,7 +156,7 @@ class MainActivity : ComponentActivity() {
         return if (enabled) {
             connectTunnel(profileId)
         } else {
-            tunnelStrategy.disconnect()
+            disconnectTunnel(profileId)
             true
         }
     }
@@ -177,8 +171,23 @@ class MainActivity : ComponentActivity() {
             Log.e("Passepartout", "Unable to start missing profile: $profileId")
             return false
         }
-        tunnelStrategy.connect(profile)
-        return true
+        return suspendCancellableCoroutine { continuation ->
+            library.appConnect (profile) { code, json ->
+                if (continuation.isActive) {
+                    continuation.resume(code == 0)
+                }
+            }
+        }
+    }
+
+    private suspend fun disconnectTunnel(profileId: String) {
+        suspendCancellableCoroutine { continuation ->
+            library.appDisconnect(profileId) { code, json ->
+                if (continuation.isActive) {
+                    continuation.resume(Unit)
+                }
+            }
+        }
     }
 
     private fun openProfileImporter() {
@@ -216,7 +225,7 @@ class MainActivity : ComponentActivity() {
     private val vpnPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        tunnelStrategy.onVpnPermissionResult(result.resultCode == RESULT_OK)
+        tunnel.onVpnPermissionResult(result.resultCode == RESULT_OK)
     }
 
     private companion object {
@@ -231,12 +240,12 @@ class MainActivity : ComponentActivity() {
         )
     }
 
-    private fun readProfile(profileId: String): TaggedProfile? {
+    private fun readProfile(profileId: String): String? {
         val profileFile = File(profilesDirectory, "$OBJECTS_DIR/$profileId.json")
         if (!profileFile.isFile) {
             return null
         }
-        return globalJsonCoder.decodeFromString(profileFile.readText())
+        return profileFile.readText()
     }
 
     private fun displayName(uri: Uri): String? {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVPNService.kt
@@ -17,7 +17,7 @@ import com.algoritmico.passepartout.abi.PassepartoutWrapper
 import io.partout.abi.ConnectionStatus
 import io.partout.abi.TaggedProfile
 import io.partout.jni.AndroidTunnelController
-import io.partout.jni.AndroidTunnelStrategy
+import io.partout.jni.AndroidTunnel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +31,7 @@ import java.io.Closeable
 
 class PassepartoutVPNService: VpnService() {
     private val library = PassepartoutWrapper()
-    private val vpnWrapper = AndroidTunnelController(this)
+    private val tunnelController = AndroidTunnelController(this)
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val commandMutex = Mutex()
     private var statusSubscription: Closeable? = null
@@ -40,11 +40,11 @@ class PassepartoutVPNService: VpnService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         startServiceForeground()
-        if (intent?.action == AndroidTunnelStrategy.ACTION_STOP_VPN) {
+        if (intent?.action == AndroidTunnel.ACTION_STOP_VPN) {
             stopVpn()
             return START_NOT_STICKY;
         }
-        val profileJSON = intent?.getStringExtra(AndroidTunnelStrategy.EXTRA_PROFILE_JSON)
+        val profileJSON = intent?.getStringExtra(AndroidTunnel.EXTRA_PROFILE_JSON)
         if (profileJSON.isNullOrBlank()) {
             Log.e("Passepartout", "Missing profile in VPN start intent")
             stopServiceForeground()
@@ -145,18 +145,17 @@ class PassepartoutVPNService: VpnService() {
         profileJSON: String,
         cachePath: String
     ): ABIResult = withContext(Dispatchers.IO) {
-        val result = CompletableDeferred<ABIResult>()
-        library.tunnelStart(
-            bundle,
-            constants,
-            profileJSON,
-            cachePath,
-            ABIConnectionStatusDispatcher,
-            vpnWrapper
-        ) { code, json ->
-            result.complete(ABIResult(code, json))
-        }
-        result.await()
+        ABIResult(
+            library.tunnelStart(
+                bundle,
+                constants,
+                profileJSON,
+                cachePath,
+                tunnelController,
+                ABIConnectionStatusDispatcher
+            ),
+            null
+        )
     }
 
     private suspend fun awaitTunnelStop(): ABIResult = withContext(Dispatchers.IO) {
@@ -170,7 +169,6 @@ class PassepartoutVPNService: VpnService() {
     private fun releaseTunnelReferences() {
         statusSubscription?.close()
         statusSubscription = null
-        library.tunnelRelease()
     }
 
     private fun handleStatus(onStatusJSON: String) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
@@ -8,6 +8,8 @@ import android.util.Log
 import com.algoritmico.passepartout.abi.helpers.ABICompletionCallback
 import com.algoritmico.passepartout.abi.helpers.ABIConnectionStatusHandler
 import com.algoritmico.passepartout.abi.helpers.ABIEventHandler
+import io.partout.abi.TaggedProfile
+import io.partout.jni.AndroidTunnel
 import io.partout.jni.AndroidTunnelController
 
 class PassepartoutWrapper {
@@ -17,9 +19,9 @@ class PassepartoutWrapper {
         constants: String,
         profilesDir: String,
         cacheDir: String,
-        eventHandler: ABIEventHandler,
-        completion: ABICompletionCallback
-    )
+        tunnel: AndroidTunnel,
+        eventHandler: ABIEventHandler
+    ): Int
     external fun appDeinit(completion: ABICompletionCallback)
     external fun appOnForeground()
     external fun appImportProfileText(
@@ -40,18 +42,12 @@ class PassepartoutWrapper {
         constants: String,
         profile: String,
         cacheDir: String,
-        statusHandler: ABIConnectionStatusHandler,
         controller: AndroidTunnelController,
-        completion: ABICompletionCallback
-    )
+        statusHandler: ABIConnectionStatusHandler
+    ): Int
     external fun tunnelStop(
         completion: ABICompletionCallback
     )
-
-    // These are specific to Android to release JNI references
-    // FIXME: Remove and let appDeinit/tunnelStop in JNI do the deallocation
-    external fun appRelease()
-    external fun tunnelRelease()
 
     companion object {
         init {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
@@ -37,6 +37,14 @@ class PassepartoutWrapper {
         ids: Array<String>,
         completion: ABICompletionCallback
     )
+    external fun appConnect(
+        profile: String,
+        completion: ABICompletionCallback
+    )
+    external fun appDisconnect(
+        profileId: String,
+        completion: ABICompletionCallback
+    )
     external fun tunnelStart(
         bundle: String,
         constants: String,

--- a/app-apple/Passepartout/App/Context/AppContext+Testing.swift
+++ b/app-apple/Passepartout/App/Context/AppContext+Testing.swift
@@ -87,7 +87,8 @@ extension AppContext {
             registry: registry,
             tunnelManager: tunnelManager,
             versionChecker: versionChecker,
-            webReceiverManager: webReceiverManager
+            webReceiverManager: webReceiverManager,
+            bindings: nil
         )
         return AppContext(abi: abi, appConfiguration: appConfiguration, kvStore: kvStore)
     }

--- a/app-apple/Sources/AppLibrary/Previews/AppContext+Previews.swift
+++ b/app-apple/Sources/AppLibrary/Previews/AppContext+Previews.swift
@@ -76,7 +76,8 @@ extension AppContext {
             registry: registry,
             tunnelManager: tunnelManager,
             versionChecker: versionChecker,
-            webReceiverManager: webReceiverManager
+            webReceiverManager: webReceiverManager,
+            bindings: nil
         )
         return AppContext(abi: abi, appConfiguration: appConfiguration, kvStore: kvStore)
     }()

--- a/app-cross/CMakeLists.txt
+++ b/app-cross/CMakeLists.txt
@@ -40,8 +40,9 @@ add_library(passepartout_shared_c STATIC ${PSP_C_SOURCES})
 target_link_libraries(passepartout_shared PUBLIC passepartout_shared_c)
 
 # Import the modulemap for the C ABI
-set(ABI_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/Sources/CommonLibrary_C/include)
-target_include_directories(passepartout_shared PUBLIC ${ABI_INCLUDE})
+target_include_directories(passepartout_shared PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/Sources/CommonLibrary_C/include
+)
 
 # Depend on Partout
 add_dependencies(passepartout_shared partout)
@@ -75,7 +76,6 @@ add_custom_command(
     TARGET passepartout_shared
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
-        -DABI_INCLUDE=${ABI_INCLUDE}
         -DOUTPUT_DIR=${OUTPUT_DIR}
         -DDIST_DIR=${DIST_DIR}
         -DSTRIP=${CMAKE_STRIP}

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Apple.swift
@@ -301,7 +301,8 @@ extension AppABI {
             tunnelManager: tunnelManager,
             versionChecker: versionChecker,
             webReceiverManager: webReceiverManager,
-            onEligibleFeaturesBlock: onEligibleFeaturesBlock
+            onEligibleFeaturesBlock: onEligibleFeaturesBlock,
+            bindings: nil
         )
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
@@ -35,7 +35,7 @@ extension AppABI {
         kvStore.preferences = preferences
 
         // Logging context
-        let ctx = pspLogRegister(
+        _ = pspLogRegister(
             for: .app,
             with: appConfiguration,
             preferences: preferences,

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
@@ -23,11 +23,10 @@ extension AppABI {
         let appConfiguration = ABI.AppConfiguration(bundle: bundle, constants: constants)
 
         // Parse preferences
-        let preferences = ABI.AppPreferenceValues(
+        let preferences = ABI.AppPreferenceValues.forInitialization(
             with: decoder,
             data: preferencesData,
-            newDeviceId: true,
-            deviceIdLength: constants.deviceIdLength
+            newDeviceIdLength: constants.deviceIdLength
         )
 
         let logFormatter = appConfiguration.newLogFormatter()
@@ -63,10 +62,9 @@ extension AppABI {
         let appEncoder = AppEncoder(coder: registry, kvStore: kvStore)
         let profileRepository = try appConfiguration.newFileProfileRepository(path: profilesDir)
         let profileManager = ProfileManager(repository: profileRepository)
-        let tunnelStrategy = appConfiguration.newStandaloneTunnelStrategy()
-        let tunnel = Tunnel(ctx, strategy: tunnelStrategy) { @Sendable in
-            appConfiguration.newAppTunnelEnvironment(strategy: tunnelStrategy, profileId: $0)
-        }
+        let tunnel = appConfiguration.newStandaloneTunnel(ref: bindings.tunnel)
+        // FIXME: #1656, NativeTunnel lacks environment
+//        appConfiguration.newAppTunnelEnvironment(strategy: tunnelStrategy, profileId: $0)
         let tunnelManager = TunnelManager(tunnel: tunnel, interval: 1.0)
 
         // Dummy
@@ -88,7 +86,8 @@ extension AppABI {
             registry: registry,
             tunnelManager: tunnelManager,
             versionChecker: versionChecker,
-            webReceiverManager: webReceiverManager
+            webReceiverManager: webReceiverManager,
+            bindings: bindings
         )
 
         // Register for events
@@ -98,11 +97,10 @@ extension AppABI {
             context: eventContext,
             callback: { ctx, event in
                 guard let eventCallback else { return }
-                // Enrich event JSON with metadata for decoding
-                let wrapper = ABI.EventWrapper(event)
                 do {
-                    // Dispatch JSON event to cross-platform apps
-                    let json = try ABI.encodeWrapper(wrapper)
+                    // Make the event encodable with metadata for decoding
+                    let eventWrapper = ABI.EventWrapper(event)
+                    let json = try ABI.encodeCrossWrapper(eventWrapper)
                     json.withCString {
                         eventCallback(ctx, $0)
                     }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+import CommonLibrary_C
 import Partout
 
 @BusinessActor
@@ -36,6 +37,7 @@ public final class AppABI: Sendable {
     private let webReceiverManager: WebReceiverManager
     // Purchases handler
     private let onEligibleFeaturesBlock: (@Sendable (Set<ABI.AppFeature>) async -> Void)?
+    nonisolated(unsafe) private let bindings: psp_app_bindings?
 
     // Internal state
     private var launchTask: Task<Void, Error>?
@@ -59,7 +61,8 @@ public final class AppABI: Sendable {
         tunnelManager: TunnelManager,
         versionChecker: VersionChecker,
         webReceiverManager: WebReceiverManager,
-        onEligibleFeaturesBlock: (@Sendable (Set<ABI.AppFeature>) async -> Void)? = nil
+        onEligibleFeaturesBlock: (@Sendable (Set<ABI.AppFeature>) async -> Void)? = nil,
+        bindings: psp_app_bindings?
     ) {
         self.appConfiguration = appConfiguration
         self.configManager = configManager
@@ -76,6 +79,7 @@ public final class AppABI: Sendable {
         self.apiManager = apiManager ?? APIManager()
         self.preferencesManager = preferencesManager ?? PreferencesManager()
 #endif
+        self.bindings = bindings
         subscriptions = []
 
         let supportsIAP = appConfiguration.bundle.distributionTarget.supportsIAP
@@ -101,7 +105,11 @@ public final class AppABI: Sendable {
     }
 
     deinit {
+        pspLog(.abi, .debug, "Deinit AppABI")
         subscriptions.forEach { $0.cancel() }
+        if var bindings {
+            bindings.free?(&bindings)
+        }
     }
 }
 

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI.swift
@@ -557,7 +557,7 @@ private extension AppABI {
                 pspLog(.core, .info, "\tReconnect profile \(profile.id)")
                 try await tunnelManager.disconnect(from: profile.id)
                 do {
-                    try await tunnelManager.connect(with: profile)
+                    try await tunnelManager.connect(with: profile, force: false)
                 } catch ABI.AppError.interactiveLogin {
                     pspLog(.core, .info, "\tProfile \(profile.id) is interactive, do not reconnect")
                 } catch {

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -11,15 +11,18 @@ private var abi: AppABI?
 
 @c(psp_app_init)
 public func __psp_app_init(
-    args: UnsafePointer<psp_app_init_args>?,
-    completion: psp_completion
-) {
-    guard let args,
-          let appBundleData = args.pointee.bundle?.asJSONData,
+    args: UnsafePointer<psp_app_init_args>?
+) -> Int32 {
+    guard let args else {
+        return PSPCompletionCodeArgs
+    }
+    nonisolated(unsafe) var bindings = args.pointee.bindings
+    guard let appBundleData = args.pointee.bundle?.asJSONData,
           let appConstantsData = args.pointee.constants?.asJSONData,
           let cProfilesDir = args.pointee.profiles_dir,
           let cCacheDir = args.pointee.cache_dir else {
-        fatalError("NULL args or required fields")
+        bindings.free?(&bindings)
+        return PSPCompletionCodeArgs
     }
     let preferencesData = args.pointee.preferences?.asJSONData
     if args.pointee.preferences != nil {
@@ -27,8 +30,7 @@ public func __psp_app_init(
     }
     let profilesDir = String(cString: cProfilesDir)
     let cachesURL = URL(filePath: String(cString: cCacheDir))
-    nonisolated(unsafe) let bindings = args.pointee.bindings
-    ABI.run(completion) { callback in
+    return ABI.runBlockingInitialization {
         do {
             abi = try AppABI.forCrossPlatform(
                 bindings: bindings,
@@ -38,9 +40,10 @@ public func __psp_app_init(
                 profilesDir: profilesDir,
                 cachesURL: cachesURL
             )
-            callback?(PSPCompletionCodeOK, nil)
+            return PSPCompletionCodeOK
         } catch {
-            fatalError("Unable to start app: \(error)")
+            bindings.free?(&bindings)
+            return PSPCompletionCodeFailure
         }
     }
 }
@@ -135,8 +138,9 @@ public func __psp_app_delete_profiles(
         }
         ids.append(id)
     }
+    let fixedIds = ids
     ABI.run(completion) { callback in
-        await abi.profile.remove(ids)
+        await abi.profile.remove(fixedIds)
         callback?(PSPCompletionCodeOK, nil)
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -145,6 +145,51 @@ public func __psp_app_delete_profiles(
     }
 }
 
+@c(psp_app_connect)
+public func __psp_app_connect(
+    profile: UnsafePointer<CChar>?,
+    completion: psp_completion
+) {
+    guard let abi, let profile, let profileData = profile.asJSONData else {
+        completion.callback?(completion.ctx, PSPCompletionCodeArgs, nil)
+        return
+    }
+    let swiftProfile: Profile
+    do {
+        swiftProfile = try JSONDecoder().decode(TaggedProfile.self, from: profileData).asProfile()
+    } catch {
+        completion.callback?(completion.ctx, PSPCompletionCodeFailure, error.localizedDescription)
+        return
+    }
+    ABI.run(completion) { callback in
+        do {
+            try await abi.tunnel.connect(to: swiftProfile, force: true)
+            callback?(PSPCompletionCodeOK, nil)
+        } catch {
+            callback?(PSPCompletionCodeFailure, error.localizedDescription)
+        }
+    }
+}
+
+@c(psp_app_disconnect)
+public func __psp_app_disconnect(
+    uuid: UnsafePointer<CChar>?,
+    completion: psp_completion
+) {
+    guard let abi, let uuid, let id = Profile.ID(uuidString: String(cString: uuid)) else {
+        completion.callback?(completion.ctx, PSPCompletionCodeArgs, nil)
+        return
+    }
+    ABI.run(completion) { callback in
+        do {
+            try await abi.tunnel.disconnect(from: id)
+            callback?(PSPCompletionCodeOK, nil)
+        } catch {
+            callback?(PSPCompletionCodeFailure, error.localizedDescription)
+        }
+    }
+}
+
 @c(psp_app_flush_log)
 public func __psp_app_flush_log() {
     pspLogFlush()

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -24,8 +24,55 @@ enum ABIError: Error {
 }
 
 extension ABI {
-    typealias RunCallback = @Sendable (_ code: Int32, _ json: String?) -> Void
+    // Following psp_completion:
+    //
+    // Code == 0 -> Success, String = JSON payload
+    // Code != 0 -> Failure, String = Error message
+    typealias RunCallback = @Sendable (_ code: Int32, _ string: String?) -> Void
 
+    // Run ABI initialization synchronously.
+    //
+    // WARNING: This method is potentially DANGEROUS and fights Concurrency
+    // only to simplify the app initialization flow. Any other ABI function
+    // MUST NEVER block the current thread. Use run() variants instead.
+    //
+    static func runBlockingInitialization(
+        _ block: @escaping @Sendable @BusinessActor () async -> Int32
+    ) -> Int32 {
+        let isBusinessRunningOnMainThread = BusinessActor.self == MainActor.self
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result = PSPCompletionCodeFailure
+        Task { @Sendable @BusinessActor in
+            result = await block()
+            semaphore.signal()
+        }
+#if canImport(Darwin)
+        // Business code runs on MainActor on macOS
+        guard isBusinessRunningOnMainThread else {
+            fatalError("Apple BusinessActor must be MainActor")
+        }
+        // Yield the main thread otherwise the block() invocation may deadlock
+        // on the first async call to business objects, as they run on MainActor
+        let isMainThread = pthread_main_np() == 1
+        if isMainThread {
+            let yield = 0.001
+            while semaphore.wait(timeout: .now()) == .timedOut {
+                RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: yield))
+            }
+            return result
+        }
+#else
+        // Ensure that non-Apple business runs off of MainActor
+        // because other UI engines may lock the main thread
+        guard !isBusinessRunningOnMainThread else {
+            fatalError("Non-Apple BusinessActor must not be MainActor")
+        }
+#endif
+        semaphore.wait()
+        return result
+    }
+
+    // Run ABI function without waiting for completion
     static func run(
         _ block: @escaping @Sendable @BusinessActor () async -> Void
     ) {
@@ -34,6 +81,8 @@ extension ABI {
         }
     }
 
+    // Run ABI function with a completion callback. The consumer must call
+    // the RunCallback block argument to invoke completion with a return code.
     static func run(
         _ completion: psp_completion,
         _ block: @escaping @Sendable @BusinessActor (RunCallback?) async -> Void
@@ -52,7 +101,8 @@ extension ABI {
         }
     }
 
-    static func encodeWrapper<T>(_ wrapper: T) throws -> String where T: Encodable {
+    // Encode a cross-platform type using ISO8601 dates
+    static func encodeCrossWrapper<T>(_ wrapper: T) throws -> String where T: Encodable {
         let data: Data
         do {
             let encoder = JSONEncoder()
@@ -64,48 +114,43 @@ extension ABI {
         guard let json = String(data: data, encoding: .utf8) else {
             throw ABIError.wrapping()
         }
-        // Dispatch JSON event to cross-platform apps
         return json
     }
 }
 
-extension UnsafePointer where Pointee == CChar {
-    var asJSONData: Data? {
-        String(cString: self).data(using: .utf8)
-    }
-}
-
-// MARK: - Wrapping
-
 extension ABI {
+    // Wrap ABI.Event in a format that decodes cross-platform
     struct EventWrapper: Encodable {
         private let payload: Encodable
 
         init?(_ event: Event) {
-            guard let payload = event.payload else { return nil }
+            guard let payload = Self.payload(of: event) else { return nil }
             self.payload = payload
         }
 
-        func encode(to encoder: any Encoder) throws {
+        func encode(to encoder: Encoder) throws {
             try payload.encode(to: encoder)
         }
-    }
-}
 
-private extension ABI.Event {
-    // Return the first (and only) associated value of the enum
-    var payload: Encodable? {
-        let mirror = Mirror(reflecting: self)
-        guard let arg = mirror.children.first else { return nil }
-        let children = Mirror(reflecting: arg.value).children
-        assert(children.count == 1)
-        guard let payload = children.first?.value else { return nil }
-        return payload as? Encodable
+        // Return the first (and only) associated value of the enum
+        private static func payload(of event: Event) -> Encodable? {
+            let mirror = Mirror(reflecting: self)
+            guard let arg = mirror.children.first else { return nil }
+            let children = Mirror(reflecting: arg.value).children
+            assert(children.count == 1)
+            guard let payload = children.first?.value else { return nil }
+            return payload as? Encodable
+        }
     }
 }
 
 extension ABI.AppPreferenceValues {
-    init(with decoder: JSONDecoder, data: Data?, newDeviceId: Bool, deviceIdLength: Int) {
+    // Init ABI.AppPreferenceValues from JSON data and optionally generate a new Device ID
+    static func forInitialization(
+        with decoder: JSONDecoder,
+        data: Data?,
+        newDeviceIdLength: Int?
+    ) -> Self {
         var values = ABI.AppPreferenceValues()
         if let data {
             do {
@@ -116,11 +161,17 @@ extension ABI.AppPreferenceValues {
         } else {
             pspLog(.core, .info, "No preferences provided")
         }
-        if newDeviceId && values.deviceId == nil {
-            values.deviceId = String.random(count: deviceIdLength)
+        if let newDeviceIdLength, values.deviceId == nil {
+            values.deviceId = String.random(count: newDeviceIdLength)
         }
-        self = values
+        return values
     }
 }
 
+// Shortcut to convert a C string to JSON data
+extension UnsafePointer where Pointee == CChar {
+    var asJSONData: Data? {
+        String(cString: self).data(using: .utf8)
+    }
+}
 #endif

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -134,7 +134,7 @@ extension ABI {
 
         // Return the first (and only) associated value of the enum
         private static func payload(of event: Event) -> Encodable? {
-            let mirror = Mirror(reflecting: self)
+            let mirror = Mirror(reflecting: event)
             guard let arg = mirror.children.first else { return nil }
             let children = Mirror(reflecting: arg.value).children
             assert(children.count == 1)

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -133,7 +133,8 @@ extension TunnelABI {
             environment: environment,
             iap: iap,
             logFormatter: logFormatter,
-            originalProfile: originalProfile
+            originalProfile: originalProfile,
+            bindings: nil
         )
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -24,11 +24,10 @@ extension TunnelABI {
         let appConfiguration = ABI.AppConfiguration(bundle: bundle, constants: constants)
 
         // Parse preferences
-        var preferences = ABI.AppPreferenceValues(
+        var preferences = ABI.AppPreferenceValues.forInitialization(
             with: decoder,
             data: preferencesData,
-            newDeviceId: true,
-            deviceIdLength: constants.deviceIdLength
+            newDeviceIdLength: constants.deviceIdLength
         )
         // FIXME: ###, Cross, Hardcoded config flags
         preferences.configFlags = [.ovpnCrossV2, .wgCrossV2]
@@ -54,7 +53,7 @@ extension TunnelABI {
         )
 
         // Create platform-specific objects
-        let controller = try VirtualTunnelController(ctx, impl: bindings.controller)
+        let controller = try NativeTunnelController(ctx, ref: bindings.controller)
         let betterPathBlock: BetterPathBlock
 #if !PSP_CROSS
         betterPathBlock = NEBetterPathBlock(ctx).block
@@ -73,12 +72,13 @@ extension TunnelABI {
         let statusCallback = bindings.status_cb
         let onStatus: SimpleConnectionDaemon.StatusCallback = { profileId, status in
             guard let statusCallback else { return }
-            let wrapper = ABI.OnConnectionStatus(
-                profileId: profileId.uuidString,
-                status: status
-            )
             do {
-                let json = try ABI.encodeWrapper(wrapper)
+                // Pack the status payload
+                let onStatus = ABI.OnConnectionStatus(
+                    profileId: profileId.uuidString,
+                    status: status
+                )
+                let json = try ABI.encodeCrossWrapper(onStatus)
                 json.withCString {
                     statusCallback(statusContext, $0)
                 }
@@ -111,7 +111,8 @@ extension TunnelABI {
             environment: environment,
             iap: nil,
             logFormatter: logFormatter,
-            originalProfile: profile
+            originalProfile: profile,
+            bindings: bindings
         )
     }
 }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
+import CommonLibrary_C
 import Partout
 
 public final class TunnelABI: TunnelABIProtocol {
@@ -29,8 +30,8 @@ public final class TunnelABI: TunnelABIProtocol {
     private let iap: IAP?
     private let logFormatter: LogFormatter
     private let originalProfile: Profile
+    nonisolated(unsafe) private let bindings: psp_tunnel_bindings?
 
-    nonisolated(unsafe)
     private var verifierSubscription: Task<Void, Error>?
 
     public init(
@@ -38,17 +39,26 @@ public final class TunnelABI: TunnelABIProtocol {
         environment: TunnelEnvironment,
         iap: IAP?,
         logFormatter: LogFormatter,
-        originalProfile: Profile
+        originalProfile: Profile,
+        bindings: psp_tunnel_bindings?
     ) {
         self.daemon = daemon
         self.environment = environment
         self.iap = iap
         self.logFormatter = logFormatter
         self.originalProfile = originalProfile
+        self.bindings = bindings
 
         // Disable if skips purchases
         if let iap {
             iap.manager.isEnabled = !iap.skipsPurchases
+        }
+    }
+
+    deinit {
+        pspLog(.abi, .debug, "Deinit TunnelABI")
+        if var bindings {
+            bindings.free?(&bindings)
         }
     }
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -56,6 +56,7 @@ public func __psp_tunnel_start(
             if globalABI != nil {
                 await globalABI?.stop()
                 globalABI = nil
+            } else {
                 bindings.free?(&bindings)
             }
             return PSPCompletionCodeFailure

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI_C.swift
@@ -11,15 +11,18 @@ private var globalABI: TunnelABIProtocol?
 
 @c(psp_tunnel_start)
 public func __psp_tunnel_start(
-    args: UnsafePointer<psp_tunnel_start_args>?,
-    completion: psp_completion
-) {
-    guard let args,
-          let appBundleData = args.pointee.bundle?.asJSONData,
+    args: UnsafePointer<psp_tunnel_start_args>?
+) -> Int32 {
+    guard let args else {
+        return PSPCompletionCodeArgs
+    }
+    nonisolated(unsafe) var bindings = args.pointee.bindings
+    guard let appBundleData = args.pointee.bundle?.asJSONData,
           let appConstantsData = args.pointee.constants?.asJSONData,
           let cProfileJSON = args.pointee.profile,
           let cCacheDir = args.pointee.cache_dir else {
-        fatalError("NULL args or required fields")
+        bindings.free?(&bindings)
+        return PSPCompletionCodeArgs
     }
     // Process input
     let preferencesData = args.pointee.preferences?.asJSONData
@@ -34,10 +37,8 @@ public func __psp_tunnel_start(
     let cachesURL = URL(filePath: String(cString: cCacheDir))
     let isInteractive = args.pointee.is_interactive
     let isDaemon = args.pointee.is_daemon
-    nonisolated(unsafe) let bindings = args.pointee.bindings
     // Start tunnel ABI
-    ABI.run(completion) { callback in
-        defer { pspUnlock() }
+    let result = ABI.runBlockingInitialization {
         do {
             await globalABI?.stop()
             globalABI = nil
@@ -50,15 +51,20 @@ public func __psp_tunnel_start(
                 cachesURL: cachesURL
             )
             try await globalABI?.start(isInteractive: isInteractive)
-            callback?(PSPCompletionCodeOK, nil)
+            return PSPCompletionCodeOK
         } catch {
-            await globalABI?.stop()
-            globalABI = nil
-            callback?(PSPCompletionCodeFailure, error.localizedDescription)
-            fatalError("Unable to start tunnel: \(error)")
+            if globalABI != nil {
+                await globalABI?.stop()
+                globalABI = nil
+                bindings.free?(&bindings)
+            }
+            return PSPCompletionCodeFailure
         }
     }
-    pspLock(isDaemon: isDaemon)
+    if result == PSPCompletionCodeOK {
+        pspLock(isDaemon: isDaemon)
+    }
+    return result
 }
 
 @c(psp_tunnel_stop)
@@ -70,22 +76,14 @@ public func __psp_tunnel_stop(completion: psp_completion) {
     }
 }
 
-private let semaphore = DispatchSemaphore(value: 0)
-
 private func pspLock(isDaemon: Bool) {
+    guard isDaemon else { return }
 #if canImport(Darwin)
-    if isDaemon { CFRunLoopRun() }
+    CFRunLoopRun()
 #else
-    // Wait for ABI to start
+    // Block main thread indefinitely to keep the process running
+    let semaphore = DispatchSemaphore(value: 0)
     semaphore.wait()
-    // Block main thread indefinitely if daemon
-    if isDaemon { semaphore.wait() }
-#endif
-}
-
-private func pspUnlock() {
-#if !canImport(Darwin)
-    semaphore.signal()
 #endif
 }
 

--- a/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
@@ -136,6 +136,10 @@ extension ABI.AppConfiguration {
         )
     }
 
+    public func newStandaloneTunnel(ref: UnsafeMutableRawPointer?) -> TunnelProtocol {
+        NativeTunnel(ref: ref)
+    }
+
     @BusinessActor
     public func newTunnelManager(
         tunnel: Tunnel,
@@ -437,11 +441,6 @@ extension ABI.AppConfiguration {
         SharedTunnelEnvironment(profileId: profileId)
     }
 
-    // FIXME: ###, Cross UI, Apple standalone tunnel strategy
-    public func newStandaloneTunnelStrategy() -> TunnelObservableStrategy {
-        FakeTunnelStrategy()
-    }
-
     public func newSystemExtensionManager(tunnelIdentifier: String) -> ExtensionInstaller? {
         guard bundle.distributionTarget == .developerID else {
             return nil
@@ -502,10 +501,6 @@ extension ABI.AppConfiguration {
 
     public func newStandaloneTunnelEnvironment(profileId: Profile.ID) -> TunnelEnvironment {
         SharedTunnelEnvironment(profileId: profileId)
-    }
-
-    public func newStandaloneTunnelStrategy() -> TunnelObservableStrategy {
-        FakeTunnelStrategy()
     }
 }
 

--- a/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
@@ -10,7 +10,7 @@ public final class TunnelManager {
 
     public static nonisolated let appPreferences = "appPreferences"
 
-    private let tunnel: Tunnel
+    private let tunnel: TunnelProtocol
 
     private let extensionInstaller: ExtensionInstaller?
 
@@ -32,7 +32,7 @@ public final class TunnelManager {
 
     // TODO: #218, keep "last used profile" until .multiple
     public nonisolated init(
-        tunnel: Tunnel,
+        tunnel: TunnelProtocol,
         extensionInstaller: ExtensionInstaller? = nil,
         kvStore: KeyValueStore? = nil,
         processor: AppTunnelProcessor? = nil,

--- a/app-cross/Sources/CommonLibraryCore/Domain/Extensions/Codegen+Events.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Extensions/Codegen+Events.swift
@@ -37,7 +37,7 @@ extension ABI.IAPEvent {
         public let originalPurchase: ABI.OriginalPurchase?
         public let products: Set<ABI.AppProduct>
         public let isBeta: Bool
-        public func encode(to encoder: any Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             try container.encode(OpenAPIIAPEventNewReceipt(
                 originalPurchase: originalPurchase?.toProto,
@@ -63,7 +63,7 @@ extension ABI.ProfileEvent {
     public struct Save: ABI.EventProtocol {
         public let profile: Profile
         public let previous: Profile?
-        public func encode(to encoder: any Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             try container.encode(OpenAPIProfileEventSave(
                 profile: profile.asTaggedProfile,
@@ -90,7 +90,7 @@ extension ABI.TunnelEvent {
 extension ABI.VersionEvent {
     public struct New: ABI.EventProtocol {
         public let release: ABI.VersionRelease
-        public func encode(to encoder: any Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             try container.encode(OpenAPIVersionEventNew(
                 release: release.toProto

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -71,6 +71,8 @@ void psp_app_import_profile_path(const char *path, psp_completion completion);
 void psp_app_import_profile_text(const char *text, const char *filename, psp_completion completion);
 void psp_app_delete_profile(const char *uuid, psp_completion completion);
 void psp_app_delete_profiles(const char **uuids, size_t num, psp_completion completion);
+void psp_app_connect(const char *profile, psp_completion completion);
+void psp_app_disconnect(const char *profile_id, psp_completion completion);
 void psp_app_flush_log(void);
 
 /* Daemon initialization. */

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -19,13 +19,13 @@ char *psp_readfile(const char *rel_path, const char *parent);
 typedef void (*psp_event_callback)(void *event_ctx, const char *event);
 
 /* Completion callback.
- * - Success: code == 0, data = JSON (optional)
- * - Error:   code != 0, data = String
+ * - Success: code == 0, string = JSON (optional)
+ * - Error:   code != 0, string = error message
  */
 #define PSPCompletionCodeOK         0
 #define PSPCompletionCodeArgs       -2
 #define PSPCompletionCodeFailure    -1
-typedef void (*psp_completion_cb)(void *ctx, int code, const char *data);
+typedef void (*psp_completion_cb)(void *ctx, int code, const char *string);
 typedef struct {
     void *ctx;
     psp_completion_cb callback;
@@ -39,15 +39,18 @@ psp_completion PSP_CB(void *ctx, psp_completion_cb callback) {
 }
 #define PSP_CB_NOP() PSP_CB(NULL, NULL)
 
-typedef struct {
+typedef struct __psp_app_bindings {
+    void *tunnel;
     void *event_ctx;
     psp_event_callback event_cb;
+    void (*free)(struct __psp_app_bindings *);
 } psp_app_bindings;
 
-typedef struct {
+typedef struct __psp_tunnel_bindings {
     void *controller;
     void *status_ctx;
     psp_event_callback status_cb;
+    void (*free)(struct __psp_tunnel_bindings *);
 } psp_tunnel_bindings;
 
 /* App initialization. */
@@ -61,7 +64,7 @@ typedef struct {
 } psp_app_init_args;
 
 /* App functions. */
-void psp_app_init(const psp_app_init_args *args, psp_completion completion);
+int psp_app_init(const psp_app_init_args *args);
 void psp_app_deinit(psp_completion completion);
 void psp_app_on_foreground(void);
 void psp_app_import_profile_path(const char *path, psp_completion completion);
@@ -83,7 +86,7 @@ typedef struct {
 } psp_tunnel_start_args;
 
 /* Daemon functions. */
-void psp_tunnel_start(const psp_tunnel_start_args *args, psp_completion completion);
+int psp_tunnel_start(const psp_tunnel_start_args *args);
 void psp_tunnel_stop(psp_completion completion);
 
 #endif

--- a/app-cross/Sources/CommonProvidersCore/ProviderModule.swift
+++ b/app-cross/Sources/CommonProvidersCore/ProviderModule.swift
@@ -206,7 +206,7 @@ extension ProviderModule {
             }
         }
 
-        public func encode(to encoder: any Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             let rawMap: [String: Data] = map.reduce(into: [:]) {
                 $0[$1.key.id] = $1.value
             }

--- a/app-cross/passepartout/app/app.cc
+++ b/app-cross/passepartout/app/app.cc
@@ -19,7 +19,7 @@ bool MyApp::OnInit()
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 #endif
 
-    psp_app_init_args args;
+    psp_app_init_args args = { 0 };
     char *bundle = NULL;
     char *constants = NULL;
     MyFrame* frame = 0;
@@ -50,7 +50,7 @@ bool MyApp::OnInit()
     args.cache_dir = cache_dir;
     args.bindings.event_ctx = this;
     args.bindings.event_cb = onABIEvent;
-    psp_app_init(&args, PSP_CB_NOP());
+    if (psp_app_init(&args) != PSPCompletionCodeOK) goto failure;
     free(bundle);
     free(constants);
 

--- a/app-cross/passepartout/tunnel/main.c
+++ b/app-cross/passepartout/tunnel/main.c
@@ -8,16 +8,6 @@
 #include <stdlib.h>
 #include "passepartout.h"
 
-static
-void start_callback(void *ctx, int result, const char *error) {
-    (void)ctx;
-    if (error) {
-        printf("Result: %d, %s\n", result, error);
-    } else {
-        printf("Result: %d\n", result);
-    }
-}
-
 int main(int argc, char *argv[]) {
     char *bundle = NULL;
     char *constants = NULL;
@@ -65,12 +55,12 @@ int main(int argc, char *argv[]) {
     args.bindings.controller = NULL;
 
     /* Will block indefinitely. */
-    psp_tunnel_start(&args, PSP_CB(NULL, start_callback));
+    const int result = psp_tunnel_start(&args);
 
     free(bundle);
     free(constants);
     free(profile);
-    return 0;
+    return result;
 failure:
     if (bundle) free(bundle);
     if (constants) free(constants);


### PR DESCRIPTION
ABI:

- Make psp_app_init() and psp_tunnel_start() synchronous to simplify the lifecycle
- Delegate bindings clean-up to a free() function pointer to avoid manual app/tunnel release
- Use NativeTunnel in cross-platform AppABI via TunnelProtocol
- Refactor and document helpers in CommonABI.swift

Android:

- Simplify app/tunnel initialization lifecycle
- Integrate connect/disconnect ABI (via AndroidTunnel)
- Add JNI helper macros