### PR TITLE
WireGuard: Fix ugly message when no peers defined

### DIFF
--- a/app-apple/Sources/AppLibrary/L10n/AppError+L10n.swift
+++ b/app-apple/Sources/AppLibrary/L10n/AppError+L10n.swift
@@ -118,6 +118,9 @@ extension PartoutError: @retroactive LocalizedError {
         case .timeout:
             return V.timeout
 
+        case .WireGuard.emptyPeers:
+            return V.Wireguard.emptyPeers
+
         case .unhandled:
             return reason?.localizedDescription
 

--- a/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Ungültige Felder.";
 "errors.app.passepartout.missing_provider_entity" = "Kein Server beim Anbieter ausgewählt.";
 "errors.app.passepartout.no_active_modules" = "Das Profil hat keine aktiven Module.";
-"errors.app.passepartout.parsing" = "Datei konnte nicht analysiert werden.";
+"errors.app.passepartout.parsing" = "Konnte nicht analysiert werden.";
 "errors.app.passepartout.timeout" = "Die Operation hat das Zeitlimit überschritten.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN-Kompression ist unsicher und wird nicht mehr unterstützt.";
 "errors.app.passepartout.wireguard.empty_peers" = "Keine Peers definiert.";

--- a/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Datei konnte nicht analysiert werden.";
 "errors.app.passepartout.timeout" = "Die Operation hat das Zeitlimit überschritten.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN-Kompression ist unsicher und wird nicht mehr unterstützt.";
+"errors.app.passepartout.wireguard.empty_peers" = "Keine Peers definiert.";
 "errors.app.permission_denied" = "Zugriff verweigert";
 "errors.app.tunnel" = "Aktion konnte nicht ausgeführt werden.";
 "errors.app.web_receiver" = "Import kann nicht gestartet werden. Stellen Sie sicher, dass Ihr Fernseher ordnungsgemäß mit dem lokalen Netzwerk verbunden ist.";

--- a/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Μη έγκυρα πεδία.";
 "errors.app.passepartout.missing_provider_entity" = "Δεν επιλέχθηκε διακομιστής στον πάροχο.";
 "errors.app.passepartout.no_active_modules" = "Το προφίλ δεν έχει ενεργές μονάδες.";
-"errors.app.passepartout.parsing" = "Δεν ήταν δυνατή η ανάλυση αρχείου.";
+"errors.app.passepartout.parsing" = "Δεν ήταν δυνατή η ανάλυση.";
 "errors.app.passepartout.timeout" = "Η λειτουργία έληξε λόγω χρονικού ορίου.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Η συμπίεση OpenVPN δεν είναι ασφαλής και δεν υποστηρίζεται πλέον.";
 "errors.app.passepartout.wireguard.empty_peers" = "Δεν έχουν οριστεί ομότιμοι.";

--- a/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Δεν ήταν δυνατή η ανάλυση αρχείου.";
 "errors.app.passepartout.timeout" = "Η λειτουργία έληξε λόγω χρονικού ορίου.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Η συμπίεση OpenVPN δεν είναι ασφαλής και δεν υποστηρίζεται πλέον.";
+"errors.app.passepartout.wireguard.empty_peers" = "Δεν έχουν οριστεί ομότιμοι.";
 "errors.app.permission_denied" = "Άρνηση άδειας";
 "errors.app.tunnel" = "Δεν ήταν δυνατή η εκτέλεση της ενέργειας.";
 "errors.app.web_receiver" = "Δεν είναι δυνατή η εκκίνηση της εισαγωγής. Βεβαιωθείτε ότι η τηλεόρασή σας είναι σωστά συνδεδεμένη στο τοπικό δίκτυο.";

--- a/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
@@ -458,6 +458,7 @@
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN compression is unsafe and no longer supported.";
 "errors.app.passepartout.parsing" = "Unable to parse file.";
 "errors.app.passepartout.timeout" = "The operation timed out.";
+"errors.app.passepartout.wireguard.empty_peers" = "No peers defined.";
 
 "errors.tunnel.auth" = "Auth failed";
 "errors.tunnel.compression" = "Compression unsupported";

--- a/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
@@ -456,7 +456,7 @@
 "errors.app.passepartout.missing_provider_entity" = "No server selected in provider.";
 "errors.app.passepartout.no_active_modules" = "The profile has no active modules.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN compression is unsafe and no longer supported.";
-"errors.app.passepartout.parsing" = "Unable to parse file.";
+"errors.app.passepartout.parsing" = "Unable to parse.";
 "errors.app.passepartout.timeout" = "The operation timed out.";
 "errors.app.passepartout.wireguard.empty_peers" = "No peers defined.";
 

--- a/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "No se pudo analizar el archivo.";
 "errors.app.passepartout.timeout" = "La operación agotó el tiempo de espera.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "La compresión de OpenVPN no es segura y ya no se admite.";
+"errors.app.passepartout.wireguard.empty_peers" = "No se han definido pares.";
 "errors.app.permission_denied" = "Permiso denegado";
 "errors.app.tunnel" = "No se pudo ejecutar la operación.";
 "errors.app.web_receiver" = "No se puede iniciar la importación. Asegúrate de que tu TV esté correctamente conectada a la red local.";

--- a/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Campos no válidos.";
 "errors.app.passepartout.missing_provider_entity" = "No se seleccionó un servidor en el proveedor.";
 "errors.app.passepartout.no_active_modules" = "El perfil no tiene módulos activos.";
-"errors.app.passepartout.parsing" = "No se pudo analizar el archivo.";
+"errors.app.passepartout.parsing" = "No se pudo analizar.";
 "errors.app.passepartout.timeout" = "La operación agotó el tiempo de espera.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "La compresión de OpenVPN no es segura y ya no se admite.";
 "errors.app.passepartout.wireguard.empty_peers" = "No se han definido pares.";

--- a/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Impossible d'analyser le fichier.";
 "errors.app.passepartout.timeout" = "L'opération a expiré.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "La compression OpenVPN n'est pas sûre et n'est plus prise en charge.";
+"errors.app.passepartout.wireguard.empty_peers" = "Aucun pair défini.";
 "errors.app.permission_denied" = "Permission refusée";
 "errors.app.tunnel" = "Impossible d'exécuter l'opération.";
 "errors.app.web_receiver" = "Impossible de démarrer l'importation. Assurez-vous que votre téléviseur est correctement connecté au réseau local.";

--- a/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Champs invalides.";
 "errors.app.passepartout.missing_provider_entity" = "Aucun serveur sélectionné chez le fournisseur.";
 "errors.app.passepartout.no_active_modules" = "Le profil n'a pas de modules actifs.";
-"errors.app.passepartout.parsing" = "Impossible d'analyser le fichier.";
+"errors.app.passepartout.parsing" = "Impossible d'analyser.";
 "errors.app.passepartout.timeout" = "L'opération a expiré.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "La compression OpenVPN n'est pas sûre et n'est plus prise en charge.";
 "errors.app.passepartout.wireguard.empty_peers" = "Aucun pair défini.";

--- a/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Campi non validi.";
 "errors.app.passepartout.missing_provider_entity" = "Nessun server selezionato nel provider.";
 "errors.app.passepartout.no_active_modules" = "Il profilo non ha moduli attivi.";
-"errors.app.passepartout.parsing" = "Impossibile analizzare il file.";
+"errors.app.passepartout.parsing" = "Impossibile analizzare.";
 "errors.app.passepartout.timeout" = "L'operazione ha superato il tempo limite.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "La compressione OpenVPN non è sicura e non è più supportata.";
 "errors.app.passepartout.wireguard.empty_peers" = "Nessun peer definito.";

--- a/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Impossibile analizzare il file.";
 "errors.app.passepartout.timeout" = "L'operazione ha superato il tempo limite.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "La compressione OpenVPN non è sicura e non è più supportata.";
+"errors.app.passepartout.wireguard.empty_peers" = "Nessun peer definito.";
 "errors.app.permission_denied" = "Permesso negato";
 "errors.app.tunnel" = "Impossibile eseguire l'operazione.";
 "errors.app.web_receiver" = "Impossibile avviare l'importazione. Assicurati che la tua TV sia correttamente connessa alla rete locale.";

--- a/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Ongeldige velden.";
 "errors.app.passepartout.missing_provider_entity" = "Geen server geselecteerd bij provider.";
 "errors.app.passepartout.no_active_modules" = "Het profiel heeft geen actieve modules.";
-"errors.app.passepartout.parsing" = "Kan bestand niet parseren.";
+"errors.app.passepartout.parsing" = "Kan niet parseren.";
 "errors.app.passepartout.timeout" = "De bewerking is verlopen.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN-compressie is onveilig en wordt niet meer ondersteund.";
 "errors.app.passepartout.wireguard.empty_peers" = "Geen peers gedefinieerd.";

--- a/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Kan bestand niet parseren.";
 "errors.app.passepartout.timeout" = "De bewerking is verlopen.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN-compressie is onveilig en wordt niet meer ondersteund.";
+"errors.app.passepartout.wireguard.empty_peers" = "Geen peers gedefinieerd.";
 "errors.app.permission_denied" = "Toegang geweigerd";
 "errors.app.tunnel" = "Actie kan niet worden uitgevoerd.";
 "errors.app.web_receiver" = "Kan de import niet starten. Zorg ervoor dat uw TV correct verbonden is met het lokale netwerk.";

--- a/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Nie można przeanalizować pliku.";
 "errors.app.passepartout.timeout" = "Operacja przekroczyła limit czasu.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Kompresja OpenVPN nie jest bezpieczna i nie jest już obsługiwana.";
+"errors.app.passepartout.wireguard.empty_peers" = "Nie zdefiniowano peerów.";
 "errors.app.permission_denied" = "Brak uprawnień";
 "errors.app.tunnel" = "Nie można wykonać operacji.";
 "errors.app.web_receiver" = "Nie można rozpocząć importu. Upewnij się, że Twój telewizor jest prawidłowo podłączony do sieci lokalnej.";

--- a/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Nieprawidłowe pola.";
 "errors.app.passepartout.missing_provider_entity" = "Nie wybrano serwera w dostawcy.";
 "errors.app.passepartout.no_active_modules" = "Profil nie ma aktywnych modułów.";
-"errors.app.passepartout.parsing" = "Nie można przeanalizować pliku.";
+"errors.app.passepartout.parsing" = "Nie można przeanalizować.";
 "errors.app.passepartout.timeout" = "Operacja przekroczyła limit czasu.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Kompresja OpenVPN nie jest bezpieczna i nie jest już obsługiwana.";
 "errors.app.passepartout.wireguard.empty_peers" = "Nie zdefiniowano peerów.";

--- a/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Campos inválidos.";
 "errors.app.passepartout.missing_provider_entity" = "Nenhum servidor selecionado no provedor.";
 "errors.app.passepartout.no_active_modules" = "O perfil não possui módulos ativos.";
-"errors.app.passepartout.parsing" = "Não foi possível analisar o arquivo.";
+"errors.app.passepartout.parsing" = "Não foi possível analisar.";
 "errors.app.passepartout.timeout" = "A operação expirou.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "A compressão OpenVPN não é segura e não é mais suportada.";
 "errors.app.passepartout.wireguard.empty_peers" = "Nenhum peer definido.";

--- a/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Não foi possível analisar o arquivo.";
 "errors.app.passepartout.timeout" = "A operação expirou.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "A compressão OpenVPN não é segura e não é mais suportada.";
+"errors.app.passepartout.wireguard.empty_peers" = "Nenhum peer definido.";
 "errors.app.permission_denied" = "Permissão negada";
 "errors.app.tunnel" = "Não foi possível executar a operação.";
 "errors.app.web_receiver" = "Não é possível iniciar a importação. Certifique-se de que sua TV esteja devidamente conectada à rede local.";

--- a/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Некорректные поля.";
 "errors.app.passepartout.missing_provider_entity" = "На провайдере не выбран сервер.";
 "errors.app.passepartout.no_active_modules" = "В профиле нет активных модулей.";
-"errors.app.passepartout.parsing" = "Не удалось разобрать файл.";
+"errors.app.passepartout.parsing" = "Не удалось разобрать.";
 "errors.app.passepartout.timeout" = "Время операции истекло.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Сжатие OpenVPN небезопасно и больше не поддерживается.";
 "errors.app.passepartout.wireguard.empty_peers" = "Узлы не определены.";

--- a/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Не удалось разобрать файл.";
 "errors.app.passepartout.timeout" = "Время операции истекло.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Сжатие OpenVPN небезопасно и больше не поддерживается.";
+"errors.app.passepartout.wireguard.empty_peers" = "Узлы не определены.";
 "errors.app.permission_denied" = "Доступ запрещен";
 "errors.app.tunnel" = "Не удалось выполнить операцию.";
 "errors.app.web_receiver" = "Не удается запустить импорт. Убедитесь, что ваш телевизор правильно подключен к локальной сети.";

--- a/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Kan inte tolka filen.";
 "errors.app.passepartout.timeout" = "Åtgärden tog för lång tid.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN-komprimering är osäker och stöds inte längre.";
+"errors.app.passepartout.wireguard.empty_peers" = "Inga peers definierade.";
 "errors.app.permission_denied" = "Åtkomst nekad";
 "errors.app.tunnel" = "Kunde inte utföra åtgärden.";
 "errors.app.web_receiver" = "Kan inte starta importen. Se till att din TV är korrekt ansluten till det lokala nätverket.";

--- a/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Ogiltiga fält.";
 "errors.app.passepartout.missing_provider_entity" = "Ingen server vald hos leverantören.";
 "errors.app.passepartout.no_active_modules" = "Profilen har inga aktiva moduler.";
-"errors.app.passepartout.parsing" = "Kan inte tolka filen.";
+"errors.app.passepartout.parsing" = "Kan inte tolka.";
 "errors.app.passepartout.timeout" = "Åtgärden tog för lång tid.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN-komprimering är osäker och stöds inte längre.";
 "errors.app.passepartout.wireguard.empty_peers" = "Inga peers definierade.";

--- a/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "Не вдалося розібрати файл.";
 "errors.app.passepartout.timeout" = "Час виконання операції вичерпано.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Стиснення OpenVPN небезпечне й більше не підтримується.";
+"errors.app.passepartout.wireguard.empty_peers" = "Вузли не визначено.";
 "errors.app.permission_denied" = "Доступ заборонено";
 "errors.app.tunnel" = "Не вдалося виконати операцію.";
 "errors.app.web_receiver" = "Неможливо розпочати імпорт. Переконайтеся, що ваш телевізор правильно підключений до локальної мережі.";

--- a/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "Некоректні поля.";
 "errors.app.passepartout.missing_provider_entity" = "Не вибрано сервер у постачальника.";
 "errors.app.passepartout.no_active_modules" = "Профіль не має активних модулів.";
-"errors.app.passepartout.parsing" = "Не вдалося розібрати файл.";
+"errors.app.passepartout.parsing" = "Не вдалося розібрати.";
 "errors.app.passepartout.timeout" = "Час виконання операції вичерпано.";
 "errors.app.passepartout.openvpn.unsupported_compression" = "Стиснення OpenVPN небезпечне й більше не підтримується.";
 "errors.app.passepartout.wireguard.empty_peers" = "Вузли не визначено.";

--- a/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "errors.app.passepartout.parsing" = "无法解析文件。";
 "errors.app.passepartout.timeout" = "操作超时。";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN 压缩不安全，已不再受支持。";
+"errors.app.passepartout.wireguard.empty_peers" = "未定义对等端。";
 "errors.app.permission_denied" = "权限被拒绝";
 "errors.app.tunnel" = "无法执行操作。";
 "errors.app.web_receiver" = "无法启动导入。请确保您的电视已正确连接到本地网络。";

--- a/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "errors.app.passepartout.invalid_fields" = "字段无效。";
 "errors.app.passepartout.missing_provider_entity" = "未在提供商中选择服务器。";
 "errors.app.passepartout.no_active_modules" = "配置文件没有激活模块。";
-"errors.app.passepartout.parsing" = "无法解析文件。";
+"errors.app.passepartout.parsing" = "无法解析。";
 "errors.app.passepartout.timeout" = "操作超时。";
 "errors.app.passepartout.openvpn.unsupported_compression" = "OpenVPN 压缩不安全，已不再受支持。";
 "errors.app.passepartout.wireguard.empty_peers" = "未定义对等端。";

--- a/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
+++ b/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
@@ -143,8 +143,8 @@ public enum Strings {
         public static let missingProviderEntity = Strings.tr("Localizable", "errors.app.passepartout.missing_provider_entity", fallback: "No server selected in provider.")
         /// The profile has no active modules.
         public static let noActiveModules = Strings.tr("Localizable", "errors.app.passepartout.no_active_modules", fallback: "The profile has no active modules.")
-        /// Unable to parse file.
-        public static let parsing = Strings.tr("Localizable", "errors.app.passepartout.parsing", fallback: "Unable to parse file.")
+        /// Unable to parse.
+        public static let parsing = Strings.tr("Localizable", "errors.app.passepartout.parsing", fallback: "Unable to parse.")
         /// The operation timed out.
         public static let timeout = Strings.tr("Localizable", "errors.app.passepartout.timeout", fallback: "The operation timed out.")
         public enum Openvpn {

--- a/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
+++ b/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
@@ -151,6 +151,10 @@ public enum Strings {
           /// OpenVPN compression is unsafe and no longer supported.
           public static let unsupportedCompression = Strings.tr("Localizable", "errors.app.passepartout.openvpn.unsupported_compression", fallback: "OpenVPN compression is unsafe and no longer supported.")
         }
+        public enum Wireguard {
+          /// No peers defined.
+          public static let emptyPeers = Strings.tr("Localizable", "errors.app.passepartout.wireguard.empty_peers", fallback: "No peers defined.")
+        }
       }
     }
     public enum Modules {


### PR DESCRIPTION
StandardWireGuardParser.validate() doesn't throw on empty peers.