### PR TITLE
Update Partout with cross-platform event loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT DEFINED OUTPUT_DIR)
     set(OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin/${PLATFORM_NAME}-${ARCH_NAME}")
 endif()
 if(NOT DEFINED DIST_DIR)
-    set(DIST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin/dist")
+    set(DIST_DIR "${OUTPUT_DIR}/dist")
 endif()
 
 # Options

--- a/app-android/app/src/main/cpp/CMakeLists.txt
+++ b/app-android/app/src/main/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ set(ENV_ANDROID
 # Build app-cross dependency with given environment
 include(ExternalProject)
 set(JNI_LIBS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs/${ANDROID_ABI})
-set(LIBPASSEPARTOUT_DIST ${JNI_LIBS_DIR})
+set(LIBPASSEPARTOUT_DIST ${CMAKE_CURRENT_SOURCE_DIR}/dist)
 set(LIBPASSEPARTOUT_INCLUDE ${PROJECT_ROOT}/app-cross/Sources/CommonLibrary_C/include)
 set(LIBPASSEPARTOUT_SOS
     ${LIBPASSEPARTOUT_DIST}/libcrypto.so
@@ -39,7 +39,11 @@ ExternalProject_Add(libpassepartout
         -B <BINARY_DIR>
     BUILD_COMMAND ${CMAKE_COMMAND} -E env ${ENV_ANDROID}
         ${CMAKE_COMMAND} --build <BINARY_DIR>
-    INSTALL_COMMAND ""
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${JNI_LIBS_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${LIBPASSEPARTOUT_SOS}
+            ${LIBPASSEPARTOUT_CXX_SHARED_SO}
+            ${JNI_LIBS_DIR}
     BUILD_ALWAYS TRUE
     BUILD_BYPRODUCTS
         ${LIBPASSEPARTOUT_SOS}
@@ -71,13 +75,4 @@ foreach(SO_FILE IN LISTS LIBPASSEPARTOUT_SOS)
 endforeach()
 target_link_libraries(passepartout_wrapper PRIVATE
     ${LIBPASSEPARTOUT_IMPORTED_LIBS}
-)
-
-# Distribute the NDK C++ runtime as a JNI lib.
-add_custom_command(
-    TARGET passepartout_wrapper
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${JNI_LIBS_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBPASSEPARTOUT_CXX_SHARED_SO} ${JNI_LIBS_DIR}
-    COMMENT "Copying C++ runtime to jniLibs"
 )

--- a/app-cross/CMakeLists.txt
+++ b/app-cross/CMakeLists.txt
@@ -102,7 +102,5 @@ add_custom_command(
         -P "${CMAKE_CURRENT_SOURCE_DIR}/distribute.cmake"
 )
 
-# Optionally build end-user applications
-if(BUILD_APP)
-    add_subdirectory(passepartout)
-endif()
+# Build end-user applications
+add_subdirectory(passepartout)

--- a/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-cross/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -45,7 +45,8 @@ extension TunnelABI {
         let controller = try NativeTunnelController(
             ctx,
             ref: bindings.controller,
-            environment: environment
+            environment: environment,
+            encodeInfo: NativeTunnelController.encodeInfoAsJSON
         )
         let betterPathFactory: BetterPathStreamFactory
 #if !PSP_CROSS

--- a/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
@@ -40,8 +40,16 @@ private extension OpenVPNImplementationBuilder {
         var options = OpenVPNConnectionOptions()
         options.writeTimeout = TimeInterval(parameters.options.linkWriteTimeout) / 1000.0
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
+#if PSP_CROSS || USE_CMAKE
+        return try _OpenVPNConnectionV3(
+            ctx,
+            parameters: parameters,
+            module: module,
+            cachesURL: cachesURL,
+            options: options
+        )
+#else
         let flags = configBlock()
-#if !PSP_CROSS && !USE_CMAKE
         if flags.contains(.ovpnV3) {
             return try _OpenVPNConnectionV3(
                 ctx,
@@ -59,14 +67,6 @@ private extension OpenVPNImplementationBuilder {
                 options: options
             )
         }
-#else
-        return try _OpenVPNConnectionV3(
-            ctx,
-            parameters: parameters,
-            module: module,
-            cachesURL: cachesURL,
-            options: options
-        )
 #endif
     }
 }

--- a/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/OpenVPNImplementationBuilder.swift
@@ -41,12 +41,8 @@ private extension OpenVPNImplementationBuilder {
         options.writeTimeout = TimeInterval(parameters.options.linkWriteTimeout) / 1000.0
         options.minDataCountInterval = TimeInterval(parameters.options.minDataCountInterval) / 1000.0
         let flags = configBlock()
-#if PSP_CROSS
-        let isCross = true
-#else
-        let isCross = false
-#endif
-        if isCross || flags.contains(.ovpnV3) {
+#if !PSP_CROSS && !USE_CMAKE
+        if flags.contains(.ovpnV3) {
             return try _OpenVPNConnectionV3(
                 ctx,
                 parameters: parameters,
@@ -63,5 +59,14 @@ private extension OpenVPNImplementationBuilder {
                 options: options
             )
         }
+#else
+        return try _OpenVPNConnectionV3(
+            ctx,
+            parameters: parameters,
+            module: module,
+            cachesURL: cachesURL,
+            options: options
+        )
+#endif
     }
 }

--- a/app-cross/Sources/CommonLibrary/Dependencies/WireGuardImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/WireGuardImplementationBuilder.swift
@@ -18,7 +18,7 @@ struct WireGuardImplementationBuilder: Sendable {
             validatorBlock: { newParser() },
             connectionBlock: {
                 let ctx = PartoutLoggerContext($0.profile.id)
-#if !PSP_CROSS
+#if !PSP_CROSS && !USE_CMAKE
                 let flags = configBlock()
                 if flags.contains(.wgCrossV2) {
                     return try _WireGuardConnectionV2(

--- a/app-cross/Sources/CommonLibrary/Dependencies/WireGuardImplementationBuilder.swift
+++ b/app-cross/Sources/CommonLibrary/Dependencies/WireGuardImplementationBuilder.swift
@@ -18,7 +18,13 @@ struct WireGuardImplementationBuilder: Sendable {
             validatorBlock: { newParser() },
             connectionBlock: {
                 let ctx = PartoutLoggerContext($0.profile.id)
-#if !PSP_CROSS && !USE_CMAKE
+#if PSP_CROSS || USE_CMAKE
+                return try _WireGuardConnectionV2(
+                    ctx,
+                    parameters: $0,
+                    module: $1
+                )
+#else
                 let flags = configBlock()
                 if flags.contains(.wgCrossV2) {
                     return try _WireGuardConnectionV2(
@@ -33,12 +39,6 @@ struct WireGuardImplementationBuilder: Sendable {
                         module: $1
                     )
                 }
-#else
-                return try _WireGuardConnectionV2(
-                    ctx,
-                    parameters: $0,
-                    module: $1
-                )
 #endif
             }
         )

--- a/app-cross/distribute.cmake
+++ b/app-cross/distribute.cmake
@@ -1,18 +1,23 @@
 if(WIN32)
     set(OPENSSL_FOLDER bin)
+    file(GLOB LIBPASSEPARTOUT
+        "${OUTPUT_DIR}/passepartout.dll"
+        "${OUTPUT_DIR}/passepartout.lib"
+        "${OUTPUT_DIR}/passepartout.pdb"
+    )
 else()
     set(OPENSSL_FOLDER lib)
+    file(GLOB LIBPASSEPARTOUT "${OUTPUT_DIR}/libpassepartout*")
 endif()
 
 # Bundle compiled binaries
-file(GLOB LIBPASSEPARTOUT "${OUTPUT_DIR}/*passepartout*")
 file(GLOB LIBSSL "${OUTPUT_DIR}/openssl/${OPENSSL_FOLDER}/libssl*")
 file(GLOB LIBCRYPTO "${OUTPUT_DIR}/openssl/${OPENSSL_FOLDER}/libcrypto*")
 file(GLOB LIBWGGO "${OUTPUT_DIR}/wg-go/lib/*wg-go*")
-file(COPY ${LIBPASSEPARTOUT} DESTINATION ${DIST_DIR})
-file(COPY ${LIBSSL} DESTINATION ${DIST_DIR})
-file(COPY ${LIBCRYPTO} DESTINATION ${DIST_DIR})
-file(COPY ${LIBWGGO} DESTINATION ${DIST_DIR})
+file(MAKE_DIRECTORY "${DIST_DIR}")
+foreach(lib IN LISTS LIBPASSEPARTOUT LIBSSL LIBCRYPTO LIBWGGO)
+    file(COPY "${lib}" DESTINATION "${DIST_DIR}")
+endforeach()
 
 # Clean up static libs and metadata
 file(GLOB CLEANUP
@@ -50,12 +55,13 @@ if(WIN32)
 endif()
 
 foreach(lib ${PREBUILT_LIBS})
-    file(COPY ${lib} DESTINATION ${DIST_DIR})
+    file(COPY "${lib}" DESTINATION "${DIST_DIR}")
 endforeach()
 foreach(lib ${SWIFT_LIBS})
-    file(COPY "$ENV{SWIFT_RUNTIME}/${lib}" DESTINATION ${DIST_DIR})
+    file(COPY "$ENV{SWIFT_RUNTIME}/${lib}" DESTINATION "${DIST_DIR}")
 endforeach()
 
-if(STRIP AND NOT WIN32)
-    execute_process(COMMAND ${STRIP} ${DIST_DIR}/libpassepartout.${LIBEXT})
+set(LIBPASSEPARTOUT_BINARY "${DIST_DIR}/libpassepartout.${LIBEXT}")
+if(STRIP AND NOT WIN32 AND EXISTS "${LIBPASSEPARTOUT_BINARY}")
+    execute_process(COMMAND "${STRIP}" "${LIBPASSEPARTOUT_BINARY}")
 endif()

--- a/app-cross/passepartout/CMakeLists.txt
+++ b/app-cross/passepartout/CMakeLists.txt
@@ -54,8 +54,12 @@ if(BUILD_APP)
     add_custom_command(
         TARGET passepartout
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:passepartout> ${APP_DIR}
-        COMMAND ${STRIP} ${APP_DIR}/passepartout
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${APP_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:passepartout>"
+            "${APP_DIR}/$<TARGET_FILE_NAME:passepartout>"
+        COMMAND ${STRIP} "${APP_DIR}/$<TARGET_FILE_NAME:passepartout>"
+        VERBATIM
     )
 endif()
 
@@ -89,6 +93,10 @@ endif()
 add_custom_command(
     TARGET passepartout-tunnel
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:passepartout-tunnel> ${APP_DIR}
-    COMMAND ${STRIP} ${APP_DIR}/passepartout-tunnel
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${APP_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "$<TARGET_FILE:passepartout-tunnel>"
+        "${APP_DIR}/$<TARGET_FILE_NAME:passepartout-tunnel>"
+    COMMAND ${STRIP} "${APP_DIR}/$<TARGET_FILE_NAME:passepartout-tunnel>"
+    VERBATIM
 )

--- a/app-cross/passepartout/CMakeLists.txt
+++ b/app-cross/passepartout/CMakeLists.txt
@@ -3,20 +3,61 @@ set(CMAKE_CXX_FLAGS "-Wall -W -pedantic")
 
 # Include file lists
 include("passepartout.cmake")
+set(APP_DIR ${DIST_DIR})
+
+# Strip executables except on Windows
+if(WIN32)
+    set(STRIP rem)
+else()
+    set(STRIP ${CMAKE_STRIP})
+endif()
 
 # Define app target
-add_executable(passepartout "")
-set_target_properties(passepartout PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}
-    ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIR}
-    RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIR}
-)
-target_sources(passepartout PRIVATE ${APP_SOURCES})
-target_include_directories(passepartout PRIVATE
-    ${OUTPUT_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/app/include
-)
-target_link_libraries(passepartout PRIVATE passepartout_shared)
+if(BUILD_APP)
+    add_executable(passepartout "")
+    set_target_properties(passepartout PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR}
+        ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIR}
+        RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIR}
+    )
+    target_sources(passepartout PRIVATE ${APP_SOURCES})
+    target_include_directories(passepartout PRIVATE
+        ${OUTPUT_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/app/include
+    )
+    target_link_libraries(passepartout PRIVATE passepartout_shared)
+
+    # wxWidgets only required to build app executable
+    include("wx.cmake")
+
+    if(APPLE)
+        # Mangle macOS @rpath
+        set_target_properties(passepartout PROPERTIES
+            MACOSX_RPATH ON
+            BUILD_WITH_INSTALL_RPATH TRUE
+            INSTALL_RPATH "@loader_path"
+            INSTALL_NAME_DIR "@rpath"
+        )
+    elseif(LINUX)
+        # Mangle Linux RPATH
+        set_target_properties(passepartout PROPERTIES
+            BUILD_RPATH "\$ORIGIN"
+            INSTALL_RPATH "\$ORIGIN"
+            SKIP_BUILD_RPATH OFF
+        )
+    elseif(WIN32)
+        # Build WinMain app
+        set_target_properties(passepartout PROPERTIES WIN32_EXECUTABLE ON)
+    endif()
+
+    # Distribute
+    add_custom_command(
+        TARGET passepartout
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:passepartout> ${APP_DIR}
+        COMMAND ${STRIP} ${APP_DIR}/passepartout
+    )
+endif()
 
 # Define tunnel target
 add_executable(passepartout-tunnel "")
@@ -31,18 +72,7 @@ target_include_directories(passepartout-tunnel PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/tunnel/include
 )
 target_link_libraries(passepartout-tunnel PRIVATE passepartout_shared)
-
-# wxWidgets only required to build executable
-include("wx.cmake")
-
 if(APPLE)
-    # Mangle macOS @rpath
-    set_target_properties(passepartout PROPERTIES
-        MACOSX_RPATH ON
-        BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH "@loader_path"
-        INSTALL_NAME_DIR "@rpath"
-    )
     set_target_properties(passepartout-tunnel PROPERTIES
         MACOSX_RPATH ON
         BUILD_WITH_INSTALL_RPATH TRUE
@@ -50,35 +80,12 @@ if(APPLE)
         INSTALL_NAME_DIR "@rpath"
     )
 elseif(LINUX)
-    # Mangle Linux RPATH
-    set_target_properties(passepartout PROPERTIES
-        BUILD_RPATH "\$ORIGIN"
-        INSTALL_RPATH "\$ORIGIN"
-        SKIP_BUILD_RPATH OFF
-    )
     set_target_properties(passepartout-tunnel PROPERTIES
         BUILD_RPATH "\$ORIGIN"
         INSTALL_RPATH "\$ORIGIN"
         SKIP_BUILD_RPATH OFF
     )
-elseif(WIN32)
-    # Build WinMain app
-    set_target_properties(passepartout PROPERTIES WIN32_EXECUTABLE ON)
 endif()
-
-# Strip executables except on Windows
-set(APP_DIR ${OUTPUT_DIR}/${DIST_DIR})
-if(WIN32)
-    set(STRIP rem)
-else()
-    set(STRIP ${CMAKE_STRIP})
-endif()
-add_custom_command(
-    TARGET passepartout
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:passepartout> ${APP_DIR}
-    COMMAND ${STRIP} ${APP_DIR}/passepartout
-)
 add_custom_command(
     TARGET passepartout-tunnel
     POST_BUILD


### PR DESCRIPTION
Fix CMake regressions along the way, and always build passepartout-tunnel even if BUILD_APP is OFF.

Stick to latest VPN implementations when building with CMake.