### PR TITLE
ABI: Encode dates as UNIX milliseconds

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/models/OriginalPurchase.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/models/OriginalPurchase.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.Contextual
  * 
  *
  * @param buildNumber 
- * @param purchaseDate ISO8601 timestamp string.
+ * @param purchaseDate 64-bit millis since UNIX epoch.
  */
 @Serializable
 
@@ -33,9 +33,9 @@ data class OriginalPurchase (
     @SerialName(value = "buildNumber")
     val buildNumber: kotlin.Int,
 
-    /* ISO8601 timestamp string. */
+    /* 64-bit millis since UNIX epoch. */
     @SerialName(value = "purchaseDate")
-    val purchaseDate: kotlin.String
+    val purchaseDate: kotlin.Long
 
 ) {
 

--- a/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIOriginalPurchase.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIOriginalPurchase.swift
@@ -10,10 +10,10 @@ import Partout
 public struct OpenAPIOriginalPurchase: Sendable, Codable, Hashable {
 
     public var buildNumber: Int
-    /** ISO8601 timestamp string. */
-    public var purchaseDate: String
+    /** 64-bit millis since UNIX epoch. */
+    public var purchaseDate: Int64
 
-    public init(buildNumber: Int, purchaseDate: String) {
+    public init(buildNumber: Int, purchaseDate: Int64) {
         self.buildNumber = buildNumber
         self.purchaseDate = purchaseDate
     }

--- a/app-cross/Sources/CommonLibraryCore/Domain/Extensions/Mappers.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Extensions/Mappers.swift
@@ -49,7 +49,7 @@ extension ABI.OriginalPurchase: OpenAPIEncodable {
     var toProto: OpenAPIOriginalPurchase {
         OpenAPIOriginalPurchase(
             buildNumber: buildNumber,
-            purchaseDate: purchaseDate.formatted(.iso8601)
+            purchaseDate: purchaseDate.timestamp
         )
     }
 }

--- a/app-cross/Sources/CommonLibraryCore/Domain/Issue.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Issue.swift
@@ -14,7 +14,7 @@ extension ABI {
 
         public let purchasedProducts: Set<ABI.AppProduct>
 
-        public let providerLastUpdates: [ProviderID: UInt32]
+        public let providerLastUpdates: [ProviderID: Timestamp]
 
         public let appLog: Data?
 
@@ -28,7 +28,7 @@ extension ABI {
             comment: String,
             appLine: String?,
             purchasedProducts: Set<ABI.AppProduct>,
-            providerLastUpdates: [ProviderID: UInt32] = [:],
+            providerLastUpdates: [ProviderID: Timestamp] = [:],
             appLog: Data? = nil,
             tunnelLog: Data? = nil
         ) {

--- a/app-cross/Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
+++ b/app-cross/Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
@@ -5,27 +5,11 @@
 import Partout
 
 extension ABI {
-    private static let encoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-#if PSP_CROSS
-        encoder.dateEncodingStrategy = .iso8601
-#endif
-        return encoder
-    }()
-
-    private static let decoder: JSONDecoder = {
-        let decoder = JSONDecoder()
-#if PSP_CROSS
-        decoder.dateDecodingStrategy = .iso8601
-#endif
-        return decoder
-    }()
-
     public static func encode<T>(_ value: T) throws -> Data where T: Encodable {
-        try encoder.encode(value)
+        try JSONEncoder.new().encode(value)
     }
 
     public static func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
-        try decoder.decode(type, from: data)
+        try JSONDecoder.new().decode(type, from: data)
     }
 }

--- a/app-cross/Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
+++ b/app-cross/Sources/CommonLibraryCore/Extensions/ABI+JSON.swift
@@ -6,10 +6,10 @@ import Partout
 
 extension ABI {
     public static func encode<T>(_ value: T) throws -> Data where T: Encodable {
-        try JSONEncoder.new().encode(value)
+        try JSONEncoder.shared().encode(value)
     }
 
     public static func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
-        try JSONDecoder.new().decode(type, from: data)
+        try JSONDecoder.shared().decode(type, from: data)
     }
 }

--- a/app-cross/Sources/CommonProviders/API/DefaultAPIMapper.swift
+++ b/app-cross/Sources/CommonProviders/API/DefaultAPIMapper.swift
@@ -28,7 +28,7 @@ public final class DefaultAPIMapper: APIMapper {
 
     public func index() async throws -> [Provider] {
         let data = try await data(for: .index)
-        let json = try JSONDecoder().decode(API.REST.Index.self, from: data)
+        let json = try JSONDecoder.new().decode(API.REST.Index.self, from: data)
 
         return json
             .providers
@@ -132,7 +132,7 @@ extension ScriptingEngine {
                 } else if let value = $0 as? Bool {
                     return value.description
                 } else if let value = $0 as? Encodable {
-                    let encoded = try JSONEncoder().encode(value)
+                    let encoded = try JSONEncoder.new().encode(value)
                     guard let json = String(data: encoded, encoding: .utf8) else {
                         throw PartoutError(.encoding)
                     }

--- a/app-cross/Sources/CommonProviders/API/DefaultAPIMapper.swift
+++ b/app-cross/Sources/CommonProviders/API/DefaultAPIMapper.swift
@@ -28,7 +28,7 @@ public final class DefaultAPIMapper: APIMapper {
 
     public func index() async throws -> [Provider] {
         let data = try await data(for: .index)
-        let json = try JSONDecoder.new().decode(API.REST.Index.self, from: data)
+        let json = try JSONDecoder.shared().decode(API.REST.Index.self, from: data)
 
         return json
             .providers
@@ -132,7 +132,7 @@ extension ScriptingEngine {
                 } else if let value = $0 as? Bool {
                     return value.description
                 } else if let value = $0 as? Encodable {
-                    let encoded = try JSONEncoder.new().encode(value)
+                    let encoded = try JSONEncoder.shared().encode(value)
                     guard let json = String(data: encoded, encoding: .utf8) else {
                         throw PartoutError(.encoding)
                     }

--- a/app-cross/Sources/CommonProviders/API/DefaultProviderScriptingAPI.swift
+++ b/app-cross/Sources/CommonProviders/API/DefaultProviderScriptingAPI.swift
@@ -101,12 +101,15 @@ extension DefaultProviderScriptingAPI: ProviderScriptingAPI {
         }
     }
 
-    public func timestampFromISO(isoString: String) -> Int {
-        Int(ISO8601DateFormatter().date(from: isoString)?.timeIntervalSinceReferenceDate ?? 0)
+    public func timestampFromISO(isoString: String) -> Int64 {
+        guard let date = ISO8601DateFormatter().date(from: isoString) else { return 0 }
+        return Int64(date.timeIntervalSince1970 * 1000)
     }
 
-    public func timestampToISO(timestamp: Int) -> String {
-        ISO8601DateFormatter().string(from: Date(timeIntervalSinceReferenceDate: TimeInterval(timestamp)))
+    public func timestampToISO(timestamp: Int64) -> String {
+        let seconds = TimeInterval(timestamp / 1000)
+        let date = Date(timeIntervalSince1970: seconds)
+        return ISO8601DateFormatter().string(from: date)
     }
 
     public func ipV4ToBase64(ip: String) -> String? {

--- a/app-cross/Sources/CommonProviders/Providers/ProviderScriptingEngine+Apple.swift
+++ b/app-cross/Sources/CommonProviders/Providers/ProviderScriptingEngine+Apple.swift
@@ -14,8 +14,8 @@ extension AppleJavaScriptEngine: ProviderScriptingEngine {
         func getJSON(_ urlString: String, _ headers: [String: String]?) -> [String: Any]
         func jsonFromBase64(_ string: String) -> Any?
         func jsonToBase64(_ object: Any) -> String?
-        func timestampFromISO(_ isoString: String) -> Int
-        func timestampToISO(_ timestamp: Int) -> String
+        func timestampFromISO(_ isoString: String) -> Int64
+        func timestampToISO(_ timestamp: Int64) -> String
         func ipV4ToBase64(_ ip: String) -> String?
         func openVPNTLSWrap(_ strategy: String, _ file: String) -> [String: Any]?
         func errorResponse(_ message: String) -> [String: Any]
@@ -67,11 +67,11 @@ extension AppleJavaScriptEngine: ProviderScriptingEngine {
             vm.jsonToBase64(object: object)
         }
 
-        func timestampFromISO(_ isoString: String) -> Int {
+        func timestampFromISO(_ isoString: String) -> Int64 {
             vm.timestampFromISO(isoString: isoString)
         }
 
-        func timestampToISO(_ timestamp: Int) -> String {
+        func timestampToISO(_ timestamp: Int64) -> String {
             vm.timestampToISO(timestamp: timestamp)
         }
 

--- a/app-cross/Sources/CommonProvidersCore/ProviderModule.swift
+++ b/app-cross/Sources/CommonProvidersCore/ProviderModule.swift
@@ -136,7 +136,7 @@ extension ProviderModule {
         }
 
         public mutating func setOptions<O>(_ options: O, for moduleType: ModuleType) throws where O: ProviderOptions {
-            let encoded = try JSONEncoder().encode(options)
+            let encoded = try JSONEncoder.new().encode(options)
             if moduleOptions == nil {
                 moduleOptions = CodableOptions(map: [moduleType: encoded])
             } else {

--- a/app-cross/Sources/CommonProvidersCore/ProviderModule.swift
+++ b/app-cross/Sources/CommonProvidersCore/ProviderModule.swift
@@ -136,7 +136,7 @@ extension ProviderModule {
         }
 
         public mutating func setOptions<O>(_ options: O, for moduleType: ModuleType) throws where O: ProviderOptions {
-            let encoded = try JSONEncoder.new().encode(options)
+            let encoded = try JSONEncoder.shared().encode(options)
             if moduleOptions == nil {
                 moduleOptions = CodableOptions(map: [moduleType: encoded])
             } else {

--- a/app-cross/Sources/CommonProvidersCore/ProviderPreset.swift
+++ b/app-cross/Sources/CommonProvidersCore/ProviderPreset.swift
@@ -47,6 +47,6 @@ extension ProviderPreset {
 
 extension ProviderPreset {
     public func template<Template>(ofType type: Template.Type) throws -> Template where Template: Decodable {
-        try JSONDecoder.new().decode(type, from: templateData)
+        try JSONDecoder.shared().decode(type, from: templateData)
     }
 }

--- a/app-cross/Sources/CommonProvidersCore/ProviderPreset.swift
+++ b/app-cross/Sources/CommonProvidersCore/ProviderPreset.swift
@@ -47,6 +47,6 @@ extension ProviderPreset {
 
 extension ProviderPreset {
     public func template<Template>(ofType type: Template.Type) throws -> Template where Template: Decodable {
-        try JSONDecoder().decode(type, from: templateData)
+        try JSONDecoder.new().decode(type, from: templateData)
     }
 }

--- a/app-cross/Sources/CommonProvidersCore/ProviderScriptingAPI.swift
+++ b/app-cross/Sources/CommonProvidersCore/ProviderScriptingAPI.swift
@@ -20,9 +20,9 @@ public protocol ProviderScriptingAPI: Sendable {
 
     func jsonToBase64(object: Any) -> String?
 
-    func timestampFromISO(isoString: String) -> Int
+    func timestampFromISO(isoString: String) -> Int64
 
-    func timestampToISO(timestamp: Int) -> String
+    func timestampToISO(timestamp: Int64) -> String
 
     func ipV4ToBase64(ip: String) -> String?
 

--- a/app-cross/Sources/CommonProvidersCore/Timestamp+Date.swift
+++ b/app-cross/Sources/CommonProvidersCore/Timestamp+Date.swift
@@ -4,22 +4,21 @@
 
 import Partout
 
-public typealias Timestamp = UInt32
+public typealias Timestamp = Int64
 
-// seconds since the epoch
+// Milliseconds since the epoch
 extension Timestamp {
     public var date: Date {
-        Date(timeIntervalSince1970: TimeInterval(self))
+        Date(timeIntervalSince1970: TimeInterval(self) / 1000.0)
     }
 
-    // this can be easily done without Foundation
     public static func now() -> Self {
-        Timestamp(Date().timeIntervalSince1970)
+        Timestamp(Date().timeIntervalSince1970 * 1000.0)
     }
 }
 
 extension Date {
     public var timestamp: Timestamp {
-        Timestamp(timeIntervalSince1970)
+        Timestamp(timeIntervalSince1970 * 1000.0)
     }
 }

--- a/app-cross/Tests/CommonProvidersTests/API/HideMeProviderTests.swift
+++ b/app-cross/Tests/CommonProvidersTests/API/HideMeProviderTests.swift
@@ -46,7 +46,7 @@ struct HideMeProviderTests: APITestSuite {
             #expect(infra.servers.count == input.serversCount)
 
             try infra.presets.forEach {
-                let template = try JSONDecoder().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
+                let template = try JSONDecoder.new().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
                 switch $0.presetId {
                 case "default":
                     #expect(template.configuration.cipher == .aes256cbc)

--- a/app-cross/Tests/CommonProvidersTests/API/HideMeProviderTests.swift
+++ b/app-cross/Tests/CommonProvidersTests/API/HideMeProviderTests.swift
@@ -46,7 +46,7 @@ struct HideMeProviderTests: APITestSuite {
             #expect(infra.servers.count == input.serversCount)
 
             try infra.presets.forEach {
-                let template = try JSONDecoder.new().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
+                let template = try JSONDecoder.shared().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
                 switch $0.presetId {
                 case "default":
                     #expect(template.configuration.cipher == .aes256cbc)

--- a/app-cross/Tests/CommonProvidersTests/API/MullvadProviderTests.swift
+++ b/app-cross/Tests/CommonProvidersTests/API/MullvadProviderTests.swift
@@ -34,7 +34,7 @@ struct MullvadProviderTests: APITestSuite {
             try infra.presets.forEach {
                 switch $0.moduleType {
                 case .OpenVPN:
-                    let template = try JSONDecoder().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
+                    let template = try JSONDecoder.new().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
                     switch $0.presetId {
                     case "default":
                         #expect(template.configuration.cipher == .aes256cbc)
@@ -52,7 +52,7 @@ struct MullvadProviderTests: APITestSuite {
                         break
                     }
                 case .WireGuard:
-                    let template = try JSONDecoder().decode(WireGuardProviderTemplate.self, from: $0.templateData)
+                    let template = try JSONDecoder.new().decode(WireGuardProviderTemplate.self, from: $0.templateData)
                     switch $0.presetId {
                     case "default":
                         #expect(template.ports == [51820])

--- a/app-cross/Tests/CommonProvidersTests/API/MullvadProviderTests.swift
+++ b/app-cross/Tests/CommonProvidersTests/API/MullvadProviderTests.swift
@@ -34,7 +34,7 @@ struct MullvadProviderTests: APITestSuite {
             try infra.presets.forEach {
                 switch $0.moduleType {
                 case .OpenVPN:
-                    let template = try JSONDecoder.new().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
+                    let template = try JSONDecoder.shared().decode(OpenVPNProviderTemplate.self, from: $0.templateData)
                     switch $0.presetId {
                     case "default":
                         #expect(template.configuration.cipher == .aes256cbc)
@@ -52,7 +52,7 @@ struct MullvadProviderTests: APITestSuite {
                         break
                     }
                 case .WireGuard:
-                    let template = try JSONDecoder.new().decode(WireGuardProviderTemplate.self, from: $0.templateData)
+                    let template = try JSONDecoder.shared().decode(WireGuardProviderTemplate.self, from: $0.templateData)
                     switch $0.presetId {
                     case "default":
                         #expect(template.ports == [51820])

--- a/app-cross/Tests/CommonProvidersTests/ProviderScriptingAPITests.swift
+++ b/app-cross/Tests/CommonProvidersTests/ProviderScriptingAPITests.swift
@@ -32,8 +32,8 @@ struct ProviderScriptingAPITests {
     }
 
     @Test(arguments: [
-        (1752562800, "Tue, 15 Jul 2025 07:00:00 GMT"),
-        (1698907632, "Thu, 02 Nov 2023 06:47:12 GMT")
+        (1752562800 * 1000, "Tue, 15 Jul 2025 07:00:00 GMT"),
+        (1698907632 * 1000, "Thu, 02 Nov 2023 06:47:12 GMT")
     ])
     func givenTimestamp_whenGetRFC1123_thenIsExpected(timestamp: Timestamp, rfc: String) {
         #expect(timestamp.toRFC1123() == rfc)

--- a/app-cross/Tests/CommonProvidersTests/ProviderScriptingAPITests.swift
+++ b/app-cross/Tests/CommonProvidersTests/ProviderScriptingAPITests.swift
@@ -48,7 +48,7 @@ struct ProviderScriptingAPITests {
 
         let object = try #require(sut.serialized()["cache"])
         let data = try JSONSerialization.data(withJSONObject: object)
-        let cache = try JSONDecoder().decode(ProviderCache.self, from: data)
+        let cache = try JSONDecoder.new().decode(ProviderCache.self, from: data)
 
         #expect(cache.lastUpdate == date)
         #expect(cache.tag == tag)

--- a/app-cross/Tests/CommonProvidersTests/ProviderScriptingAPITests.swift
+++ b/app-cross/Tests/CommonProvidersTests/ProviderScriptingAPITests.swift
@@ -48,7 +48,7 @@ struct ProviderScriptingAPITests {
 
         let object = try #require(sut.serialized()["cache"])
         let data = try JSONSerialization.data(withJSONObject: object)
-        let cache = try JSONDecoder.new().decode(ProviderCache.self, from: data)
+        let cache = try JSONDecoder.shared().decode(ProviderCache.self, from: data)
 
         #expect(cache.lastUpdate == date)
         #expect(cache.tag == tag)

--- a/app-cross/abi.yaml
+++ b/app-cross/abi.yaml
@@ -754,8 +754,9 @@ components:
     TaggedProfile:
       type: object
     Timestamp:
-      description: ISO8601 timestamp string.
-      type: string
+      description: 64-bit millis since UNIX epoch.
+      type: integer
+      format: int64
     TunnelEventRefresh:
       type: object
       additionalProperties: false


### PR DESCRIPTION
Reuse Partout JSONEncoder/JSONDecoder in both ABI and CommonProviders. Might softly break serialized providers' `lastUpdate`, but profiles are unaffected. ABI only uses `Date` in `OriginalPurchase.purchaseDate`. Make providers `Timestamp` consistent with Partout encoding.

See https://github.com/partout-io/partout/pull/390