### PR TITLE
Fix regressions in tunnel error reporting

### DIFF
--- a/app-apple/Sources/AppLibrary/L10n/AppError+L10n.swift
+++ b/app-apple/Sources/AppLibrary/L10n/AppError+L10n.swift
@@ -159,6 +159,9 @@ extension PartoutError.Code: StyledLocalizableEntity {
             case .OpenVPN.noRouting:
                 return V.routing
 
+            case .OpenVPN.recoverableAuthentication:
+                return Strings.Entities.TunnelStatus.activating
+
             case .OpenVPN.serverShutdown:
                 return V.shutdown
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Apple.swift
@@ -100,7 +100,8 @@ extension TunnelABI {
             connectionFactory: registry,
             connectionParameters: connectionParameters,
             messageHandler: messageHandler,
-            startsImmediately: true
+            startsImmediately: true,
+            cancelsUnrecoverable: false // Prevents on-demand reconnection
         )
         let daemon = try SimpleConnectionDaemon(params: params)
 

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -76,7 +76,8 @@ extension TunnelABI {
             connectionFactory: registry,
             connectionParameters: connectionParameters,
             messageHandler: DefaultMessageHandler(ctx, environment: environment),
-            startsImmediately: false
+            startsImmediately: false,
+            cancelsUnrecoverable: true
         )
         let daemon = try SimpleConnectionDaemon(params: daemonParameters)
 


### PR DESCRIPTION
- On-demand reconnecting over and over on unrecoverable failure
- OpenVPN not retrying on temporary auth failure