### PR TITLE
Android: Fix occasional DataStore crash on relaunch

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -7,6 +7,9 @@ package com.algoritmico.passepartout.observables
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.PassepartoutVpnService
 import com.algoritmico.passepartout.abi.AppABIKeyStore
@@ -52,7 +55,7 @@ class AppContext(
             AppABIKeyStore(library),
             appEvents,
             coroutineScope,
-            context
+            applicationContext.userPreferencesStore
         )
         val preferences = userPreferencesObservable.preferencesJSON()
         Log.i(Globals.TAG_APP, ">>> Preferences: $preferences")
@@ -120,3 +123,7 @@ class AppContext(
         library.appDeinit { _, _ -> }
     }
 }
+
+private val Context.userPreferencesStore: DataStore<Preferences> by preferencesDataStore(
+    Globals.PREFERENCES_STORE_NAME
+)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -52,8 +52,7 @@ class AppContext(
             AppABIKeyStore(library),
             appEvents,
             coroutineScope,
-            context,
-            Globals.PREFERENCES_STORE_NAME
+            context
         )
         val preferences = userPreferencesObservable.preferencesJSON()
         Log.i(Globals.TAG_APP, ">>> Preferences: $preferences")
@@ -115,6 +114,7 @@ class AppContext(
     override fun close() {
         eventSubscription?.close()
         eventSubscription = null
+        userPreferencesObservable.close()
         profileObservable.close()
         tunnelObservable.close()
         library.appDeinit { _, _ -> }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -41,17 +41,16 @@ class UserPreferencesObservable(
     private val abi: AppABIKeyStoreProtocol,
     events: Flow<Event>,
     coroutineScope: CoroutineScope,
-    private val context: Context,
-    filename: String
+    context: Context
 ) : Closeable {
+    private val context = context.applicationContext
     private val scope = CoroutineScope(
         coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
     )
 
-    private val Context.store: DataStore<Preferences> by preferencesDataStore(filename)
     private val flow: Flow<Preferences>
         get() {
-            return context.store.data
+            return context.userPreferencesStore.data
         }
 
     val preferences: Flow<AppPreferences> = flow.map { it.toAppPreferences() }
@@ -73,7 +72,7 @@ class UserPreferencesObservable(
     val dnsFallback: Flow<Boolean> = preferences.map { it.dnsFallsBack }
 
     suspend fun toggleDnsFallback() {
-        context.store.edit {
+        context.userPreferencesStore.edit {
             val newValue = !(it[DNS_FALLS_BACK] ?: AppPreferences.default.dnsFallsBack)
             it[DNS_FALLS_BACK] = newValue
             snapshot = snapshot.copy(dnsFallsBack = newValue)
@@ -90,7 +89,7 @@ class UserPreferencesObservable(
     private suspend fun onUpdate(event: Event) {
         if (event !is MixedEventShouldUpdatePreferences) return
         Log.d(logTag, "Updating fields from library: ${event.fields}")
-        context.store.edit {
+        context.userPreferencesStore.edit {
             it.update(event.preferences, event.fields)
         }
         snapshot = snapshot.update(event.preferences, event.fields)
@@ -181,6 +180,10 @@ class UserPreferencesObservable(
         }
         this[key] = value
     }
+
+    private val Context.userPreferencesStore: DataStore<Preferences> by preferencesDataStore(
+        Globals.PREFERENCES_STORE_NAME
+    )
 
     private inline fun <reified T> String.decodePreference(): T? {
         return runCatching {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -4,7 +4,6 @@
 
 package com.algoritmico.passepartout.observables
 
-import android.content.Context
 import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
@@ -14,7 +13,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.algoritmico.passepartout.Globals
 import com.algoritmico.passepartout.abi.AppABIKeyStoreProtocol
 import com.algoritmico.passepartout.abi.default
@@ -41,16 +39,15 @@ class UserPreferencesObservable(
     private val abi: AppABIKeyStoreProtocol,
     events: Flow<Event>,
     coroutineScope: CoroutineScope,
-    context: Context
+    private val store: DataStore<Preferences>
 ) : Closeable {
-    private val context = context.applicationContext
     private val scope = CoroutineScope(
         coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
     )
 
     private val flow: Flow<Preferences>
         get() {
-            return context.userPreferencesStore.data
+            return store.data
         }
 
     val preferences: Flow<AppPreferences> = flow.map { it.toAppPreferences() }
@@ -72,7 +69,7 @@ class UserPreferencesObservable(
     val dnsFallback: Flow<Boolean> = preferences.map { it.dnsFallsBack }
 
     suspend fun toggleDnsFallback() {
-        context.userPreferencesStore.edit {
+        store.edit {
             val newValue = !(it[DNS_FALLS_BACK] ?: AppPreferences.default.dnsFallsBack)
             it[DNS_FALLS_BACK] = newValue
             snapshot = snapshot.copy(dnsFallsBack = newValue)
@@ -89,7 +86,7 @@ class UserPreferencesObservable(
     private suspend fun onUpdate(event: Event) {
         if (event !is MixedEventShouldUpdatePreferences) return
         Log.d(logTag, "Updating fields from library: ${event.fields}")
-        context.userPreferencesStore.edit {
+        store.edit {
             it.update(event.preferences, event.fields)
         }
         snapshot = snapshot.update(event.preferences, event.fields)
@@ -180,10 +177,6 @@ class UserPreferencesObservable(
         }
         this[key] = value
     }
-
-    private val Context.userPreferencesStore: DataStore<Preferences> by preferencesDataStore(
-        Globals.PREFERENCES_STORE_NAME
-    )
 
     private inline fun <reified T> String.decodePreference(): T? {
         return runCatching {


### PR DESCRIPTION
The store was not properly cleaned up, but it'd better be a singleton regardless.