### PR TITLE
ABI: Encode some error descriptions

### DIFF
--- a/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/CommonABI.swift
@@ -183,10 +183,19 @@ extension ABI.AppError: Encodable {
         }
     }
 
+    public var localizedDescription: String? {
+        switch self {
+        case .importError(let message):
+            return message
+        default:
+            return nil
+        }
+    }
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(code, forKey: .code)
-        try container.encode(localizedDescription, forKey: .description)
+        try container.encodeIfPresent(localizedDescription, forKey: .description)
     }
 }
 

--- a/app-cross/Sources/CommonLibraryCore/Domain/AppError.swift
+++ b/app-cross/Sources/CommonLibraryCore/Domain/AppError.swift
@@ -101,8 +101,18 @@ extension ABI {
                     let option = partoutError.userInfo as? String
                     self = .openVPNUnsupportedCompression(option: option)
                 case .parsing:
-                    let message = partoutError.userInfo as? String ??
-                        (partoutError.reason as? LocalizedError)?.localizedDescription
+                    let message: String?
+                    if let info = partoutError.userInfo as? String {
+                        message = info
+                    } else if let reason = partoutError.reason {
+                        if let localizedReason = reason as? LocalizedError {
+                            message = localizedReason.localizedDescription
+                        } else {
+                            message = String(describing: reason)
+                        }
+                    } else {
+                        message = nil
+                    }
                     self = .importError(message: message)
                 case .Providers.corruptModule:
                     let reason = partoutError.reason

--- a/app-cross/Sources/CommonLibraryCore/Extensions/CodingRegistry+Extensions.swift
+++ b/app-cross/Sources/CommonLibraryCore/Extensions/CodingRegistry+Extensions.swift
@@ -53,8 +53,13 @@ extension CodingRegistry {
         }
 
         // Fall back to parsing a single module
-        let importedModule = try module(fromContents: contents, object: passphrase)
-        return try Profile(withName: name, singleModule: importedModule)
+        do {
+            let importedModule = try module(fromContents: contents, object: passphrase)
+            return try Profile(withName: name, singleModule: importedModule)
+        } catch {
+            pspLog(.core, .error, "Unable to import profile module: \(error)")
+            throw error
+        }
     }
 }
 


### PR DESCRIPTION
Beware that AppError.localizedDescription is not accessible from app-cross because it lives in app-apple.