### PR TITLE
ABI: Centralize JSON coding and ISO8601

### DIFF
--- a/app-cross/Sources/CommonDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
+++ b/app-cross/Sources/CommonDataPreferences/Strategy/CDProviderPreferencesRepositoryV3.swift
@@ -44,7 +44,7 @@ private final class CDProviderPreferencesRepositoryV3: ProviderPreferencesReposi
             // migrate favorite server ids
             if let favoriteServerIds = entity.favoriteServerIds {
                 let mapper = CoreDataMapper(context: context)
-                let ids = try? JSONDecoder().decode(Set<String>.self, from: favoriteServerIds)
+                let ids = try? ABI.decode(Set<String>.self, from: favoriteServerIds)
                 var favoriteServers: Set<CDFavoriteServer> = []
                 ids?.forEach {
                     favoriteServers.insert(mapper.cdFavoriteServer(from: $0))

--- a/app-cross/Sources/CommonDataProviders/Domain/CoreDataMapper.swift
+++ b/app-cross/Sources/CommonDataProviders/Domain/CoreDataMapper.swift
@@ -10,20 +10,18 @@ struct CoreDataMapper {
     @discardableResult
     func cdProvider(from provider: Provider, cache: Data?) throws -> CDProviderV3 {
         let entity = CDProviderV3(context: context)
-        let encoder = JSONEncoder()
-
         entity.providerId = provider.id.rawValue
         entity.fullName = provider.description
         entity.cache = cache
         entity.supportedModuleTypes = provider.metadata.map(\.key.rawValue).joined(separator: ",")
-        entity.encodedMetadata = try encoder.encode(provider.metadata)
+        entity.encodedMetadata = try ABI.encode(provider.metadata)
         return entity
     }
 
     @discardableResult
     func cdServer(from server: ProviderServer) throws -> CDProviderServerV3 {
         let entity = CDProviderServerV3(context: context)
-        let encoder = JSONEncoder()
+        let encoder = ABI.self
 
         entity.serverId = server.serverId
         entity.hostname = server.hostname

--- a/app-cross/Sources/CommonDataProviders/Domain/DomainMapper.swift
+++ b/app-cross/Sources/CommonDataProviders/Domain/DomainMapper.swift
@@ -13,7 +13,7 @@ struct DomainMapper {
         let metadata: [ModuleType: Provider.Metadata]
         if let encodedMetadata = entity.encodedMetadata {
             do {
-                metadata = try JSONDecoder().decode([ModuleType: Provider.Metadata].self, from: encodedMetadata)
+                metadata = try ABI.decode([ModuleType: Provider.Metadata].self, from: encodedMetadata)
             } catch {
                 return nil
             }
@@ -32,7 +32,7 @@ struct DomainMapper {
     }
 
     func cache(from entities: [CDProviderV3]) -> [ProviderID: ProviderCache] {
-        let decoder = JSONDecoder()
+        let decoder = ABI.self
         return entities.reduce(into: [:]) {
             guard let id = $1.providerId else {
                 return
@@ -73,7 +73,7 @@ struct DomainMapper {
             return nil
         }
 
-        let decoder = JSONDecoder()
+        let decoder = ABI.self
         let hostname = entity.hostname
         let ipAddresses = try entity.ipAddresses.map {
             Set(try decoder.decode([Data].self, from: $0))

--- a/app-cross/Sources/CommonDataProviders/Strategy/CDAPIRepositoryV3.swift
+++ b/app-cross/Sources/CommonDataProviders/Strategy/CDAPIRepositoryV3.swift
@@ -102,7 +102,7 @@ private final class CDAPIRepositoryV3: NSObject, APIRepository {
                 providerRequest.predicate = predicate
                 let providers = try providerRequest.execute()
                 if let provider = providers.first, let cache = infrastructure.cache {
-                    provider.cache = try JSONEncoder().encode(cache)
+                    provider.cache = try ABI.encode(cache)
                 }
 
                 // delete all provider entities

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
@@ -15,16 +15,12 @@ extension AppABI {
         profilesDir: String,
         cachesURL: URL
     ) throws -> AppABI {
-        let decoder = JSONDecoder()
-
-        // Decode app configuration
-        let bundle = try decoder.decode(ABI.AppBundle.self, from: appBundleData)
-        let constants = try decoder.decode(ABI.AppConstants.self, from: appConstantsData)
+        let bundle = try ABI.decode(ABI.AppBundle.self, from: appBundleData)
+        let constants = try ABI.decode(ABI.AppConstants.self, from: appConstantsData)
         let appConfiguration = ABI.AppConfiguration(bundle: bundle, constants: constants)
 
         // Parse preferences
         let preferences = ABI.AppPreferenceValues.forInitialization(
-            with: decoder,
             data: preferencesData,
             newDeviceIdLength: constants.deviceIdLength
         )

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI_C.swift
@@ -156,7 +156,7 @@ public func __psp_app_connect(
     }
     let swiftProfile: Profile
     do {
-        swiftProfile = try JSONDecoder().decode(TaggedProfile.self, from: profileData).asProfile()
+        swiftProfile = try ABI.decode(TaggedProfile.self, from: profileData).asProfile()
     } catch {
         completion.callback?(completion.ctx, PSPCompletionCodeFailure, error.localizedDescription)
         return

--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -105,9 +105,7 @@ extension ABI {
     static func encodeCrossWrapper<T>(_ wrapper: T) throws -> String where T: Encodable {
         let data: Data
         do {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            data = try encoder.encode(wrapper)
+            data = try ABI.encode(wrapper)
         } catch {
             throw ABIError.wrapping(reason: error)
         }
@@ -146,15 +144,11 @@ extension ABI {
 
 extension ABI.AppPreferenceValues {
     // Init ABI.AppPreferenceValues from JSON data and optionally generate a new Device ID
-    static func forInitialization(
-        with decoder: JSONDecoder,
-        data: Data?,
-        newDeviceIdLength: Int?
-    ) -> Self {
+    static func forInitialization(data: Data?, newDeviceIdLength: Int?) -> Self {
         var values = ABI.AppPreferenceValues()
         if let data {
             do {
-                values = try decoder.decode(Self.self, from: data)
+                values = try ABI.decode(Self.self, from: data)
             } catch {
                 pspLog(.core, .error, "Unable to decode preferences: \(error)")
             }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -16,16 +16,12 @@ extension TunnelABI {
         profileInput: ABI.ProfileImporterInput,
         cachesURL: URL
     ) throws -> TunnelABI {
-        let decoder = JSONDecoder()
-
-        // Decode app configuration
-        let bundle = try decoder.decode(ABI.AppBundle.self, from: appBundleData)
-        let constants = try decoder.decode(ABI.AppConstants.self, from: appConstantsData)
+        let bundle = try ABI.decode(ABI.AppBundle.self, from: appBundleData)
+        let constants = try ABI.decode(ABI.AppConstants.self, from: appConstantsData)
         let appConfiguration = ABI.AppConfiguration(bundle: bundle, constants: constants)
 
         // Parse preferences
         var preferences = ABI.AppPreferenceValues.forInitialization(
-            with: decoder,
             data: preferencesData,
             newDeviceIdLength: constants.deviceIdLength
         )

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
@@ -130,9 +130,9 @@ public final class TunnelABI: TunnelABIProtocol {
         guard let daemon else { return nil }
         pspLog(.core, .debug, "Handle tunnel message")
         do {
-            let input = try JSONDecoder().decode(Message.Input.self, from: messageData)
+            let input = try ABI.decode(Message.Input.self, from: messageData)
             let output = try await daemon.sendMessage(input)
-            let encodedOutput = try JSONEncoder().encode(output)
+            let encodedOutput = try ABI.encode(output)
             switch input {
             case .environment:
                 break

--- a/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Registry.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Registry.swift
@@ -57,8 +57,8 @@ extension ABI.AppConfiguration {
                 switch $0.innerType {
                 case .Provider:
                     do {
-                        let data = try JSONEncoder().encode($0.json)
-                        return try JSONDecoder().decode(ProviderModule.self, from: data)
+                        let data = try ABI.encode($0.json)
+                        return try ABI.decode(ProviderModule.self, from: data)
                     } catch {
                         pspLog(.profiles, .error, "Unable to decode ProviderModule: \(error)")
                         return $0

--- a/app-cross/Sources/CommonLibraryApple/Bundle+Extensions.swift
+++ b/app-cross/Sources/CommonLibraryApple/Bundle+Extensions.swift
@@ -11,7 +11,7 @@ extension Bundle {
         }
         do {
             let data = try Data(contentsOf: jsonURL)
-            return try JSONDecoder().decode(type, from: data)
+            return try ABI.decode(type, from: data)
         } catch {
             fatalError("Unable to decode \(filename).json: \(error)")
         }

--- a/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
@@ -70,7 +70,7 @@ extension TunnelManager {
 #if !PSP_CROSS
         var options: [String: NSObject] = [Self.isManualKey: true as NSNumber]
         if let preferences = kvStore?.preferences {
-            let encodedPreferences = try JSONEncoder().encode(preferences)
+            let encodedPreferences = try ABI.encode(preferences)
             options[Self.appPreferences] = encodedPreferences as NSData
         }
 #else

--- a/app-cross/Sources/CommonLibraryCore/Domain/AppPreference.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppPreference.swift
@@ -94,7 +94,7 @@ extension ABI.AppPreferenceValues {
         get {
             guard let configFlagsData else { return [] }
             do {
-                return try JSONDecoder().decode(Set<ABI.ConfigFlag>.self, from: configFlagsData)
+                return try ABI.decode(Set<ABI.ConfigFlag>.self, from: configFlagsData)
             } catch {
                 pspLog(.core, .error, "Unable to decode config flags: \(error)")
                 return []
@@ -102,7 +102,7 @@ extension ABI.AppPreferenceValues {
         }
         set {
             do {
-                configFlagsData = try JSONEncoder().encode(newValue)
+                configFlagsData = try ABI.encode(newValue)
             } catch {
                 pspLog(.core, .error, "Unable to encode config flags: \(error)")
             }
@@ -113,7 +113,7 @@ extension ABI.AppPreferenceValues {
         get {
             guard let experimentalData else { return Experimental() }
             do {
-                return try JSONDecoder().decode(Experimental.self, from: experimentalData)
+                return try ABI.decode(Experimental.self, from: experimentalData)
             } catch {
                 pspLog(.core, .error, "Unable to decode experimental: \(error)")
                 return Experimental()
@@ -121,7 +121,7 @@ extension ABI.AppPreferenceValues {
         }
         set {
             do {
-                experimentalData = try JSONEncoder().encode(newValue)
+                experimentalData = try ABI.encode(newValue)
             } catch {
                 pspLog(.core, .error, "Unable to encode experimental: \(error)")
             }

--- a/app-cross/Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
+++ b/app-cross/Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import Partout
+
+extension ABI {
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+#if PSP_CROSS
+        encoder.dateEncodingStrategy = .iso8601
+#endif
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+#if PSP_CROSS
+        decoder.dateDecodingStrategy = .iso8601
+#endif
+        return decoder
+    }()
+
+    public static func encode<T>(_ value: T) throws -> Data where T: Encodable {
+        try encoder.encode(value)
+    }
+
+    public static func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
+        try decoder.decode(type, from: data)
+    }
+}

--- a/app-cross/Sources/CommonLibraryCore/Strategy/FileProfileRepository.swift
+++ b/app-cross/Sources/CommonLibraryCore/Strategy/FileProfileRepository.swift
@@ -39,8 +39,6 @@ public actor FileProfileRepository: ProfileRepository {
     private let objectsURL: URL
     private let tmpURL: URL
     private let indexURL: URL
-    private let encoder: JSONEncoder
-    private let decoder: JSONDecoder
 
     public init(directoryURL: URL) throws {
         profilesSubject = CurrentValueStream([])
@@ -49,20 +47,10 @@ public actor FileProfileRepository: ProfileRepository {
         tmpURL = directoryURL.appending(component: "tmp", directoryHint: .isDirectory)
         indexURL = directoryURL.appending(component: "index.json")
 
-        encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: objectsURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: tmpURL, withIntermediateDirectories: true)
-        try Self.ensureIndex(
-            indexURL: indexURL,
-            objectsURL: objectsURL,
-            encoder: encoder,
-            decoder: decoder
-        )
+        try Self.ensureIndex(indexURL: indexURL, objectsURL: objectsURL)
     }
 
     public nonisolated var profilesPublisher: AsyncStream<[Profile]> {
@@ -76,7 +64,7 @@ public actor FileProfileRepository: ProfileRepository {
     }
 
     public func saveProfile(_ profile: Profile) async throws {
-        let data = try encoder.encode(profile.asTaggedProfile)
+        let data = try ABI.encode(profile.asTaggedProfile)
         try writeAtomically(data, to: objectURL(for: profile.id))
         try persistIndex(for: try loadProfilesById())
         try publishProfiles()
@@ -107,31 +95,24 @@ public actor FileProfileRepository: ProfileRepository {
 }
 
 private extension FileProfileRepository {
-    static func ensureIndex(
-        indexURL: URL,
-        objectsURL: URL,
-        encoder: JSONEncoder,
-        decoder: JSONDecoder
-    ) throws {
+    static func ensureIndex(indexURL: URL, objectsURL: URL) throws {
         guard FileManager.default.fileExists(atPath: indexURL.filePath()) else {
             try persistIndex(
-                for: loadProfilesByIdFromObjects(objectsURL: objectsURL, decoder: decoder),
+                for: loadProfilesByIdFromObjects(objectsURL: objectsURL),
                 indexURL: indexURL,
                 tmpURL: objectsURL.deletingLastPathComponent().appending(component: "tmp", directoryHint: .isDirectory),
-                encoder: encoder,
                 sortProfiles: sortProfiles
             )
             return
         }
         do {
-            _ = try loadIndex(from: indexURL, decoder: decoder)
+            _ = try loadIndex(from: indexURL)
         } catch {
             pspLog(.profiles, .error, "Rebuilding malformed profile index: \(error)")
             try persistIndex(
-                for: loadProfilesByIdFromObjects(objectsURL: objectsURL, decoder: decoder),
+                for: loadProfilesByIdFromObjects(objectsURL: objectsURL),
                 indexURL: indexURL,
                 tmpURL: objectsURL.deletingLastPathComponent().appending(component: "tmp", directoryHint: .isDirectory),
-                encoder: encoder,
                 sortProfiles: sortProfiles
             )
         }
@@ -181,7 +162,7 @@ private extension FileProfileRepository {
     }
 
     func loadProfilesByIdFromObjects() throws -> [String: Profile] {
-        try Self.loadProfilesByIdFromObjects(objectsURL: objectsURL, decoder: decoder)
+        try Self.loadProfilesByIdFromObjects(objectsURL: objectsURL)
     }
 
     func orderedIds() throws -> [String] {
@@ -189,7 +170,7 @@ private extension FileProfileRepository {
     }
 
     private func loadIndex() throws -> IndexFile {
-        try Self.loadIndex(from: indexURL, decoder: decoder)
+        try Self.loadIndex(from: indexURL)
     }
 
     func persistIndex(for profilesById: [String: Profile]) throws {
@@ -197,7 +178,6 @@ private extension FileProfileRepository {
             for: profilesById,
             indexURL: indexURL,
             tmpURL: tmpURL,
-            encoder: encoder,
             sortProfiles: sortProfiles
         )
     }
@@ -233,16 +213,13 @@ private extension FileProfileRepository {
         try FileManager.default.moveItem(at: tempURL, to: destinationURL)
     }
 
-    static func loadProfilesByIdFromObjects(
-        objectsURL: URL,
-        decoder: JSONDecoder
-    ) throws -> [String: Profile] {
+    static func loadProfilesByIdFromObjects(objectsURL: URL) throws -> [String: Profile] {
         let fileURLs = try FileManager.default.contentsOfDirectory(at: objectsURL)
         var profilesById: [String: Profile] = [:]
         for fileURL in fileURLs where fileURL.pathExtension == "json" {
             let data = try Data(contentsOf: fileURL)
             do {
-                let tagged = try decoder.decode(TaggedProfile.self, from: data)
+                let tagged = try ABI.decode(TaggedProfile.self, from: data)
                 let profile = try tagged.asProfile()
                 profilesById[profile.id.uuidString] = profile
             } catch {
@@ -252,10 +229,10 @@ private extension FileProfileRepository {
         return profilesById
     }
 
-    private static func loadIndex(from indexURL: URL, decoder: JSONDecoder) throws -> IndexFile {
+    private static func loadIndex(from indexURL: URL) throws -> IndexFile {
         do {
             let data = try Data(contentsOf: indexURL)
-            return try decoder.decode(IndexFile.self, from: data)
+            return try ABI.decode(IndexFile.self, from: data)
         } catch let error as FileProfileRepositoryError {
             throw error
         } catch {
@@ -267,7 +244,6 @@ private extension FileProfileRepository {
         for profilesById: [String: Profile],
         indexURL: URL,
         tmpURL: URL,
-        encoder: JSONEncoder,
         sortProfiles: (Profile, Profile) -> Bool
     ) throws {
         let profiles = profilesById.values.sorted(by: sortProfiles)
@@ -282,7 +258,7 @@ private extension FileProfileRepository {
                 )
             }
         )
-        let data = try encoder.encode(index)
+        let data = try ABI.encode(index)
         try writeAtomically(data, to: indexURL, tmpURL: tmpURL)
     }
 

--- a/app-cross/Sources/CommonLibraryCore/Strategy/GitHubConfigStrategy.swift
+++ b/app-cross/Sources/CommonLibraryCore/Strategy/GitHubConfigStrategy.swift
@@ -47,7 +47,7 @@ public final class GitHubConfigStrategy: ConfigManagerStrategy {
         let targetURL = isBeta ? betaURL : url
         pspLog(.core, .info, "Config (GitHub): fetching bundle from \(targetURL)")
         let data = try await fetcher(targetURL)
-        let json = try JSONDecoder().decode(ConfigBundle.self, from: data)
+        let json = try ABI.decode(ConfigBundle.self, from: data)
         lastUpdated = Date()
         return json
     }

--- a/app-cross/Sources/CommonLibraryCore/Strategy/GitHubReleaseStrategy.swift
+++ b/app-cross/Sources/CommonLibraryCore/Strategy/GitHubReleaseStrategy.swift
@@ -31,7 +31,7 @@ public final class GitHubReleaseStrategy: VersionCheckerStrategy {
             }
         }
         let data = try await fetcher(releaseURL)
-        let json = try JSONDecoder().decode(VersionJSON.self, from: data)
+        let json = try ABI.decode(VersionJSON.self, from: data)
         let newVersion = json.name
         guard let semNew = ABI.SemanticVersion(newVersion) else {
             pspLog(.core, .error, "Version (GitHub): unparsable release name '\(newVersion)'")

--- a/app-cross/Tests/CommonLibraryTests/Business/KeyValueStoreTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/KeyValueStoreTests.swift
@@ -36,7 +36,7 @@ struct KeyValueStoreTests {
         sut.preferences.configFlags = flags
         #expect(sut.preferences.configFlags == flags)
 
-        let flagsData = try JSONEncoder().encode(flags)
+        let flagsData = try ABI.encode(flags)
         #expect(sut.preferences.configFlagsData == flagsData)
     }
 }

--- a/app-cross/Tests/CommonLibraryTests/Domain/AppPreferenceTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Domain/AppPreferenceTests.swift
@@ -15,8 +15,8 @@ struct AppPreferenceTests {
 
         let configFlagsData = try #require(sut.configFlagsData)
         let experimentalData = try #require(sut.experimentalData)
-        let configFlags = try JSONDecoder().decode(Set<ABI.ConfigFlag>.self, from: configFlagsData)
-        let experimental = try JSONDecoder().decode(ABI.AppPreferenceValues.Experimental.self, from: experimentalData)
+        let configFlags = try ABI.decode(Set<ABI.ConfigFlag>.self, from: configFlagsData)
+        let experimental = try ABI.decode(ABI.AppPreferenceValues.Experimental.self, from: experimentalData)
         #expect(configFlags == sut.configFlags)
         #expect(experimental == sut.experimental)
     }
@@ -50,7 +50,7 @@ struct AppPreferenceTests {
     @Test
     func givenExperimental_whenDecodeWithoutEnabledFlags_thenUsesEmptySet() throws {
         let data = #"{"ignoredConfigFlags":["bsdSockets"]}"#.data(using: .utf8)!
-        let sut = try JSONDecoder().decode(ABI.AppPreferenceValues.Experimental.self, from: data)
+        let sut = try ABI.decode(ABI.AppPreferenceValues.Experimental.self, from: data)
         #expect(sut.ignoredConfigFlags == [.bsdSockets])
         #expect(sut.enabledConfigFlags.isEmpty)
     }

--- a/app-cross/passepartout_shared.cmake
+++ b/app-cross/passepartout_shared.cmake
@@ -165,6 +165,7 @@ Sources/CommonLibraryCore/Domain/StoreProductHint.swift
 Sources/CommonLibraryCore/Domain/StoreReceipt.swift
 Sources/CommonLibraryCore/Domain/StoreResult.swift
 Sources/CommonLibraryCore/Domain/VersionRelease.swift
+Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
 Sources/CommonLibraryCore/Extensions/ChangelogEntry+Extensions.swift
 Sources/CommonLibraryCore/Extensions/CodingRegistry+Extensions.swift
 Sources/CommonLibraryCore/Extensions/KeyValueStore+AppPreference.swift


### PR DESCRIPTION
Both for a single creation point and because dates should consistently be ISO8601 on non-Apple systems.

No JSONEncoder() or JSONDecoder(), just ABI.encode and ABI.decode