### PR TITLE
Android: Decouple runtime and JNI and make thread-safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - "**/*.md"
       - "**/*.sh"
       - "fastlane/**"
+      - "**/*.kt" # For now
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -128,7 +128,7 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStart(
         jstring constants,
         jstring profile,
         jstring cacheDir,
-        jobject runtime
+        jobject controller
 ) {
     const char *cBundle = (*env)->GetStringUTFChars(env, bundle, NULL);
     const char *cConstants = (*env)->GetStringUTFChars(env, constants, NULL);
@@ -136,7 +136,7 @@ Java_com_algoritmico_passepartout_abi_PassepartoutWrapper_tunnelStart(
     const char *cCacheDir = (*env)->GetStringUTFChars(env, cacheDir, NULL);
 
     psp_tunnel_bindings bindings = { 0 };
-    bindings.runtime = (*env)->NewGlobalRef(env, runtime);
+    bindings.controller = (*env)->NewGlobalRef(env, controller);
     bindings.free = tunnel_bindings_free;
 
     psp_tunnel_start_args args = { 0 };
@@ -178,9 +178,9 @@ void app_bindings_free(psp_app_bindings *b) {
 
 void tunnel_bindings_free(psp_tunnel_bindings *b) {
     JNI_ATTACH_OR_RETURN_VOID(env);
-    if (b->runtime) {
-        (*env)->DeleteGlobalRef(env, b->runtime);
-        b->runtime = NULL;
+    if (b->controller) {
+        (*env)->DeleteGlobalRef(env, b->controller);
+        b->controller = NULL;
     }
     JNI_DETACH(env);
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/Globals.kt
@@ -14,6 +14,7 @@ object Globals {
 
     const val logTag = "Passepartout"
     const val serviceLogTag = "PassepartoutVpnService"
+    const val jniLogTag = "JNITunnelController"
 
     // FIXME: Build bundle dynamically
     const val BUNDLE_FILENAME = "bundle.json"

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -5,7 +5,9 @@ import android.net.VpnService
 import android.os.IBinder
 import android.util.AtomicFile
 import com.algoritmico.passepartout.abi.PassepartoutWrapper
+import com.algoritmico.passepartout.abi.helpers.ABIException
 import io.partout.PartoutVpnServiceRuntime
+import io.partout.vpn.JNITunnelController
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -28,25 +30,37 @@ class PassepartoutVpnService: VpnService() {
         override suspend fun start(
             runtime: PartoutVpnServiceRuntime,
             profileJSON: String
-        ): PartoutVpnServiceRuntime.Result = withContext(Dispatchers.IO) {
-            PartoutVpnServiceRuntime.Result(
-                library.tunnelStart(
-                    readAsset(Globals.BUNDLE_FILENAME),
-                    readAsset(Globals.CONSTANTS_FILENAME),
-                    profileJSON,
-                    cacheDir.absolutePath,
-                    runtime
-                ),
-                null
+        ) = withContext(Dispatchers.IO) {
+            // This is strongly retained by Partout
+            val controller = JNITunnelController(
+                logTag = Globals.jniLogTag,
+                service = runtime.service,
+                sendSnapshot = { runtime.sendSnapshot(it) },
+                disconnect = { runtime.disconnect() }
             )
+            val code = library.tunnelStart(
+                readAsset(Globals.BUNDLE_FILENAME),
+                readAsset(Globals.CONSTANTS_FILENAME),
+                profileJSON,
+                cacheDir.absolutePath,
+                controller
+            )
+            if (code != 0) {
+                throw ABIException(code, null)
+            }
         }
 
-        override suspend fun stop(): PartoutVpnServiceRuntime.Result = withContext(Dispatchers.IO) {
-            val result = CompletableDeferred<PartoutVpnServiceRuntime.Result>()
+        override suspend fun stop() = withContext(Dispatchers.IO) {
+            val result = CompletableDeferred<Int>()
             library.tunnelStop { code, json ->
-                result.complete(PartoutVpnServiceRuntime.Result(code, json))
+                if (code != 0) {
+                    result.completeExceptionally(ABIException(code, null))
+                    return@tunnelStop
+                }
+                result.complete(code)
             }
             result.await()
+            return@withContext
         }
 
         override suspend fun readLastProfile(): String {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/abi/PassepartoutWrapper.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.helpers.ABICompletionCallback
 import com.algoritmico.passepartout.abi.helpers.ABIEventHandler
-import io.partout.PartoutVpnServiceRuntime
+import io.partout.vpn.JNITunnelController
 
 class PassepartoutWrapper {
     external fun partoutVersion(): String
@@ -43,7 +43,7 @@ class PassepartoutWrapper {
         constants: String,
         profile: String,
         cacheDir: String,
-        runtime: PartoutVpnServiceRuntime
+        controller: JNITunnelController
     ): Int
     external fun tunnelStop(
         completion: ABICompletionCallback

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -49,7 +49,7 @@ extension TunnelABI {
         )
 
         // Create platform-specific objects
-        let controller = try NativeTunnelController(ctx, ref: bindings.runtime)
+        let controller = try NativeTunnelController(ctx, ref: bindings.controller)
         let betterPathBlock: BetterPathBlock
 #if !PSP_CROSS
         betterPathBlock = NEBetterPathBlock(ctx).block

--- a/app-cross/Sources/CommonLibrary_C/include/passepartout.h
+++ b/app-cross/Sources/CommonLibrary_C/include/passepartout.h
@@ -46,7 +46,7 @@ typedef struct __psp_app_bindings {
 } psp_app_bindings;
 
 typedef struct __psp_tunnel_bindings {
-    void *runtime;
+    void *controller;
     void (*free)(struct __psp_tunnel_bindings *);
 } psp_tunnel_bindings;
 

--- a/app-cross/passepartout/tunnel/main.c
+++ b/app-cross/passepartout/tunnel/main.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
     args.profile = profile;
     args.is_interactive = true;
     args.is_daemon = true;
-    args.bindings.runtime = NULL;
+    args.bindings.controller = NULL;
 
     /* Will block indefinitely. */
     const int result = psp_tunnel_start(&args);


### PR DESCRIPTION
- Pass JNI controller to ABI, not runtime
- Throw engine exception rather than returning codes