### PR TITLE
ABI: Move snapshots/environments integration to Partout

### DIFF
--- a/app-android/app/proguard-rules.pro
+++ b/app-android/app/proguard-rules.pro
@@ -47,5 +47,5 @@
     public void testWorking();
     public int setTunnel(java.lang.String);
     public void configureSockets(int[]);
-    public void onStatus(java.lang.String);
+    public void onSnapshots(java.lang.String);
 }

--- a/app-android/app/src/main/cpp/src/helpers.c
+++ b/app-android/app/src/main/cpp/src/helpers.c
@@ -57,10 +57,6 @@ void abi_event_handler_proxy(void *ctx, const char *event_json) {
     abi_handler_proxy(ctx, "onEvent", event_json);
 }
 
-void abi_connection_status_handler_proxy(void *ctx, const char *status_json) {
-    abi_handler_proxy(ctx, "onStatus", status_json);
-}
-
 /* Completion (fire and release) */
 
 void abi_completion_proxy(void *ctx, int code, const char *json) {

--- a/app-android/app/src/main/cpp/src/helpers.h
+++ b/app-android/app/src/main/cpp/src/helpers.h
@@ -17,7 +17,6 @@ void abi_handler_free(JNIEnv *env, abi_handler *handler);
 
 /* Global handlers (lifescope = application). */
 void abi_event_handler_proxy(void *ctx, const char *event_json);
-void abi_connection_status_handler_proxy(void *ctx, const char *status_json);
 
 /* Completion handlers (lifescope = function call, released on call). */
 void abi_completion_proxy(void *ctx, int code, const char *json);

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -162,9 +162,7 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStart(
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     psp_tunnel_bindings bindings = { 0 };
-    bindings.controller = (*env)->NewGlobalRef(env, runtime);
-    bindings.status_ctx = abi_handler_create(env, runtime);
-    bindings.status_cb = abi_connection_status_handler_proxy;
+    bindings.runtime = (*env)->NewGlobalRef(env, runtime);
     bindings.free = tunnel_bindings_free;
 
     psp_tunnel_start_args args = { 0 };
@@ -210,13 +208,9 @@ void app_bindings_free(psp_app_bindings *b) {
 
 void tunnel_bindings_free(psp_tunnel_bindings *b) {
     JNI_ATTACH_OR_RETURN_VOID(env);
-    if (b->controller) {
-        (*env)->DeleteGlobalRef(env, b->controller);
-        b->controller = NULL;
-    }
-    if (b->status_ctx) {
-        abi_handler_free(env, b->status_ctx);
-        b->status_ctx = NULL;
+    if (b->runtime) {
+        (*env)->DeleteGlobalRef(env, b->runtime);
+        b->runtime = NULL;
     }
     JNI_DETACH(env);
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/models/ProfileTransfer.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/models/ProfileTransfer.kt
@@ -31,10 +31,10 @@ import kotlinx.serialization.Contextual
 data class ProfileTransfer (
 
     @SerialName(value = "received")
-    val received: kotlin.Int = 0,
+    val received: kotlin.Long = 0L,
 
     @SerialName(value = "sent")
-    val sent: kotlin.Int = 0
+    val sent: kotlin.Long = 0L
 
 ) {
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/ProfileContainerView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/ProfileContainerView.kt
@@ -45,9 +45,11 @@ import com.algoritmico.passepartout.abi.models.AppProfileHeader
 import com.algoritmico.passepartout.abi.models.AppProfileStatus
 import com.algoritmico.passepartout.abi.models.AppTunnelInfo
 import com.algoritmico.passepartout.abi.models.ProfileEventSave
+import com.algoritmico.passepartout.abi.models.ProfileTransfer
 import io.partout.abi.TaggedProfile
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 @Composable
 fun ProfileContainerView(
@@ -89,6 +91,10 @@ fun ProfileContainerView(
         return activeProfiles[profileId]?.status
             ?: requestedConnection?.statusFor(profileId)
             ?: AppProfileStatus.disconnected
+    }
+
+    fun profileTransfer(profileId: String): ProfileTransfer? {
+        return activeProfiles[profileId]?.transfer
     }
 
     fun requestProfileToggle(profileId: String, enabled: Boolean) {
@@ -178,6 +184,7 @@ fun ProfileContainerView(
             contextualProfileIds = contextualProfileIds,
             isProfileEnabled = ::isProfileEnabled,
             profileStatus = ::profileStatus,
+            profileTransfer = ::profileTransfer,
             onProfileSelected = onProfileSelected,
             onProfileToggle = ::requestProfileToggle,
             onProfileContextualAction = onProfileContextualAction
@@ -190,6 +197,7 @@ fun ProfileContainerView(
             contextualProfileIds = contextualProfileIds,
             isProfileEnabled = ::isProfileEnabled,
             profileStatus = ::profileStatus,
+            profileTransfer = ::profileTransfer,
             onProfileSelected = onProfileSelected,
             onProfileToggle = ::requestProfileToggle,
             onProfileContextualAction = onProfileContextualAction
@@ -205,6 +213,7 @@ private fun MobileProfilesView(
     contextualProfileIds: List<String>,
     isProfileEnabled: (String) -> Boolean,
     profileStatus: (String) -> AppProfileStatus,
+    profileTransfer: (String) -> ProfileTransfer?,
     onProfileSelected: (String) -> Unit,
     onProfileToggle: (String, Boolean) -> Unit,
     onProfileContextualAction: (String) -> Unit
@@ -228,6 +237,7 @@ private fun MobileProfilesView(
                 header = header,
                 isEnabled = isProfileEnabled(header.id),
                 status = profileStatus(header.id),
+                transfer = profileTransfer(header.id),
                 isSelected = if (contextualProfileIds.isNotEmpty()) {
                     header.id in contextualProfileIds
                 } else {
@@ -249,6 +259,7 @@ private fun TabletProfilesView(
     contextualProfileIds: List<String>,
     isProfileEnabled: (String) -> Boolean,
     profileStatus: (String) -> AppProfileStatus,
+    profileTransfer: (String) -> ProfileTransfer?,
     onProfileSelected: (String) -> Unit,
     onProfileToggle: (String, Boolean) -> Unit,
     onProfileContextualAction: (String) -> Unit
@@ -282,6 +293,7 @@ private fun TabletProfilesView(
                         header = header,
                         isEnabled = isProfileEnabled(header.id),
                         status = profileStatus(header.id),
+                        transfer = profileTransfer(header.id),
                         isSelected = if (contextualProfileIds.isNotEmpty()) {
                             header.id in contextualProfileIds
                         } else {
@@ -313,11 +325,17 @@ private fun ProfileRow(
     header: AppProfileHeader,
     isEnabled: Boolean,
     status: AppProfileStatus,
+    transfer: ProfileTransfer?,
     isSelected: Boolean,
     onProfileSelected: (String) -> Unit,
     onProfileToggle: (String, Boolean) -> Unit,
     onProfileContextualAction: (String) -> Unit
 ) {
+    val statusDescription = if (status == AppProfileStatus.connected && transfer != null) {
+        transfer.transferText()
+    } else {
+        status.statusText()
+    }
     val containerColor = if (isSelected) {
         MaterialTheme.colorScheme.secondaryContainer
     } else {
@@ -360,7 +378,7 @@ private fun ProfileRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = status.statusText(),
+                    text = statusDescription,
                     style = MaterialTheme.typography.bodySmall,
                     color = statusColor(status)
                 )
@@ -530,6 +548,30 @@ private fun AppProfileStatus.statusText(): String {
     }
 }
 
+private fun ProfileTransfer.transferText(): String {
+    return "↓${received.toLong().formatDataUnit()} ↑${sent.toLong().formatDataUnit()}"
+}
+
+private fun Long.formatDataUnit(): String {
+    val value = coerceAtLeast(0L)
+    if (value == 0L) {
+        return "0B"
+    }
+    if (value < KILOBYTE) {
+        return "${value}B"
+    }
+    return when {
+        value >= GIGABYTE / 10L -> value.formatDecimalDataUnit(GIGABYTE, "GB")
+        value >= MEGABYTE / 10L -> value.formatDecimalDataUnit(MEGABYTE, "MB")
+        else -> "${value / KILOBYTE}kB"
+    }
+}
+
+private fun Long.formatDecimalDataUnit(unitSize: Long, unit: String): String {
+    val count = toDouble() / unitSize.toDouble()
+    return String.format(Locale.US, "%.2f%s", count, unit)
+}
+
 private fun AppProfileStatus.canToggle(): Boolean {
     return when (this) {
         AppProfileStatus.disconnecting -> false
@@ -571,3 +613,7 @@ private data class RequestedConnection(
         }
     }
 }
+
+private const val KILOBYTE = 1024L
+private const val MEGABYTE = KILOBYTE * 1024L
+private const val GIGABYTE = MEGABYTE * 1024L

--- a/app-apple/Passepartout/App/Context/AppContext+Testing.swift
+++ b/app-apple/Passepartout/App/Context/AppContext+Testing.swift
@@ -65,8 +65,7 @@ extension AppContext {
         )
         let tunnelManager = TunnelManager(
             tunnel: tunnel,
-            processor: tunnelProcessor,
-            interval: appConfiguration.constants.tunnel.refreshInterval
+            processor: tunnelProcessor
         )
         let configManager = ConfigManager()
         let preferencesManager = PreferencesManager()

--- a/app-apple/Sources/AppLibrary/Previews/AppContext+Previews.swift
+++ b/app-apple/Sources/AppLibrary/Previews/AppContext+Previews.swift
@@ -44,13 +44,12 @@ extension AppContext {
                 }
             return ProfileManager(profiles: profiles)
         }()
-        let tunnel = Tunnel(.global, strategy: FakeTunnelStrategy()) { @Sendable _ in
+        let tunnel = Tunnel(.global, strategy: FakeTunnelStrategy(), updateInterval: 10.0) { @Sendable _ in
             SharedTunnelEnvironment(profileId: nil)
         }
         let tunnelManager = TunnelManager(
             tunnel: tunnel,
-            processor: processor,
-            interval: 10.0
+            processor: processor
         )
         let preferencesManager = PreferencesManager()
 

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Apple.swift
@@ -174,9 +174,7 @@ extension AppABI {
             backupRepository: backupProfileRepository,
             mirrorsRemoteRepository: false
         )
-        let tunnel = Tunnel(ctx, strategy: tunnelStrategy) { @Sendable in
-            appConfiguration.newAppTunnelEnvironment(strategy: tunnelStrategy, profileId: $0)
-        }
+        let tunnel = appConfiguration.newTunnel(ctx, strategy: tunnelStrategy)
         let sysexManager = appConfiguration.newSystemExtensionManager(
             tunnelIdentifier: tunnelIdentifier
         )

--- a/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/AppABI+Cross.swift
@@ -66,9 +66,7 @@ extension AppABI {
                 pspLog(.abi, .fault, "Unable to prepare NativeTunnel: \(error)")
             }
         }
-        // FIXME: #1656, NativeTunnel lacks environment
-//        appConfiguration.newAppTunnelEnvironment(strategy: tunnelStrategy, profileId: $0)
-        let tunnelManager = TunnelManager(tunnel: tunnel, interval: 1.0)
+        let tunnelManager = TunnelManager(tunnel: tunnel)
 
         // Dummy
         let iapManager = IAPManager()

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -35,7 +35,7 @@ extension TunnelABI {
             cachesURL: cachesURL
         )
         let profile = try registry.importedProfile(from: profileInput, passphrase: nil)
-        let environment = appConfiguration.newStandaloneTunnelEnvironment(profileId: profile.id)
+        let environment = SharedTunnelEnvironment(profileId: profile.id)
         let logFormatter = appConfiguration.newLogFormatter()
 
         // Logging context
@@ -49,7 +49,7 @@ extension TunnelABI {
         )
 
         // Create platform-specific objects
-        let controller = try NativeTunnelController(ctx, ref: bindings.controller)
+        let controller = try NativeTunnelController(ctx, ref: bindings.runtime)
         let betterPathBlock: BetterPathBlock
 #if !PSP_CROSS
         betterPathBlock = NEBetterPathBlock(ctx).block
@@ -62,21 +62,6 @@ extension TunnelABI {
         let factory = BSDSocketFactory(ctx, betterPathBlock: betterPathBlock)
         // FIXME: #1656, C ABI, reachability observer
         let reachability = DummyReachabilityObserver()
-
-        // Wrap onStatus callback
-        nonisolated(unsafe) let statusContext = bindings.status_ctx
-        let statusCallback = bindings.status_cb
-        let onStatus: OnConnectionStatusCallback = { event in
-            guard let statusCallback else { return }
-            do {
-                let json = try ABI.encodeJSON(event)
-                json.withCString {
-                    statusCallback(statusContext, $0)
-                }
-            } catch {
-                assertionFailure("Unable to encode on status event: \(event), \(error)")
-            }
-        }
 
         let connectionOptions = ConnectionParameters.Options()
         let connectionParameters = ConnectionParameters(
@@ -91,8 +76,7 @@ extension TunnelABI {
             connectionFactory: registry,
             connectionParameters: connectionParameters,
             messageHandler: DefaultMessageHandler(ctx, environment: environment),
-            startsImmediately: false,
-            onStatus: onStatus
+            startsImmediately: false
         )
         let daemon = try SimpleConnectionDaemon(params: daemonParameters)
 

--- a/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
@@ -140,7 +140,8 @@ extension ABI.AppConfiguration {
         _ ctx: PartoutLoggerContext,
         ref: UnsafeMutableRawPointer?
     ) -> TunnelProtocol {
-        NativeTunnel(ctx, ref: ref)
+        nonisolated(unsafe) let unsafeRef = ref
+        return NativeTunnel(ctx, ref: unsafeRef)
     }
 
     @BusinessActor
@@ -154,8 +155,7 @@ extension ABI.AppConfiguration {
             tunnel: tunnel,
             extensionInstaller: extensionInstaller,
             kvStore: kvStore,
-            processor: processor,
-            interval: constants.tunnel.refreshInterval
+            processor: processor
         )
     }
 
@@ -439,11 +439,6 @@ extension ABI.AppConfiguration {
         return try await URLSession.shared.data(for: request).0
     }
 
-    // FIXME: ###, Cross UI, Apple standalone tunnel environment
-    public func newStandaloneTunnelEnvironment(profileId: Profile.ID) -> TunnelEnvironment {
-        SharedTunnelEnvironment(profileId: profileId)
-    }
-
     public func newSystemExtensionManager(tunnelIdentifier: String) -> ExtensionInstaller? {
         guard bundle.distributionTarget == .developerID else {
             return nil
@@ -452,6 +447,17 @@ extension ABI.AppConfiguration {
             identifier: tunnelIdentifier,
             version: bundle.versionNumber,
             build: bundle.buildNumber
+        )
+    }
+
+    public func newTunnel(_ ctx: PartoutLoggerContext, strategy: TunnelObservableStrategy) -> Tunnel {
+        Tunnel(
+            ctx,
+            strategy: strategy,
+            updateInterval: constants.tunnel.refreshInterval,
+            environmentFactory: { @Sendable in
+                newAppTunnelEnvironment(strategy: strategy, profileId: $0)
+            }
         )
     }
 
@@ -486,10 +492,6 @@ extension ABI.AppConfiguration {
 
 // FIXME: #1656, C ABI, non-Apple strategies
 extension ABI.AppConfiguration {
-    public func newAppTunnelEnvironment(strategy: TunnelStrategy, profileId: Profile.ID) -> TunnelEnvironmentReader {
-        SharedTunnelEnvironment(profileId: profileId)
-    }
-
     public func newKeyValueStore() -> KeyValueStore {
         InMemoryStore()
     }
@@ -500,10 +502,6 @@ extension ABI.AppConfiguration {
 
     public func newRequest(for url: URL, cached: Bool) async throws -> Data {
         Data()
-    }
-
-    public func newStandaloneTunnelEnvironment(profileId: Profile.ID) -> TunnelEnvironment {
-        SharedTunnelEnvironment(profileId: profileId)
     }
 }
 

--- a/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
+++ b/app-cross/Sources/CommonLibraryCore/Business/TunnelManager.swift
@@ -18,8 +18,6 @@ public final class TunnelManager {
 
     private let processor: AppTunnelProcessor?
 
-    private let interval: TimeInterval
-
     private nonisolated let didChange: PassthroughStream<ABI.TunnelEvent>
 
     private var latestInfo: [Profile.ID: ABI.AppTunnelInfo]? {
@@ -35,14 +33,12 @@ public final class TunnelManager {
         tunnel: TunnelProtocol,
         extensionInstaller: ExtensionInstaller? = nil,
         kvStore: KeyValueStore? = nil,
-        processor: AppTunnelProcessor? = nil,
-        interval: TimeInterval
+        processor: AppTunnelProcessor? = nil
     ) {
         self.tunnel = tunnel
         self.extensionInstaller = extensionInstaller
         self.kvStore = kvStore
         self.processor = processor
-        self.interval = interval
         didChange = PassthroughStream()
         latestInfo = nil
         subscriptions = []
@@ -174,12 +170,10 @@ extension TunnelManager {
                     break
                 }
                 // Copy locally for sync access
-                let latestEnvironments = await tunnel.allEnvironments()
-                let newInfo = latestInfo?.with(
+                let newInfo = (latestInfo ?? [:]).with(
                     snapshots: snapshots,
-                    lastUsedProfile: lastUsedProfile,
-                    environments: latestEnvironments
-                ) ?? [:]
+                    lastUsedProfile: lastUsedProfile
+                )
                 // TODO: #218, keep "last used profile" until .multiple
                 if let first = snapshots.first {
                     kvStore?.set(first.key.uuidString, forAppPreference: .lastUsedProfileId)
@@ -190,24 +184,7 @@ extension TunnelManager {
                 }
             }
         }
-
-        let timerSubscription = Task { [weak self] in
-            while true {
-                guard let self else { return }
-                guard !Task.isCancelled else {
-                    pspLog(.core, .debug, "Cancelled TunnelManager.timerSubscription")
-                    break
-                }
-                let latestEnvironments = await tunnel.allEnvironments()
-                let newInfo = latestInfo?.updated(with: latestEnvironments) ?? [:]
-                if newInfo != latestInfo {
-                    latestInfo = newInfo
-                }
-                try? await Task.sleep(interval: interval)
-            }
-        }
-
-        subscriptions = [tunnelSubscription, timerSubscription]
+        subscriptions = [tunnelSubscription]
         return didChange.subscribe()
     }
 }
@@ -253,22 +230,14 @@ private extension TunnelManager {
 private extension Dictionary where Key == Profile.ID, Value == ABI.AppTunnelInfo {
     func with(
         snapshots: [Profile.ID: TunnelSnapshot],
-        lastUsedProfile: TunnelSnapshot?,
-        environments: [Profile.ID: TunnelEnvironmentReader],
+        lastUsedProfile: TunnelSnapshot?
     ) -> Self {
         var info = snapshots.mapValues {
-            $0.abiInfo(withEnvironment: environments[$0.id])
+            $0.abiInfo()
         }
         if info.isEmpty, let last = lastUsedProfile {
-            info = [last.id: last.abiInfo(withEnvironment: nil)]
+            info = [last.id: last.abiInfo()]
         }
         return info
-    }
-
-    func updated(with environments: [Profile.ID: TunnelEnvironmentReader]) -> Self {
-        mapValues {
-            guard let env = environments[$0.id] else { return $0 }
-            return $0.with(environment: env)
-        }
     }
 }

--- a/app-cross/Sources/CommonLibraryCore/Domain/AppProfile.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppProfile.swift
@@ -67,7 +67,7 @@ extension ABI {
             isEnabled: Bool,
             tunnelStatus: TunnelStatus,
             onDemand: Bool,
-            environment: TunnelEnvironmentReader?
+            environment: TunnelSnapshot.Environment?
         ) {
             self.id = id
             self.isEnabled = isEnabled
@@ -77,15 +77,11 @@ extension ABI {
             transfer = nil
             lastErrorCode = nil
 
-            transfer = environment?.environmentValue(
-                forKey: TunnelEnvironmentKeys.dataCount
-            )?.abiTransfer
-            lastErrorCode = environment?.environmentValue(
-                forKey: TunnelEnvironmentKeys.lastErrorCode
-            )
+            transfer = environment?.dataCount.abiTransfer
+            lastErrorCode = environment?.lastErrorCode
         }
 
-        public func with(environment: TunnelEnvironmentReader) -> Self {
+        public func with(environment: TunnelSnapshot.Environment) -> Self {
             Self(
                 id: id,
                 isEnabled: isEnabled,

--- a/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIProfileTransfer.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIProfileTransfer.swift
@@ -9,10 +9,10 @@ import Partout
 
 public struct OpenAPIProfileTransfer: Sendable, Codable, Hashable {
 
-    public var received: Int = 0
-    public var sent: Int = 0
+    public var received: Int64 = 0
+    public var sent: Int64 = 0
 
-    public init(received: Int = 0, sent: Int = 0) {
+    public init(received: Int64 = 0, sent: Int64 = 0) {
         self.received = received
         self.sent = sent
     }

--- a/app-cross/Sources/CommonLibraryCore/Mappers/Partout+Tunnel.swift
+++ b/app-cross/Sources/CommonLibraryCore/Mappers/Partout+Tunnel.swift
@@ -5,11 +5,11 @@
 import Partout
 
 extension TunnelStatus {
-    func considering(_ environment: TunnelEnvironmentReader?) -> TunnelStatus {
+    func considering(_ environment: TunnelSnapshot.Environment?) -> TunnelStatus {
         // If the tunnel is active and it relies on a
         // connection, map to the connection status
         if self == .active,
-           let connectionStatus = environment?.environmentValue(forKey: TunnelEnvironmentKeys.connectionStatus) {
+           let connectionStatus = environment?.connectionStatus {
             switch connectionStatus {
             case .connecting:
                 return .activating
@@ -36,7 +36,7 @@ extension TunnelStatus {
 }
 
 extension TunnelSnapshot {
-    func abiInfo(withEnvironment environment: TunnelEnvironmentReader?) -> ABI.AppTunnelInfo {
+    func abiInfo() -> ABI.AppTunnelInfo {
         ABI.AppTunnelInfo(
             id: id,
             isEnabled: isEnabled,

--- a/app-cross/Sources/CommonLibraryCore/Mappers/Partout+Tunnel.swift
+++ b/app-cross/Sources/CommonLibraryCore/Mappers/Partout+Tunnel.swift
@@ -49,6 +49,6 @@ extension TunnelSnapshot {
 
 extension DataCount {
     var abiTransfer: ABI.ProfileTransfer {
-        ABI.ProfileTransfer(received: Int(received), sent: Int(sent))
+        ABI.ProfileTransfer(received: Int64(received), sent: Int64(sent))
     }
 }

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -47,9 +47,7 @@ typedef struct __psp_app_bindings {
 } psp_app_bindings;
 
 typedef struct __psp_tunnel_bindings {
-    void *controller;
-    void *status_ctx;
-    psp_event_callback status_cb;
+    void *runtime;
     void (*free)(struct __psp_tunnel_bindings *);
 } psp_tunnel_bindings;
 

--- a/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
@@ -19,10 +19,10 @@ extension TunnelManagerTests {
     @Test
     func givenTunnel_whenDisconnectWithError_thenPublishesLastErrorCode() async throws {
         let env = SharedTunnelEnvironment(profileId: nil)
-        let tunnel = Tunnel(ctx, strategy: newStrategy()) { @Sendable _ in
+        let tunnel = Tunnel(ctx, strategy: newStrategy(), updateInterval: 0.1) { @Sendable _ in
             env
         }
-        let sut = TunnelManager(tunnel: tunnel, interval: 0.1)
+        let sut = TunnelManager(tunnel: tunnel)
 
         let module = IPModule.Builder().build()
         let profile = try Profile.Builder(modules: [module]).build()
@@ -55,10 +55,10 @@ extension TunnelManagerTests {
     @Test
     func givenTunnel_whenPublishesDataCount_thenIsAvailable() async throws {
         let env = SharedTunnelEnvironment(profileId: nil)
-        let tunnel = Tunnel(ctx, strategy: newStrategy()) { @Sendable _ in
+        let tunnel = Tunnel(ctx, strategy: newStrategy(), updateInterval: 0.1) { @Sendable _ in
             env
         }
-        let sut = TunnelManager(tunnel: tunnel, interval: 0.1)
+        let sut = TunnelManager(tunnel: tunnel)
         let stream = sut.observeObjects()
         #expect(await stream.nextActiveProfiles() == [:])
 
@@ -80,11 +80,11 @@ extension TunnelManagerTests {
     @Test
     func givenTunnelAndProcessor_whenInstall_thenProcessesProfile() async throws {
         let env = SharedTunnelEnvironment(profileId: nil)
-        let tunnel = Tunnel(ctx, strategy: newStrategy()) { @Sendable _ in
+        let tunnel = Tunnel(ctx, strategy: newStrategy(), updateInterval: 0.1) { @Sendable _ in
             env
         }
         let processor = MockTunnelProcessor()
-        let sut = TunnelManager(tunnel: tunnel, processor: processor, interval: 0.1)
+        let sut = TunnelManager(tunnel: tunnel, processor: processor)
         let stream = sut.observeObjects()
         #expect(await stream.nextActiveProfiles() == [:])
 
@@ -102,11 +102,11 @@ extension TunnelManagerTests {
     @Test
     func givenTunnel_whenStatusChanges_thenConnectionStatusIsExpected() async throws {
         let env = SharedTunnelEnvironment(profileId: nil)
-        let tunnel = Tunnel(ctx, strategy: newStrategy()) { @Sendable _ in
+        let tunnel = Tunnel(ctx, strategy: newStrategy(), updateInterval: 0.1) { @Sendable _ in
             env
         }
         let processor = MockTunnelProcessor()
-        let sut = TunnelManager(tunnel: tunnel, processor: processor, interval: 0.1)
+        let sut = TunnelManager(tunnel: tunnel, processor: processor)
         let stream = sut.observeObjects()
         #expect(await stream.nextActiveProfiles() == [:])
 
@@ -136,23 +136,21 @@ extension TunnelManagerTests {
             .disconnecting
         ]
 
-        let env = SharedTunnelEnvironment(profileId: nil)
-        let key = TunnelEnvironmentKeys.connectionStatus
-
-        // no connection status, tunnel status unaffected
+        // No connection status, tunnel status unaffected
         allTunnelStatuses.forEach {
-            #expect($0.considering(env) == $0)
+            #expect($0.considering(nil) == $0)
         }
 
-        // has connection status
+        // Has connection status
+        var env = TunnelSnapshot.Environment()
 
-        // affected if .active
+        // Affected if .active
         let tunnelActive: TunnelStatus = .active
-        env.setEnvironmentValue(.connected, forKey: key)
+        env = env.with(connectionStatus: .connected)
         #expect(tunnelActive.considering(env) == .active)
         allConnectionStatuses
             .forEach {
-                env.setEnvironmentValue($0, forKey: key)
+                env = env.with(connectionStatus: $0)
                 let statusWithEnv = tunnelActive.considering(env)
                 switch $0 {
                 case .connecting:
@@ -166,7 +164,7 @@ extension TunnelManagerTests {
                 }
             }
 
-        // unaffected otherwise
+        // Unaffected otherwise
         allTunnelStatuses
             .filter {
                 $0 != .active
@@ -178,9 +176,7 @@ extension TunnelManagerTests {
 
     @Test
     func givenTunnelInfo_whenEnvironmentConnectionStatusChanges_thenProfileStatusIsRecomputed() async throws {
-        let env = SharedTunnelEnvironment(profileId: nil)
-        env.setEnvironmentValue(.connecting, forKey: TunnelEnvironmentKeys.connectionStatus)
-
+        var env = TunnelSnapshot.Environment().with(connectionStatus: .connecting)
         let info = ABI.AppTunnelInfo(
             id: UniqueID(),
             isEnabled: true,
@@ -190,8 +186,7 @@ extension TunnelManagerTests {
         )
         #expect(info.status == .connecting)
 
-        env.setEnvironmentValue(.connected, forKey: TunnelEnvironmentKeys.connectionStatus)
-
+        env = env.with(connectionStatus: .connected)
         let updated = info.with(environment: env)
         #expect(updated.status == .connected)
     }

--- a/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
+++ b/app-cross/Tests/CommonLibraryTests/Business/TunnelManagerTests.swift
@@ -70,7 +70,7 @@ extension TunnelManagerTests {
 
         let expectedXfer = ABI.ProfileTransfer(received: 500, sent: 700)
         #expect(active.first?.key == profile.id)
-        let dataCount = DataCount(UInt(expectedXfer.received), UInt(expectedXfer.sent))
+        let dataCount = DataCount(UInt64(expectedXfer.received), UInt64(expectedXfer.sent))
         env.setEnvironmentValue(dataCount, forKey: TunnelEnvironmentKeys.dataCount)
         try await Task.sleep(for: .milliseconds(200)) // > 0.1s to fetch environments
         let xfer = sut.transfer(ofProfileId: profile.id)

--- a/app-cross/abi.yaml
+++ b/app-cross/abi.yaml
@@ -709,9 +709,11 @@ components:
       properties:
         received:
           type: integer
+          format: int64
           default: 0
         sent:
           type: integer
+          format: int64
           default: 0
       required:
       - received


### PR DESCRIPTION
Move what was formerly observed by TunnelManager to Tunnel and SimpleConnectionDaemon in Partout, following https://github.com/partout-io/partout/pull/400 and https://github.com/partout-io/partout/pull/401. The timer is not necessary in TunnelManager because the Tunnel snapshots are now thorough.

Let the snapshots IPC happen internally between PartoutVpnServiceRuntime and PartoutTunnel, thus making the status handler binding redundant and the TunnelManager events flow naturally.

Add data count to the Android app to showcase the new metadata.