### PR TITLE
Android: Centralize app objects in AppContext

### DIFF
--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_21
     }
     lint {
-        checkReleaseBuilds = false
+//        checkReleaseBuilds = false
         abortOnError = false
     }
     buildTypes {

--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
             </intent-filter>
         </activity>
         <service
-            android:name=".PassepartoutVpnService"
+            android:name=".tunnel.PassepartoutVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:exported="false"
             android:foregroundServiceType="specialUse">

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
@@ -11,6 +11,8 @@ object Globals {
     val json = Json {
         ignoreUnknownKeys = true
     }
+
+    const val logTag = "Passepartout"
 }
 
 fun Context.readAsset(name: String): String {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
@@ -4,8 +4,13 @@
 
 package com.algoritmico.passepartout
 
+import android.content.Context
 import kotlinx.serialization.json.Json
 
 val globalJsonCoder = Json {
     ignoreUnknownKeys = true
+}
+
+fun Context.readAsset(name: String): String {
+    return assets.open(name).bufferedReader().use { it.readText() }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
@@ -7,8 +7,10 @@ package com.algoritmico.passepartout
 import android.content.Context
 import kotlinx.serialization.json.Json
 
-val globalJsonCoder = Json {
-    ignoreUnknownKeys = true
+object Globals {
+    val json = Json {
+        ignoreUnknownKeys = true
+    }
 }
 
 fun Context.readAsset(name: String): String {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
@@ -13,6 +13,10 @@ object Globals {
     }
 
     const val logTag = "Passepartout"
+
+    const val EVENT_BUFFER_CAPACITY = 64
+
+    const val EVENT_REPLAY = 64
 }
 
 fun Context.readAsset(name: String): String {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -7,7 +7,6 @@ package com.algoritmico.passepartout
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
-import android.provider.Settings
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -56,14 +55,6 @@ class MainActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    private val vpnPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (::appContext.isInitialized) {
-            appContext.onVpnPermissionResult(result.resultCode == RESULT_OK)
-        }
-    }
-
     private fun openProfileImporter() {
         profileImportLauncher.launch(PROFILE_MIME_TYPES)
     }
@@ -88,14 +79,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private val profileImportLauncher = registerForActivityResult(
-        ActivityResultContracts.OpenDocument()
-    ) { uri ->
-        if (uri != null) {
-            importProfile(uri)
-        }
-    }
-
     private fun displayName(uri: Uri): String? {
         return contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
             ?.use { cursor ->
@@ -109,6 +92,22 @@ class MainActivity : ComponentActivity() {
                     null
                 }
             }
+    }
+
+    private val vpnPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (::appContext.isInitialized) {
+            appContext.onVpnPermissionResult(result.resultCode == RESULT_OK)
+        }
+    }
+
+    private val profileImportLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            importProfile(uri)
+        }
     }
 
     private companion object {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -7,6 +7,7 @@ package com.algoritmico.passepartout
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.provider.Settings
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -71,7 +72,7 @@ class MainActivity : ComponentActivity() {
         val profileText = try {
             contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
         } catch (e: Exception) {
-            Log.e("Passepartout", "Unable to read profile file: $uri", e)
+            Log.e(Globals.logTag, "Unable to read profile file: $uri", e)
             null
         } ?: return
 
@@ -82,7 +83,7 @@ class MainActivity : ComponentActivity() {
             }.onSuccess {
                 appContext.onApplicationActive()
             }.onFailure {
-                Log.e("Passepartout", "Import failure: $profileName", it)
+                Log.e(Globals.logTag, "Import failure: $profileName", it)
             }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -12,125 +12,55 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
-import com.algoritmico.passepartout.abi.AppABIProfile
-import com.algoritmico.passepartout.abi.AppABITunnel
-import com.algoritmico.passepartout.abi.PassepartoutWrapper
-import com.algoritmico.passepartout.abi.helpers.ABIEventDispatcher
-import com.algoritmico.passepartout.abi.models.Event
+import com.algoritmico.passepartout.tunnel.PassepartoutVpnService
+import com.algoritmico.passepartout.ui.AppContext
 import com.algoritmico.passepartout.ui.PassepartoutApp
-import com.algoritmico.passepartout.ui.ProfileObservable
-import com.algoritmico.passepartout.ui.TunnelObservable
-import io.partout.jni.PartoutTunnel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import java.io.Closeable
-import java.io.File
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
-    private val library = PassepartoutWrapper()
-
-    private val appEvents = MutableSharedFlow<Event>(
-        replay = APP_EVENT_REPLAY,
-        extraBufferCapacity = APP_EVENT_BUFFER_CAPACITY
-    )
-
-    private lateinit var profilesDirectory: File
-
-    private lateinit var profileObservable: ProfileObservable
-
-    private lateinit var tunnelObservable: TunnelObservable
-
-    private lateinit var tunnel: PartoutTunnel
-
-    private var eventSubscription: Closeable? = null
-
-    private var isAppInitialized = false
+    private lateinit var appContext: AppContext
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val version = library.partoutVersion()
-        Log.i("Passepartout", ">>> $version")
-
-        val bundle = assets.open("bundle.json").bufferedReader().use { it.readText() }
-        val constants = assets.open("constants.json").bufferedReader().use { it.readText() }
-        profilesDirectory = File(noBackupFilesDir, "profiles-v1").apply {
-            mkdirs()
-        }
-        profileObservable = ProfileObservable(
-            events = appEvents,
-            abi = AppABIProfile(library),
-            coroutineScope = lifecycleScope
-        )
-        tunnelObservable = TunnelObservable(
-            events = appEvents,
-            abi = AppABITunnel(library),
-            coroutineScope = lifecycleScope
-        )
-        tunnel = PartoutTunnel(
+        appContext = AppContext(
             this,
-            PassepartoutVpnService::class.java,
+            lifecycleScope,
             PassepartoutVpnService.channel,
             requestVpnPermission = { permissionIntent ->
                 vpnPermissionLauncher.launch(permissionIntent)
-            },
-            lifecycleScope
+            }
         )
-
-        eventSubscription = ABIEventDispatcher.register(::handleEvent)
-        val appInitCode = library.appInit(
-            bundle,
-            constants,
-            profilesDirectory.absolutePath,
-            cacheDir.absolutePath,
-            tunnel,
-            ABIEventDispatcher
-        )
-        if (appInitCode == 0) {
-            isAppInitialized = true
-            Log.e("Passepartout", ">>> Started app")
-        } else {
-            Log.e("Passepartout", "Unable to init app (code=$appInitCode)")
-            destroyApp()
-        }
 
         setContent {
             PassepartoutApp(
-                profileObservable = profileObservable,
-                tunnelObservable = tunnelObservable,
-                onImportProfile = ::openProfileImporter,
-                onProfilesDelete = ::onProfilesDelete
+                appContext.profileObservable,
+                appContext.tunnelObservable,
+                onImportProfile = ::openProfileImporter
             )
         }
     }
 
     override fun onStart() {
         super.onStart()
-        library.appOnForeground()
+        if (::appContext.isInitialized) {
+            appContext.onApplicationActive()
+        }
     }
 
     override fun onDestroy() {
-        eventSubscription?.close()
-        eventSubscription = null
-        profileObservable.close()
-        tunnelObservable.close()
-        if (isAppInitialized) {
-            library.appDeinit { _, _ -> }
+        if (::appContext.isInitialized) {
+            appContext.close()
         }
         super.onDestroy()
     }
 
-    private fun destroyApp() {
-        if (isFinishing || isDestroyed) return
-        finishAndRemoveTask()
-    }
-
-    private fun handleEvent(event: Event) {
-        Log.i("Passepartout", ">>> MainActivity: $event")
-        appEvents.tryEmit(event)
-    }
-
-    private fun onProfilesDelete(profileIds: Array<String>): Unit {
-        library.appDeleteProfiles(profileIds, { _, _ -> })
+    private val vpnPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (::appContext.isInitialized) {
+            appContext.onVpnPermissionResult(result.resultCode == RESULT_OK)
+        }
     }
 
     private fun openProfileImporter() {
@@ -146,13 +76,13 @@ class MainActivity : ComponentActivity() {
         } ?: return
 
         val profileName = displayName(uri) ?: "Imported profile"
-        library.appImportProfileText(profileText, profileName) { code, json ->
-            runOnUiThread {
-                if (code == 0) {
-                    library.appOnForeground()
-                } else {
-                    Log.e("Passepartout", "Import failure (code=$code): $json")
-                }
+        lifecycleScope.launch {
+            runCatching {
+                appContext.profileObservable.importText(profileText, profileName)
+            }.onSuccess {
+                appContext.onApplicationActive()
+            }.onFailure {
+                Log.e("Passepartout", "Import failure: $profileName", it)
             }
         }
     }
@@ -163,28 +93,6 @@ class MainActivity : ComponentActivity() {
         if (uri != null) {
             importProfile(uri)
         }
-    }
-
-    private val vpnPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        tunnel.onVpnPermissionResult(result.resultCode == RESULT_OK)
-    }
-
-    private companion object {
-        const val APP_EVENT_BUFFER_CAPACITY = 64
-
-        const val APP_EVENT_REPLAY = 64
-
-        const val OBJECTS_DIR = "objects"
-
-        val PROFILE_MIME_TYPES = arrayOf(
-            "application/x-openvpn-profile",
-            "application/x-wireguard-profile",
-            "application/octet-stream",
-            "text/*",
-            "*/*"
-        )
     }
 
     private fun displayName(uri: Uri): String? {
@@ -202,4 +110,13 @@ class MainActivity : ComponentActivity() {
             }
     }
 
+    private companion object {
+        val PROFILE_MIME_TYPES = arrayOf(
+            "application/x-openvpn-profile",
+            "application/x-wireguard-profile",
+            "application/octet-stream",
+            "text/*",
+            "*/*"
+        )
+    }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/AppABI.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/AppABI.kt
@@ -4,8 +4,8 @@
 
 package com.algoritmico.passepartout.abi
 
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.helpers.ABIResult
-import com.algoritmico.passepartout.globalJsonCoder
 import io.partout.abi.TaggedProfile
 
 internal class AppABIProfile(
@@ -34,7 +34,7 @@ internal class AppABIProfile(
             library.appFetchProfile(profileId, completion)
         }
         return result.payload?.let { json ->
-            globalJsonCoder.decodeFromString(json)
+            Globals.json.decodeFromString(json)
         }
     }
 }
@@ -43,7 +43,7 @@ internal class AppABITunnel(
     private val library: PassepartoutWrapper
 ) : AppABITunnelProtocol {
     override suspend fun connect(profile: TaggedProfile) {
-        val profileJSON = globalJsonCoder.encodeToString(profile)
+        val profileJSON = Globals.json.encodeToString(profile)
         ABIResult.await { completion ->
             library.appConnect(profileJSON, completion)
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
@@ -5,6 +5,7 @@
 package com.algoritmico.passepartout.abi
 
 import android.util.Log
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.helpers.ABICompletionCallback
 import com.algoritmico.passepartout.abi.helpers.ABIEventHandler
 import io.partout.abi.TunnelSnapshot
@@ -65,7 +66,7 @@ class PassepartoutWrapper {
                 // Name of the NDK .so without "lib" prefix or ".so"
                 System.loadLibrary("passepartout_wrapper")
             } catch (e: Exception) {
-                Log.e("Passepartout", e.localizedMessage ?: "")
+                Log.e(Globals.logTag, e.localizedMessage ?: "")
             }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/helpers/ABIEventDispatcher.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/helpers/ABIEventDispatcher.kt
@@ -42,7 +42,7 @@ object ABIEventDispatcher: ABIEventHandler {
             runCatching {
                 listener(event)
             }.onFailure {
-                Log.e("Passepartout", "Unable to dispatch ABI callback", it)
+                Log.e(Globals.logTag, "Unable to dispatch ABI callback", it)
             }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/helpers/ABIEventDispatcher.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/helpers/ABIEventDispatcher.kt
@@ -7,8 +7,9 @@ package com.algoritmico.passepartout.abi.helpers
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.models.Event
-import com.algoritmico.passepartout.globalJsonCoder
+import com.algoritmico.passepartout.Globals.json
 import java.io.Closeable
 import java.util.concurrent.CopyOnWriteArraySet
 
@@ -36,7 +37,7 @@ object ABIEventDispatcher: ABIEventHandler {
     }
 
     private fun dispatchOnMain(json: String) {
-        val event: Event = globalJsonCoder.decodeFromString(json)
+        val event: Event = Globals.json.decodeFromString(json)
         listeners.forEach { listener ->
             runCatching {
                 listener(event)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/tunnel/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/tunnel/PassepartoutVpnService.kt
@@ -125,12 +125,12 @@ class PassepartoutVpnService: VpnService() {
     companion object {
         val channel = PartoutVpnServiceRuntime.Channel()
 
-        private const val NOTIFICATION_ID = 1
-
-        private const val NOTIFICATION_CHANNEL_ID = "vpn_service_channel"
-
         private const val BUNDLE_FILENAME = "bundle.json"
 
         private const val CONSTANTS_FILENAME = "constants.json"
+
+        private const val NOTIFICATION_ID = 1
+
+        private const val NOTIFICATION_CHANNEL_ID = "vpn_service_channel"
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/tunnel/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/tunnel/PassepartoutVpnService.kt
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-package com.algoritmico.passepartout
+package com.algoritmico.passepartout.tunnel
 
 import android.app.Notification
 import android.content.Intent
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.algoritmico.passepartout.abi.PassepartoutWrapper
+import com.algoritmico.passepartout.readAsset
 import io.partout.jni.PartoutVpnServiceRuntime
 import io.partout.jni.PartoutVpnServiceRuntime.Engine
 import io.partout.jni.PartoutVpnServiceRuntime.Result
@@ -24,13 +25,13 @@ class PassepartoutVpnService: VpnService() {
             logTag = "Passepartout",
             service = this,
             channel = channel,
-            engine = PassepartoutVpnEngine(
+            engine = VpnEngine(
                 library = PassepartoutWrapper(),
                 bundleProvider = {
-                    readAsset("bundle.json")
+                    readAsset(BUNDLE_FILENAME)
                 },
                 constantsProvider = {
-                    readAsset("constants.json")
+                    readAsset(CONSTANTS_FILENAME)
                 },
                 cachePathProvider = {
                     cacheDir.absolutePath
@@ -66,7 +67,7 @@ class PassepartoutVpnService: VpnService() {
     }
 
     private fun createNotification(): Notification {
-        val channelId = "vpn_service_channel"
+        val channelId = NOTIFICATION_CHANNEL_ID
 
         // Create a notification channel (required on Android 8.0+)
         val channel = NotificationChannelCompat.Builder(
@@ -89,44 +90,46 @@ class PassepartoutVpnService: VpnService() {
             .build()
     }
 
-    private suspend fun readAsset(name: String): String = withContext(Dispatchers.IO) {
-        assets.open(name).bufferedReader().use { it.readText() }
+    private class VpnEngine(
+        private val library: PassepartoutWrapper,
+        private val bundleProvider: suspend () -> String,
+        private val constantsProvider: suspend () -> String,
+        private val cachePathProvider: () -> String
+    ) : Engine {
+        override suspend fun start(
+            runtime: PartoutVpnServiceRuntime,
+            profileJSON: String
+        ): Result = withContext(Dispatchers.IO) {
+            Result(
+                library.tunnelStart(
+                    bundleProvider(),
+                    constantsProvider(),
+                    profileJSON,
+                    cachePathProvider(),
+                    runtime
+                ),
+                null
+            )
+        }
+
+        override suspend fun stop(): Result = withContext(Dispatchers.IO) {
+            val result = CompletableDeferred<Result>()
+            library.tunnelStop { code, json ->
+                result.complete(Result(code, json))
+            }
+            result.await()
+        }
     }
 
     companion object {
+        val channel = PartoutVpnServiceRuntime.Channel()
+
         private const val NOTIFICATION_ID = 1
 
-        val channel = PartoutVpnServiceRuntime.Channel()
-    }
-}
+        private const val NOTIFICATION_CHANNEL_ID = "vpn_service_channel"
 
-private class PassepartoutVpnEngine(
-    private val library: PassepartoutWrapper,
-    private val bundleProvider: suspend () -> String,
-    private val constantsProvider: suspend () -> String,
-    private val cachePathProvider: () -> String
-) : Engine {
-    override suspend fun start(
-        runtime: PartoutVpnServiceRuntime,
-        profileJSON: String
-    ): Result = withContext(Dispatchers.IO) {
-        Result(
-            library.tunnelStart(
-                bundleProvider(),
-                constantsProvider(),
-                profileJSON,
-                cachePathProvider(),
-                runtime
-            ),
-            null
-        )
-    }
+        private const val BUNDLE_FILENAME = "bundle.json"
 
-    override suspend fun stop(): Result = withContext(Dispatchers.IO) {
-        val result = CompletableDeferred<Result>()
-        library.tunnelStop { code, json ->
-            result.complete(Result(code, json))
-        }
-        result.await()
+        private const val CONSTANTS_FILENAME = "constants.json"
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/tunnel/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/tunnel/PassepartoutVpnService.kt
@@ -10,6 +10,7 @@ import android.net.VpnService
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.PassepartoutWrapper
 import com.algoritmico.passepartout.readAsset
 import io.partout.jni.PartoutVpnServiceRuntime
@@ -22,7 +23,7 @@ import kotlinx.coroutines.withContext
 class PassepartoutVpnService: VpnService() {
     private val runtime by lazy {
         PartoutVpnServiceRuntime(
-            logTag = "Passepartout",
+            logTag = Globals.logTag,
             service = this,
             channel = channel,
             engine = VpnEngine(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package com.algoritmico.passepartout.ui
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.algoritmico.passepartout.abi.AppABIProfile
+import com.algoritmico.passepartout.abi.AppABITunnel
+import com.algoritmico.passepartout.abi.PassepartoutWrapper
+import com.algoritmico.passepartout.abi.helpers.ABIEventDispatcher
+import com.algoritmico.passepartout.abi.models.Event
+import com.algoritmico.passepartout.readAsset
+import com.algoritmico.passepartout.tunnel.PassepartoutVpnService
+import io.partout.jni.PartoutTunnel
+import io.partout.jni.PartoutVpnServiceRuntime
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.io.Closeable
+import java.io.File
+
+class AppContext(
+    context: Context,
+    coroutineScope: CoroutineScope,
+    tunnelChannel: PartoutVpnServiceRuntime.Channel,
+    requestVpnPermission: (Intent) -> Unit
+) : Closeable {
+    private val applicationContext = context.applicationContext
+
+    private val library = PassepartoutWrapper()
+
+    private val tunnel = PartoutTunnel(
+        applicationContext,
+        PassepartoutVpnService::class.java,
+        tunnelChannel,
+        requestVpnPermission,
+        coroutineScope
+    )
+
+    private val eventDispatcher: ABIEventDispatcher = ABIEventDispatcher
+
+    private var eventSubscription: Closeable? = eventDispatcher.register(::handleEvent)
+
+    private val appEvents = MutableSharedFlow<Event>(
+        replay = APP_EVENT_REPLAY,
+        extraBufferCapacity = APP_EVENT_BUFFER_CAPACITY
+    )
+
+    val profileObservable = ProfileObservable(
+        AppABIProfile(library),
+        appEvents,
+        coroutineScope
+    )
+
+    val tunnelObservable = TunnelObservable(
+        AppABITunnel(library),
+        appEvents,
+        coroutineScope
+    )
+
+    init {
+        val partoutVersion = library.partoutVersion()
+        Log.i("Passepartout", ">>> Partout $partoutVersion")
+        Log.e("Passepartout", ">>> Started app")
+
+        val bundle = applicationContext.readAsset(BUNDLE_FILENAME)
+        val constants = applicationContext.readAsset(CONSTANTS_FILENAME)
+        val profilesDirectory = File(applicationContext.noBackupFilesDir, PROFILES_DIRECTORY)
+            .apply {
+                mkdirs()
+            }
+        val cacheDirectory = applicationContext.cacheDir
+        val code = library.appInit(
+            bundle,
+            constants,
+            profilesDirectory.absolutePath,
+            cacheDirectory.absolutePath,
+            tunnel,
+            eventDispatcher
+        )
+        if (code != 0) {
+            close()
+            throw RuntimeException("Unable to init app (code=$code)")
+        }
+    }
+
+    fun onApplicationActive() {
+        library.appOnForeground()
+    }
+
+    fun onVpnPermissionResult(isGranted: Boolean) {
+        tunnel.onVpnPermissionResult(isGranted)
+    }
+
+    private fun handleEvent(event: Event) {
+        Log.i("Passepartout", ">>> AppContext: $event")
+        appEvents.tryEmit(event)
+    }
+
+    override fun close() {
+        eventSubscription?.close()
+        eventSubscription = null
+        profileObservable.close()
+        tunnelObservable.close()
+        library.appDeinit { _, _ -> }
+    }
+
+    companion object {
+        private const val APP_EVENT_BUFFER_CAPACITY = 64
+
+        private const val APP_EVENT_REPLAY = 64
+
+        private const val BUNDLE_FILENAME = "bundle.json"
+
+        private const val CONSTANTS_FILENAME = "constants.json"
+
+        private const val PROFILES_DIRECTORY = "profiles-v1"
+    }
+}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
@@ -45,8 +45,8 @@ class AppContext(
     private var eventSubscription: Closeable? = eventDispatcher.register(::handleEvent)
 
     private val appEvents = MutableSharedFlow<Event>(
-        replay = APP_EVENT_REPLAY,
-        extraBufferCapacity = APP_EVENT_BUFFER_CAPACITY
+        replay = Globals.EVENT_REPLAY,
+        extraBufferCapacity = Globals.EVENT_BUFFER_CAPACITY
     )
 
     val profileObservable = ProfileObservable(
@@ -109,10 +109,6 @@ class AppContext(
     }
 
     companion object {
-        private const val APP_EVENT_BUFFER_CAPACITY = 64
-
-        private const val APP_EVENT_REPLAY = 64
-
         private const val BUNDLE_FILENAME = "bundle.json"
 
         private const val CONSTANTS_FILENAME = "constants.json"

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
@@ -7,6 +7,7 @@ package com.algoritmico.passepartout.ui
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.AppABIProfile
 import com.algoritmico.passepartout.abi.AppABITunnel
 import com.algoritmico.passepartout.abi.PassepartoutWrapper
@@ -62,8 +63,8 @@ class AppContext(
 
     init {
         val partoutVersion = library.partoutVersion()
-        Log.i("Passepartout", ">>> Partout $partoutVersion")
-        Log.e("Passepartout", ">>> Started app")
+        Log.i(Globals.logTag, ">>> Partout $partoutVersion")
+        Log.e(Globals.logTag, ">>> Started app")
 
         val bundle = applicationContext.readAsset(BUNDLE_FILENAME)
         val constants = applicationContext.readAsset(CONSTANTS_FILENAME)
@@ -95,7 +96,7 @@ class AppContext(
     }
 
     private fun handleEvent(event: Event) {
-        Log.i("Passepartout", ">>> AppContext: $event")
+        Log.i(Globals.logTag, ">>> AppContext: $event")
         appEvents.tryEmit(event)
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppCoordinator.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppCoordinator.kt
@@ -4,12 +4,13 @@
 
 package com.algoritmico.passepartout.ui
 
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -17,6 +18,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -26,7 +28,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
-import io.partout.abi.TaggedProfile
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,12 +36,12 @@ fun AppCoordinator(
     title: String,
     profileObservable: ProfileObservable,
     tunnelObservable: TunnelObservable,
-    onProfilesDelete: (Array<String>) -> Unit,
     onImportProfile: () -> Unit
 ) {
     var contextualProfileIds by rememberSaveable {
         mutableStateOf(emptyList<String>())
     }
+    val coroutineScope = rememberCoroutineScope()
     val isContextualMode = contextualProfileIds.isNotEmpty()
 
     fun clearContextualMode() {
@@ -90,7 +92,13 @@ fun AppCoordinator(
                             onClick = {
                                 val profileIds = contextualProfileIds
                                 clearContextualMode()
-                                onProfilesDelete(profileIds.toTypedArray())
+                                coroutineScope.launch {
+                                    runCatching {
+                                        profileObservable.remove(profileIds)
+                                    }.onFailure {
+                                        Log.e("Passepartout", "Unable to delete profiles", it)
+                                    }
+                                }
                             }
                         ) {
                             Icon(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppCoordinator.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppCoordinator.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
+import com.algoritmico.passepartout.Globals
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -96,7 +97,7 @@ fun AppCoordinator(
                                     runCatching {
                                         profileObservable.remove(profileIds)
                                     }.onFailure {
-                                        Log.e("Passepartout", "Unable to delete profiles", it)
+                                        Log.e(Globals.logTag, "Unable to delete profiles", it)
                                     }
                                 }
                             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/PassepartoutApp.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/PassepartoutApp.kt
@@ -17,8 +17,7 @@ import androidx.compose.ui.Modifier
 fun PassepartoutApp(
     profileObservable: ProfileObservable,
     tunnelObservable: TunnelObservable,
-    onImportProfile: () -> Unit,
-    onProfilesDelete: (Array<String>) -> Unit
+    onImportProfile: () -> Unit
 ) {
     val colorScheme = if (isSystemInDarkTheme()) {
         darkColorScheme()
@@ -35,7 +34,6 @@ fun PassepartoutApp(
                 title = "Passepartout",
                 profileObservable = profileObservable,
                 tunnelObservable = tunnelObservable,
-                onProfilesDelete = onProfilesDelete,
                 onImportProfile = onImportProfile
             )
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/ProfileObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/ProfileObservable.kt
@@ -4,6 +4,7 @@
 
 package com.algoritmico.passepartout.ui
 
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.AppABIProfileProtocol
 import com.algoritmico.passepartout.abi.models.AppFeature
 import com.algoritmico.passepartout.abi.models.AppProfileHeader
@@ -43,7 +44,7 @@ class ProfileObservable(
     private var allHeaders: Map<String, AppProfileHeader> = emptyMap()
     private val _state = MutableStateFlow(State())
     private val searchRequests = MutableStateFlow("")
-    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = EVENT_BUFFER_CAPACITY)
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = Globals.EVENT_BUFFER_CAPACITY)
 
     val events: SharedFlow<Event> = _events.asSharedFlow()
     val state: StateFlow<State> = _state.asStateFlow()
@@ -171,7 +172,5 @@ class ProfileObservable(
                 }
                 .sortedBy { it.name.lowercase() }
         }
-
-        const val EVENT_BUFFER_CAPACITY = 64
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/ProfileObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/ProfileObservable.kt
@@ -31,8 +31,8 @@ import kotlinx.coroutines.flow.update
 import java.io.Closeable
 
 class ProfileObservable(
-    events: Flow<Event>,
     private val abi: AppABIProfileProtocol,
+    events: Flow<Event>,
     coroutineScope: CoroutineScope,
     searchDebounceMillis: Long = 200L
 ) : Closeable {
@@ -49,13 +49,13 @@ class ProfileObservable(
     val state: StateFlow<State> = _state.asStateFlow()
 
     init {
-        events
-            .onEach(::onUpdate)
-            .launchIn(scope)
-
         searchRequests
             .debounce(searchDebounceMillis)
             .onEach(::reloadHeaders)
+            .launchIn(scope)
+
+        events
+            .onEach(::onUpdate)
             .launchIn(scope)
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -30,8 +30,8 @@ import kotlinx.coroutines.flow.update
 import java.io.Closeable
 
 class TunnelObservable(
-    events: Flow<Event>,
     private val abi: AppABITunnelProtocol,
+    events: Flow<Event>,
     coroutineScope: CoroutineScope
 ) : Closeable {
     private val scope = CoroutineScope(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -4,6 +4,7 @@
 
 package com.algoritmico.passepartout.ui
 
+import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.AppABITunnelProtocol
 import com.algoritmico.passepartout.abi.models.AppProfileStatus
 import com.algoritmico.passepartout.abi.models.AppTunnelInfo
@@ -11,8 +12,6 @@ import com.algoritmico.passepartout.abi.models.Event
 import com.algoritmico.passepartout.abi.models.ProfileTransfer
 import com.algoritmico.passepartout.abi.models.TunnelEventRefresh
 import io.partout.abi.TaggedProfile
-import io.partout.abi.TunnelSnapshot
-import io.partout.jni.PartoutVpnServiceRuntime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -39,7 +38,7 @@ class TunnelObservable(
     )
 
     private val _state = MutableStateFlow(State())
-    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = EVENT_BUFFER_CAPACITY)
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = Globals.EVENT_BUFFER_CAPACITY)
 
     val events: SharedFlow<Event> = _events.asSharedFlow()
     val state: StateFlow<State> = _state.asStateFlow()
@@ -100,9 +99,5 @@ class TunnelObservable(
 
         val hasActiveProfiles: Boolean
             get() = activeProfiles.isNotEmpty()
-    }
-
-    private companion object {
-        const val EVENT_BUFFER_CAPACITY = 64
     }
 }

--- a/app-android/app/src/test/kotlin/com/algoritmico/passepartout/SerializationUnitTest.kt
+++ b/app-android/app/src/test/kotlin/com/algoritmico/passepartout/SerializationUnitTest.kt
@@ -32,7 +32,7 @@ class SerializationUnitTest {
 
     @Test
     fun dnsProtocolType_isDeserialized() {
-        val dnsProtocols = globalJsonCoder.decodeFromString<List<DNSModuleProtocolType>>(dnsProtocolsJSON)
+        val dnsProtocols = Globals.json.decodeFromString<List<DNSModuleProtocolType>>(dnsProtocolsJSON)
         assertEquals(dnsProtocols.size, 3)
         assert(dnsProtocols[0] is DNSModuleProtocolTypecleartext)
         val https = dnsProtocols[1] as DNSModuleProtocolTypehttps
@@ -47,7 +47,7 @@ class SerializationUnitTest {
         val https = DNSModuleProtocolTypehttps(url = "https://www.google.com")
         val tls = DNSModuleProtocolTypetls(hostname = "google.com")
         val dnsProtocols = listOf(clear, https, tls)
-        val json = globalJsonCoder.encodeToJsonElement(dnsProtocols).toString().trimIndent()
+        val json = Globals.json.encodeToJsonElement(dnsProtocols).toString().trimIndent()
         println(json)
         println(dnsProtocolsJSON)
         assertEquals(json, dnsProtocolsJSON)
@@ -55,7 +55,7 @@ class SerializationUnitTest {
 
     @Test
     fun obfMethod_isDeserialized() {
-        val obfMethods = globalJsonCoder.decodeFromString<List<OpenVPNObfuscationMethod>>(obfMethodsJSON)
+        val obfMethods = Globals.json.decodeFromString<List<OpenVPNObfuscationMethod>>(obfMethodsJSON)
         assertEquals(obfMethods.size, 4)
         val xormask = obfMethods[0] as OpenVPNObfuscationMethodxormask
         assertTrue(xormask.mask.contentEquals(obfMaskBase64))
@@ -72,7 +72,7 @@ class SerializationUnitTest {
         val reverse = OpenVPNObfuscationMethodreverse()
         val obfuscate = OpenVPNObfuscationMethodobfuscate(mask = obfMaskBase64)
         val obfMethods = listOf(xormask, xorptrpos, reverse, obfuscate)
-        val json = globalJsonCoder.encodeToJsonElement(obfMethods).toString().trimIndent()
+        val json = Globals.json.encodeToJsonElement(obfMethods).toString().trimIndent()
         println(json)
         println(obfMethodsJSON)
         assertEquals(json, obfMethodsJSON)


### PR DESCRIPTION
- Create observables in AppContext
- Move service to cleanly split packages into `abi`, `ui` and `tunnel`
- Update Partout to support custom log tags in runtime
- Centralize other constants