### PR TITLE
Android: Restore tunnel state on app launch

### DIFF
--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -32,7 +32,6 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appInit(
         jstring constants,
         jstring profilesDir,
         jstring cacheDir,
-        jobject tunnel,
         jobject eventHandler
 ) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
@@ -41,7 +40,6 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_appInit(
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     psp_app_bindings bindings = { 0 };
-    bindings.tunnel = (*env)->NewGlobalRef(env, tunnel);
     bindings.event_ctx = abi_handler_create(env, eventHandler);
     bindings.event_cb = abi_event_handler_proxy;
     bindings.free = app_bindings_free;
@@ -171,10 +169,6 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStop(
 
 void app_bindings_free(psp_app_bindings *b) {
     JNI_ATTACH_OR_RETURN_VOID(env);
-    if (b->tunnel) {
-        (*env)->DeleteGlobalRef(env, b->tunnel);
-        b->tunnel = NULL;
-    }
     if (b->event_ctx) {
         abi_handler_free(env, b->event_ctx);
         b->event_ctx = NULL;

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -96,7 +96,7 @@ class MainActivity : ComponentActivity() {
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (::appContext.isInitialized) {
-            appContext.onVpnPermissionResult(result.resultCode == RESULT_OK)
+            appContext.tunnelObservable.onVpnPermissionResult(result.resultCode == RESULT_OK)
         }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -3,6 +3,7 @@ package com.algoritmico.passepartout
 import android.app.Notification
 import android.content.Intent
 import android.net.VpnService
+import android.os.IBinder
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -48,6 +49,13 @@ class PassepartoutVpnService: VpnService() {
 
     override fun onRevoke() {
         runtime.onRevoke()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        if (intent?.action == SERVICE_INTERFACE) {
+            return super.onBind(intent)
+        }
+        return runtime.onBind(intent)
     }
 
     private fun createNotification(): Notification {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
@@ -8,7 +8,6 @@ import android.util.Log
 import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.helpers.ABICompletionCallback
 import com.algoritmico.passepartout.abi.helpers.ABIEventHandler
-import io.partout.PartoutTunnel
 import io.partout.PartoutVpnServiceRuntime
 
 class PassepartoutWrapper {
@@ -18,7 +17,6 @@ class PassepartoutWrapper {
         constants: String,
         profilesDir: String,
         cacheDir: String,
-        tunnel: PartoutTunnel,
         eventHandler: ABIEventHandler
     ): Int
     external fun appDeinit(completion: ABICompletionCallback)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
@@ -30,6 +30,7 @@ class AppContext(
     private val library = PassepartoutWrapper()
 
     private val tunnel = PartoutTunnel(
+        Globals.logTag,
         applicationContext,
         PassepartoutVpnService::class.java,
         requestVpnPermission

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppContext.kt
@@ -29,13 +29,6 @@ class AppContext(
 
     private val library = PassepartoutWrapper()
 
-    private val tunnel = PartoutTunnel(
-        Globals.logTag,
-        applicationContext,
-        PassepartoutVpnService::class.java,
-        requestVpnPermission
-    )
-
     private val eventDispatcher: ABIEventDispatcher = ABIEventDispatcher
 
     private var eventSubscription: Closeable? = eventDispatcher.register(::handleEvent)
@@ -45,16 +38,8 @@ class AppContext(
         extraBufferCapacity = Globals.EVENT_BUFFER_CAPACITY
     )
 
-    val profileObservable = ProfileObservable(
-        AppABIProfile(library),
-        appEvents,
-        coroutineScope
-    )
-
-    val tunnelObservable = TunnelObservable(
-        tunnel,
-        coroutineScope
-    )
+    val profileObservable: ProfileObservable
+    val tunnelObservable: TunnelObservable
 
     init {
         val partoutVersion = library.partoutVersion()
@@ -73,21 +58,34 @@ class AppContext(
             constants,
             profilesDirectory.absolutePath,
             cacheDirectory.absolutePath,
-            tunnel,
             eventDispatcher
         )
         if (code != 0) {
             close()
             throw RuntimeException("Unable to init app (code=$code)")
         }
+
+        profileObservable = ProfileObservable(
+            AppABIProfile(library),
+            appEvents,
+            coroutineScope
+        )
+        val tunnel = PartoutTunnel(
+            Globals.logTag,
+            applicationContext,
+            PassepartoutVpnService::class.java,
+            requestVpnPermission
+        )
+        tunnelObservable = TunnelObservable(
+            Globals.logTag,
+            tunnel,
+            appEvents,
+            coroutineScope
+        )
     }
 
     fun onApplicationActive() {
         library.appOnForeground()
-    }
-
-    fun onVpnPermissionResult(isGranted: Boolean) {
-        tunnel.onVpnPermissionResult(isGranted)
     }
 
     private fun handleEvent(event: Event) {
@@ -100,7 +98,6 @@ class AppContext(
         eventSubscription = null
         profileObservable.close()
         tunnelObservable.close()
-        tunnel.close()
         library.appDeinit { _, _ -> }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -97,10 +97,14 @@ class TunnelObservable(
                 // Iterate through active tunnel
                 state.value.activeProfiles.forEach {
                     val info = it.value
-                    // Ensure that profile was not deleted
-                    if (info.id in event.headers) { return@forEach }
-                    // If deleted profile was active, disconnect it
-                    if (!info.status.isActive) { return@forEach }
+                    // Ignore profiles that were not deleted
+                    if (info.id in event.headers) {
+                        return@forEach
+                    }
+                    // Ignore deletion of inactive profiles
+                    if (!info.status.isActive) {
+                        return@forEach
+                    }
                     Log.i(logTag, "Disconnect from removed profile ${info.id}")
                     tunnel.disconnect(info.id) { _ -> }
                 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -114,8 +114,8 @@ class TunnelObservable(
     }
 
     override fun close() {
-        tunnel.close()
         scope.cancel()
+        tunnel.close()
     }
 
     data class State(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -15,7 +15,6 @@ import io.partout.models.TaggedProfile
 import io.partout.models.TunnelSnapshot
 import io.partout.models.TunnelStatus
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -26,8 +25,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.Closeable
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class TunnelObservable(
     private val logTag: String,
@@ -53,21 +54,27 @@ class TunnelObservable(
     }
 
     suspend fun connect(profile: TaggedProfile) {
-        withContext(Dispatchers.IO) {
-            tunnel.connect(profile) { status ->
+        suspendCancellableCoroutine { continuation ->
+            tunnel.connect(profile) callback@ { status ->
+                if (!continuation.isActive) { return@callback }
                 if (status != PartoutTunnel.ERROR_NONE) {
-                    throw TunnelException
+                    continuation.resumeWithException(TunnelException)
+                    return@callback
                 }
+                continuation.resume(Unit)
             }
         }
     }
 
     suspend fun disconnect(profileId: String) {
-        withContext(Dispatchers.IO) {
-            tunnel.disconnect(profileId) { status ->
+        suspendCancellableCoroutine { continuation ->
+            tunnel.disconnect(profileId) callback@ { status ->
+                if (!continuation.isActive) { return@callback }
                 if (status != PartoutTunnel.ERROR_NONE) {
-                    throw TunnelException
+                    continuation.resumeWithException(TunnelException)
+                    return@callback
                 }
+                continuation.resume(Unit)
             }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -88,12 +88,14 @@ class TunnelObservable(
         when (event) {
             is ProfileEventRefresh -> {
                 // Iterate through active tunnel
-                state.value.activeProfiles.keys.forEach {
-                    // If profile was deleted, disconnect it
-                    if (!event.headers.keys.contains(it)) {
-                        Log.i(logTag, "Disconnect from removed profile ${it}")
-                        tunnel.disconnect(it) { _ -> }
-                    }
+                state.value.activeProfiles.forEach {
+                    val info = it.value
+                    // Ensure that profile was not deleted
+                    if (info.id in event.headers) { return@forEach }
+                    // If deleted profile was active, disconnect it
+                    if (!info.status.isActive) { return@forEach }
+                    Log.i(logTag, "Disconnect from removed profile ${info.id}")
+                    tunnel.disconnect(info.id) { _ -> }
                 }
             }
             else -> {}
@@ -110,6 +112,9 @@ class TunnelObservable(
     )
 
     data object TunnelException: Throwable()
+
+    private val AppProfileStatus.isActive: Boolean
+        get() = this == AppProfileStatus.connecting || this == AppProfileStatus.connected
 
     private fun TunnelSnapshot.toAppTunnelInfo(): AppTunnelInfo {
         return AppTunnelInfo(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -4,8 +4,11 @@
 
 package com.algoritmico.passepartout.ui
 
+import android.util.Log
 import com.algoritmico.passepartout.abi.models.AppProfileStatus
 import com.algoritmico.passepartout.abi.models.AppTunnelInfo
+import com.algoritmico.passepartout.abi.models.Event
+import com.algoritmico.passepartout.abi.models.ProfileEventRefresh
 import com.algoritmico.passepartout.abi.models.ProfileTransfer
 import io.partout.PartoutTunnel
 import io.partout.models.TaggedProfile
@@ -16,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,7 +30,9 @@ import kotlinx.coroutines.withContext
 import java.io.Closeable
 
 class TunnelObservable(
+    private val logTag: String,
     private val tunnel: PartoutTunnel,
+    events: Flow<Event>,
     coroutineScope: CoroutineScope
 ) : Closeable {
     private val scope = CoroutineScope(
@@ -38,6 +44,10 @@ class TunnelObservable(
 
     init {
         tunnel.state
+            .onEach(::onTunnelState)
+            .launchIn(scope)
+
+        events
             .onEach(::onUpdate)
             .launchIn(scope)
     }
@@ -62,7 +72,11 @@ class TunnelObservable(
         }
     }
 
-    private fun onUpdate(tunnelState: PartoutTunnel.State) {
+    fun onVpnPermissionResult(isGranted: Boolean) {
+        tunnel.onVpnPermissionResult(isGranted)
+    }
+
+    private fun onTunnelState(tunnelState: PartoutTunnel.State) {
         _state.update {
             it.copy(activeProfiles = tunnelState.snapshots.mapValues {
                 it.value.toAppTunnelInfo()
@@ -70,7 +84,24 @@ class TunnelObservable(
         }
     }
 
+    private fun onUpdate(event: Event) {
+        when (event) {
+            is ProfileEventRefresh -> {
+                // Iterate through active tunnel
+                state.value.activeProfiles.keys.forEach {
+                    // If profile was deleted, disconnect it
+                    if (!event.headers.keys.contains(it)) {
+                        Log.i(logTag, "Disconnect from removed profile ${it}")
+                        tunnel.disconnect(it) { _ -> }
+                    }
+                }
+            }
+            else -> {}
+        }
+    }
+
     override fun close() {
+        tunnel.close()
         scope.cancel()
     }
 

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -40,7 +40,6 @@ psp_completion PSP_CB(void *ctx, psp_completion_cb callback) {
 #define PSP_CB_NOP() PSP_CB(NULL, NULL)
 
 typedef struct __psp_app_bindings {
-    void *tunnel;
     void *event_ctx;
     psp_event_callback event_cb;
     void (*free)(struct __psp_app_bindings *);

--- a/app-cross/Sources/CommonLibrary_C/passepartout.c
+++ b/app-cross/Sources/CommonLibrary_C/passepartout.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "passepartout.h"
 
 static char *psp_strdup(const char *value) {
 #ifdef _WIN32


### PR DESCRIPTION
Request current service state with service binding.

Encapsulate TunnelObservable better, plus disconnect on profile removal.