### PR TITLE
Android: Get environment JSON from TunnelObservable

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -17,6 +17,7 @@ class PassepartoutVpnService: VpnService() {
     private val runtime by lazy {
         PartoutVpnServiceRuntime(
             logTag = Globals.serviceLogTag,
+            jniLogTag = Globals.jniLogTag,
             service = this,
             engine = engine
         )
@@ -28,16 +29,10 @@ class PassepartoutVpnService: VpnService() {
             get() = File(noBackupFilesDir, Globals.PROFILE_LAST_PATH)
 
         override suspend fun start(
-            runtime: PartoutVpnServiceRuntime,
+            controller: JNITunnelController,
             profileJSON: String
         ) = withContext(Dispatchers.IO) {
-            // This is strongly retained by Partout
-            val controller = JNITunnelController(
-                logTag = Globals.jniLogTag,
-                service = runtime.service,
-                sendSnapshot = { runtime.sendSnapshot(it) },
-                disconnect = { runtime.disconnect() }
-            )
+            // This call retains the controller strongly
             val code = library.tunnelStart(
                 readAsset(Globals.BUNDLE_FILENAME),
                 readAsset(Globals.CONSTANTS_FILENAME),

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/TunnelObservable.kt
@@ -53,7 +53,7 @@ class TunnelObservable(
             .launchIn(scope)
     }
 
-    suspend fun connect(profile: TaggedProfile) {
+    suspend fun connect(profile: TaggedProfile) =
         suspendCancellableCoroutine { continuation ->
             tunnel.connect(profile) callback@ { status ->
                 if (!continuation.isActive) { return@callback }
@@ -64,12 +64,13 @@ class TunnelObservable(
                 continuation.resume(Unit)
             }
         }
-    }
 
-    suspend fun disconnect(profileId: String) {
+    suspend fun disconnect(profileId: String) =
         suspendCancellableCoroutine { continuation ->
             tunnel.disconnect(profileId) callback@ { status ->
-                if (!continuation.isActive) { return@callback }
+                if (!continuation.isActive) {
+                    return@callback
+                }
                 if (status != PartoutTunnel.ERROR_NONE) {
                     continuation.resumeWithException(TunnelException)
                     return@callback
@@ -77,6 +78,11 @@ class TunnelObservable(
                 continuation.resume(Unit)
             }
         }
+
+    suspend fun getEnvironmentValue(name: String): String? {
+        val json = tunnel.requestEnvironmentValue(name)
+        Log.i(logTag, "TunnelObservable.getEnvironmentValue($name) = $json")
+        return json
     }
 
     fun onVpnPermissionResult(isGranted: Boolean) {

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -49,7 +49,11 @@ extension TunnelABI {
         )
 
         // Create platform-specific objects
-        let controller = try NativeTunnelController(ctx, ref: bindings.controller)
+        let controller = try NativeTunnelController(
+            ctx,
+            ref: bindings.controller,
+            environment: environment
+        )
         let betterPathBlock: BetterPathBlock
 #if !PSP_CROSS
         betterPathBlock = NEBetterPathBlock(ctx).block

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
@@ -126,20 +126,22 @@ public final class TunnelABI: TunnelABIProtocol {
         self.daemon = nil
     }
 
-    public func sendMessage(_ input: Message.Input) async -> Message.Output? {
+    public func sendMessage(_ messageData: Data) async -> Data? {
         guard let daemon else { return nil }
         pspLog(.core, .debug, "Handle tunnel message")
         do {
+            let input = try ABI.decode(Message.Input.self, from: messageData)
             let output = try await daemon.sendMessage(input)
+            let encodedOutput = try ABI.encode(output)
             switch input {
             case .environment:
                 break
             default:
-                pspLog(.core, .info, "Message handled and response encoded")
+                pspLog(.core, .info, "Message handled and response encoded (\(encodedOutput.asSensitiveBytes(.init(originalProfile.id))))")
             }
-            return output
+            return encodedOutput
         } catch {
-            pspLog(.core, .error, "Unable to decode message: \(input)")
+            pspLog(.core, .error, "Unable to decode message: \(messageData)")
             return nil
         }
     }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI.swift
@@ -126,22 +126,20 @@ public final class TunnelABI: TunnelABIProtocol {
         self.daemon = nil
     }
 
-    public func sendMessage(_ messageData: Data) async -> Data? {
+    public func sendMessage(_ input: Message.Input) async -> Message.Output? {
         guard let daemon else { return nil }
         pspLog(.core, .debug, "Handle tunnel message")
         do {
-            let input = try ABI.decode(Message.Input.self, from: messageData)
             let output = try await daemon.sendMessage(input)
-            let encodedOutput = try ABI.encode(output)
             switch input {
             case .environment:
                 break
             default:
-                pspLog(.core, .info, "Message handled and response encoded (\(encodedOutput.asSensitiveBytes(.init(originalProfile.id))))")
+                pspLog(.core, .info, "Message handled and response encoded")
             }
-            return encodedOutput
+            return output
         } catch {
-            pspLog(.core, .error, "Unable to decode message: \(messageData)")
+            pspLog(.core, .error, "Unable to decode message: \(input)")
             return nil
         }
     }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABIProtocol.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABIProtocol.swift
@@ -9,6 +9,6 @@ import Partout
 public protocol TunnelABIProtocol: AppABILoggerProtocol, Sendable {
     func start(isInteractive: Bool) async throws
     func stop() async
-    func sendMessage(_ messageData: Data) async -> Data?
+    func sendMessage(_ message: Message.Input) async -> Message.Output?
     nonisolated func cancel(_ error: Error?)
 }

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABIProtocol.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABIProtocol.swift
@@ -9,6 +9,6 @@ import Partout
 public protocol TunnelABIProtocol: AppABILoggerProtocol, Sendable {
     func start(isInteractive: Bool) async throws
     func stop() async
-    func sendMessage(_ message: Message.Input) async -> Message.Output?
+    func sendMessage(_ messageData: Data) async -> Data?
     nonisolated func cancel(_ error: Error?)
 }


### PR DESCRIPTION
NativeTunnelController now receives an environment argument, whose values are requested from the runtime through messaging.

Now the engine only receives a JNITunnelController reference for the ABI. The runtime remains private to the VpnService, because `sendSnapshots()` and `disconnect()` are now invoked through JNITunnelController delegation.

Extra:

- Restyle connect/disconnect coroutines in TunnelObservable